### PR TITLE
Add unit tests structure for WebView

### DIFF
--- a/src/common.pri
+++ b/src/common.pri
@@ -1,0 +1,5 @@
+isEmpty(DEFAULT_COMPONENT_PATH) {
+  DEFINES += DEFAULT_COMPONENTS_PATH=\"\\\"/usr/lib/mozembedlite/\\\"\"
+} else {
+  DEFINES += DEFAULT_COMPONENTS_PATH=\"\\\"$$DEFAULT_COMPONENT_PATH\\\"\"
+}

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -22,6 +22,7 @@ WebContainer {
 
     property bool loading
     property int loadProgress
+    readonly property int loaded: loadProgress === 100
     // TODO: Push this to C++ if possible. Check if TabModel is feasible to merged to DeclarativeTabModel
     property alias tabModel: model
     property string favicon
@@ -104,7 +105,7 @@ WebContainer {
     }
 
     width: parent.width
-    height: webContainer.parent.orientation === Orientation.Portrait ? Screen.height : Screen.width
+    height: portrait ? Screen.height : Screen.width
     foreground: Qt.application.active
     inputPanelHeight: window.pageStack.panelSize
     inputPanelOpenHeight: window.pageStack.imSize

--- a/src/src.pro
+++ b/src/src.pro
@@ -41,11 +41,7 @@ isEmpty(QTEMBED_LIB) {
   LIBS+=$$QTEMBED_LIB
 }
 
-isEmpty(DEFAULT_COMPONENT_PATH) {
-  DEFINES += DEFAULT_COMPONENTS_PATH=\"\\\"/usr/lib/mozembedlite/\\\"\"
-} else {
-  DEFINES += DEFAULT_COMPONENTS_PATH=\"\\\"$$DEFAULT_COMPONENT_PATH\\\"\"
-}
+include(common.pri)
 
 # Translations
 TS_PATH = $$PWD

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -3,7 +3,8 @@ TEMPLATE = subdirs
 
 SUBDIRS += tst_declarativetabmodel \
     tst_declarativetab \
-    tst_linkvalidator
+    tst_linkvalidator \
+    tst_webview
 
 OTHER_FILES += \
     *.xml

--- a/tests/auto/test_common.pri
+++ b/tests/auto/test_common.pri
@@ -5,6 +5,7 @@ QT += quick testlib qml quick concurrent sql
 
 INCLUDEPATH += ../../../src
 
+include(../../src/common.pri)
 include(../../src/history.pri)
 
 HEADERS += ../../../src/declarativewebcontainer.h

--- a/tests/auto/tests.xml
+++ b/tests/auto/tests.xml
@@ -16,6 +16,9 @@
            <case manual="false" name="linkvalidator">
                <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_linkvalidator</step>
            </case>
+           <case manual="false" name="webview">
+               <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_webview -platform wayland-egl</step>
+           </case>
            <post_steps>
                <step>/usr/sbin/mcetool -jdisabled -Doff</step>
            </post_steps>

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -1,0 +1,130 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QtTest>
+#include <QQmlContext>
+#include <QQuickView>
+#include <quickmozview.h>
+
+#include "declarativetab.h"
+#include "declarativetabmodel.h"
+#include "declarativewebcontainer.h"
+#include "declarativewebviewcreator.h"
+#include "qmozcontext.h"
+#include "webUtilsMock.h"
+
+class tst_webview : public QObject
+{
+    Q_OBJECT
+
+public:
+    tst_webview(QQuickView * view, QObject *parent = 0);
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+
+private:
+    DeclarativeTabModel *tabModel;
+    DeclarativeTab *tab;
+    DeclarativeWebContainer *webContainer;
+    QQuickView *view;
+};
+
+
+tst_webview::tst_webview(QQuickView *view, QObject *parent)
+    : QObject(parent)
+    , tabModel(0)
+    , tab(0)
+    , view(view)
+{
+}
+
+void tst_webview::initTestCase()
+{
+    view->setSource(QUrl("qrc:///tst_webview.qml"));
+    view->showFullScreen();
+    QTest::qWaitForWindowExposed(view);
+
+    QQuickItem *appWindow = view->rootObject();
+    QVariant var = appWindow->property("webView");
+    webContainer = qobject_cast<DeclarativeWebContainer *>(qvariant_cast<QObject*>(var));
+    QVERIFY(webContainer);
+
+    var = webContainer->property("tabModel");
+    tabModel = qobject_cast<DeclarativeTabModel *>(qvariant_cast<QObject*>(var));
+    QVERIFY(tabModel);
+
+    tab = webContainer->currentTab();
+    QVERIFY(tab);
+
+    QSignalSpy viewReady(webContainer, SIGNAL(_readyToLoadChanged()));
+    QSignalSpy firstPageLoaded(webContainer, SIGNAL(loadedChanged()));
+    viewReady.wait();
+    firstPageLoaded.wait();
+
+    QuickMozView *webView = webContainer->webView();
+    QVERIFY(webView);
+    QVERIFY(WebUtilsMock::instance());
+    QCOMPARE(webView->url().toString(), WebUtilsMock::instance()->homePage);
+    QCOMPARE(webView->title(), QString("TestPage"));
+    QCOMPARE(tab->url(), WebUtilsMock::instance()->homePage);
+    QCOMPARE(tab->title(), QString("TestPage"));
+    QCOMPARE(tabModel->count(), 1);
+}
+
+void tst_webview::cleanupTestCase()
+{
+    tabModel->clear();
+    QVERIFY(tabModel->count() == 0);
+    QVERIFY(tab->url().isEmpty());
+    QVERIFY(tab->title().isEmpty());
+    QVERIFY(!tab->valid());
+
+    // Wait for event loop of db manager
+    QTest::qWait(500);
+    QString dbFileName = QString("%1/%2")
+            .arg(QStandardPaths::writableLocation(QStandardPaths::DataLocation))
+            .arg(QLatin1String(DB_NAME));
+    QFile dbFile(dbFileName);
+    QVERIFY(dbFile.remove());
+    QMozContext::GetInstance()->stopEmbedding();
+}
+
+int main(int argc, char *argv[])
+{
+    setenv("USE_ASYNC", "1", 1);
+    setenv("QML_BAD_GUI_RENDER_LOOP", "1", 1);
+
+    QGuiApplication app(argc, argv);
+    QQuickView view;
+    app.setAttribute(Qt::AA_Use96Dpi, true);
+    tst_webview testcase(&view);
+
+    qmlRegisterUncreatableType<DeclarativeTab>("Sailfish.Browser", 1, 0, "Tab", "");
+    qmlRegisterType<DeclarativeTabModel>("Sailfish.Browser", 1, 0, "TabModel");
+    qmlRegisterType<DeclarativeWebContainer>("Sailfish.Browser", 1, 0, "WebContainer");
+    qmlRegisterType<DeclarativeWebViewCreator>("Sailfish.Browser", 1, 0, "WebViewCreator");
+    qmlRegisterSingletonType<WebUtilsMock>("Sailfish.Browser", 1, 0, "WebUtils", WebUtilsMock::singletonApiFactory);
+    view.rootContext()->setContextProperty("MozContext", QMozContext::GetInstance());
+
+    QString componentPath(DEFAULT_COMPONENTS_PATH);
+    QMozContext::GetInstance()->addComponentManifest(componentPath + QString("/components/EmbedLiteBinComponents.manifest"));
+    QMozContext::GetInstance()->addComponentManifest(componentPath + QString("/components/EmbedLiteJSComponents.manifest"));
+    QMozContext::GetInstance()->addComponentManifest(componentPath + QString("/chrome/EmbedLiteJSScripts.manifest"));
+    QMozContext::GetInstance()->addComponentManifest(componentPath + QString("/chrome/EmbedLiteOverrides.manifest"));
+
+    QTimer::singleShot(0, QMozContext::GetInstance(), SLOT(runEmbedding()));
+
+    return QTest::qExec(&testcase, argc, argv);
+}
+
+#include "tst_webview.moc"

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -1,0 +1,13 @@
+TARGET = tst_webview
+include(../test_common.pri)
+
+SOURCES += tst_webview.cpp \
+    webUtilsMock.cpp \
+    ../../../src/declarativewebviewcreator.cpp
+
+HEADERS += webUtilsMock.h \
+    ../../../src/declarativewebviewcreator.h
+
+OTHER_FILES = *.qml
+
+RESOURCES = tst_webview.qrc

--- a/tests/auto/tst_webview/tst_webview.qml
+++ b/tests/auto/tst_webview/tst_webview.qml
@@ -1,0 +1,35 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Browser 1.0
+
+ApplicationWindow {
+    id: window
+
+    property alias webView: webView
+
+    allowedOrientations: Orientation.Portrait
+    _defaultPageOrientations: allowedOrientations
+
+    initialPage: WebView {
+        id: webView
+
+        active: true
+        toolbarHeight: 50
+        portrait: true
+    }
+
+    cover: undefined
+}
+

--- a/tests/auto/tst_webview/tst_webview.qrc
+++ b/tests/auto/tst_webview/tst_webview.qrc
@@ -1,0 +1,21 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource>
+    <file>tst_webview.qml</file>
+    <file alias="AlertDialog.qml">../../../src/pages/components/AlertDialog.qml</file>
+    <file alias="AuthDialog.qml">../../../src/pages/components/AuthDialog.qml</file>
+    <file alias="BrowserContextMenu.qml">../../../src/pages/components/BrowserContextMenu.qml</file>
+    <file alias="ConfirmDialog.qml">../../../src/pages/components/ConfirmDialog.qml</file>
+    <file alias="LocationDialog.qml">../../../src/pages/components/LocationDialog.qml</file>
+    <file alias="PasswordManagerDialog.qml">../../../src/pages/components/PasswordManagerDialog.qml</file>
+    <file alias="PromptDialog.qml">../../../src/pages/components/PromptDialog.qml</file>
+    <file alias="PromptLabel.qml">../../../src/pages/components/PromptLabel.qml</file>
+    <file alias="ResourceController.qml">../../../src/pages/components/ResourceController.qml</file>
+    <file alias="SelectDialog.qml">../../../src/pages/components/SelectDialog.qml</file>
+    <file alias="TabModel.qml">../../../src/pages/components/TabModel.qml</file>
+    <file alias="WebView.qml">../../../src/pages/components/WebView.qml</file>
+    <file alias="WebPopupHandler.js">../../../src/pages/components/WebPopupHandler.js</file>
+    <file alias="WebViewTabCache.js">../../../src/pages/components/WebViewTabCache.js</file>
+    <file alias="UserPrompt.qml">../../../src/pages/components/UserPrompt.qml</file>
+    <file alias="ResourceController.qml">../../../src/pages/components/ResourceController.qml</file>
+</qresource>
+</RCC>

--- a/tests/auto/tst_webview/webUtilsMock.cpp
+++ b/tests/auto/tst_webview/webUtilsMock.cpp
@@ -1,0 +1,45 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "webUtilsMock.h"
+
+static WebUtilsMock *s_instance;
+
+WebUtilsMock::WebUtilsMock(QObject *parent)
+    : QObject(parent)
+    , homePage("file:///opt/tests/sailfish-browser/manual/testpage.html")
+{
+}
+
+int WebUtilsMock::getLightness(QColor color) const
+{
+    return color.lightness();
+}
+
+QString WebUtilsMock::displayableUrl(QString fullUrl) const
+{
+    return fullUrl;
+}
+
+QObject *WebUtilsMock::singletonApiFactory(QQmlEngine *, QJSEngine *)
+{
+    // Instance will be owned by QML engine.
+    s_instance = new WebUtilsMock();
+    return s_instance;
+}
+
+WebUtilsMock *WebUtilsMock::instance()
+{
+    if (!s_instance) {
+        s_instance = new WebUtilsMock();
+    }
+    return s_instance;
+}

--- a/tests/auto/tst_webview/webUtilsMock.h
+++ b/tests/auto/tst_webview/webUtilsMock.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WEBUTILS_MOCK
+#define WEBUTILS_MOCK
+
+#include <QObject>
+#include <QString>
+#include <QColor>
+#include <qqml.h>
+
+class WebUtilsMock : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString homePage MEMBER homePage NOTIFY homePageChanged FINAL)
+
+public:
+    explicit WebUtilsMock(QObject *parent = 0);
+
+    Q_INVOKABLE int getLightness(QColor color) const;
+    Q_INVOKABLE QString displayableUrl(QString fullUrl) const;
+
+    static QObject *singletonApiFactory(QQmlEngine *, QJSEngine *);
+    static WebUtilsMock *instance();
+
+    QString homePage;
+
+signals:
+    void homePageChanged();
+};
+
+QML_DECLARE_TYPE(WebUtilsMock)
+
+#endif

--- a/tests/manual/testpage.html
+++ b/tests/manual/testpage.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, user-scalable=false;">
+        <title>TestPage</title>
         <style type="text/css">
             input {
                 font-size: 100%


### PR DESCRIPTION
Will add later more valuable tests. Currently this just initializes homePage through mocked WebUtils and checks that it was loaded.

We call somewhere delete for a object from a wrong thread, seeing "Managed object is not deleted in a right thread" after tst_webview::cleanupTestCase() has finnished (cor::qt::Actor_). Cor? Haven't seen this before elsewhere.
