### PR TITLE
[sailfish-browser] Fix empty tab thumbnails not to appear. Fixes JB#1679...

### DIFF
--- a/src/declarativetabmodel.cpp
+++ b/src/declarativetabmodel.cpp
@@ -171,6 +171,17 @@ void DeclarativeTabModel::closeActiveTab()
     }
 }
 
+void DeclarativeTabModel::dumpTabs() const
+{
+    if (m_activeTab.isValid()) {
+        qDebug() << "active tab id:" << m_activeTab.tabId() << "valid:" << m_activeTab.isValid() << "url:" << m_activeTab.currentLink().url() << "title:" << m_activeTab.currentLink().title() << "thumb:" << m_activeTab.currentLink().thumbPath();
+    }
+
+    for (int i = 0; i < m_tabs.size(); i++) {
+        qDebug() << "tab[" << i << "] id:" << m_tabs.at(i).tabId() << "valid:" << m_tabs.at(i).isValid() << "url:" << m_tabs.at(i).currentLink().url() << "title:" << m_tabs.at(i).currentLink().title() << "thumb:" << m_tabs.at(i).currentLink().thumbPath();
+    }
+}
+
 int DeclarativeTabModel::count() const
 {
     if (m_activeTab.isValid()) {

--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -48,6 +48,8 @@ public:
     Q_INVOKABLE bool activateTab(const int &index);
     Q_INVOKABLE void closeActiveTab();
 
+    Q_INVOKABLE void dumpTabs() const;
+
     int count() const;
 
     // From QAbstractListModel

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -49,7 +49,6 @@ Page {
             if (webView.loading) {
                 webView.stop()
             }
-            captureScreen()
         }
 
         // Url is not need in webView.newTabData as we let engine to resolve
@@ -324,7 +323,8 @@ Page {
     TabModel {
         id: tabModel
         currentTab: tab
-        browsing: browserPage.status === PageStatus.Active && !webView.newTabData
+        browsing: browserPage.status === PageStatus.Active && !webView.newTabData && webView.loaded
+        onBrowsingChanged: if (browsing) captureScreen()
     }
 
     HistoryModel {
@@ -925,6 +925,8 @@ Page {
             }
 
             if (webView.url != "") {
+                // Remove this from newWebView branch as foreground property of newTab will be gone as well and
+                // it could handle all newTab cases related to onOpenUrlRequsted.
                 captureScreen()
                 if (!tabModel.activateTab(url)) {
                     // Not found in tabs list, create newtab and load


### PR DESCRIPTION
...1

This commit fixes two cases:
1) Multiple tabs open, active tab is closed from tabs pages, and loading
   finishes so that tabs page is still active, tabs page popped from
   the PageStack, browser pushed to home screen, and open an external link.
2) Open browser, push it to home screen, and open an external link,
   check thumbnails from tabs page.

This commit adds also dumpTabs helper that can be used when debugging tabs.
