### PR TITLE
Improve manual window opening test case

### DIFF
--- a/tests/manual/subwindow_closed_inside.html
+++ b/tests/manual/subwindow_closed_inside.html
@@ -5,6 +5,7 @@
   function closeTimer()
   {
     setTimeout(function() {
+      window.opener.location.href = "testpage.html"
       window.close()
     }, 5000);
   }

--- a/tests/manual/testwindowopen.html
+++ b/tests/manual/testwindowopen.html
@@ -21,7 +21,7 @@
     </div>
 
     <div id="div" style="width:400px;height:150px">
-      <a href="javascript:void(0)" onclick="createWindow2()"><h1>Create a window that is closed from there</h1></a>
+      <a href="javascript:void(0)" onclick="createWindow2()"><h1>Create a window that is closed from there and you're redirected main test page</h1></a>
     </div>
 
     <div id="div" style="width:400px;height:150px">


### PR DESCRIPTION
Before window is closed, opener window is changes to load "testpage.html".
This is for testing that window.opener.location works.

Doesn't really work in master yet. Only with newWebView but as we already have this test case available I think that this doesn't harm in master [diff in newWebView is already big enough :)].
