### PR TITLE
[sailfish-browser] Set allowedOrientations for ApplicationWindow

### DIFF
--- a/src/browser.qml
+++ b/src/browser.qml
@@ -16,7 +16,8 @@ import "pages"
 ApplicationWindow {
     id: window
 
-    _defaultPageOrientations: WebUtils.firstUseDone ? Orientation.Landscape | Orientation.Portrait  : Orientation.Portrait
+    allowedOrientations: WebUtils.firstUseDone ? Orientation.Landscape | Orientation.Portrait  : Orientation.Portrait
+    _defaultPageOrientations: allowedOrientations
     initialPage: Component {BrowserPage {}}
     cover: undefined
 }


### PR DESCRIPTION
Default page orientation is the same as allowedOrientations.
Page components might define as well allowedOrientations. Thus,
those pages will not follow default page orientation. Orientation
of a page's allowedOrientations is masked with
ApplicationWindow.allowedOrientations.
