### PR TITLE
[sailfish-browser] Add DeclarativeWebPage containing all browser specific properties

### DIFF
--- a/src/declarativewebpage.cpp
+++ b/src/declarativewebpage.cpp
@@ -1,0 +1,34 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jollamobile.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "declarativewebpage.h"
+
+DeclarativeWebPage::DeclarativeWebPage(QuickMozView *parent)
+    : QuickMozView(parent)
+    , m_container(0)
+    , m_tabId(0)
+    , m_viewReady(false)
+    , m_loaded(false)
+    , m_userHasDraggedWhileLoading(false)
+    , m_deferredReload(false)
+{
+
+}
+
+DeclarativeWebPage::~DeclarativeWebPage()
+{
+
+}
+
+void DeclarativeWebPage::componentComplete()
+{
+    QuickMozView::componentComplete();
+}

--- a/src/declarativewebpage.h
+++ b/src/declarativewebpage.h
@@ -1,0 +1,68 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jollamobile.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef DECLARATIVEWEBPAGE_H
+#define DECLARATIVEWEBPAGE_H
+
+#include <qqml.h>
+#include <QPointer>
+#include <quickmozview.h>
+#include <declarativewebcontainer.h>
+
+class DeclarativeWebPage : public QuickMozView {
+    Q_OBJECT
+    Q_PROPERTY(DeclarativeWebContainer* container MEMBER m_container NOTIFY containerChanged FINAL)
+    Q_PROPERTY(int tabId MEMBER m_tabId NOTIFY tabIdChanged FINAL)
+    Q_PROPERTY(bool viewReady MEMBER m_viewReady NOTIFY viewReadyChanged FINAL)
+    Q_PROPERTY(bool loaded MEMBER m_loaded NOTIFY loadedChanged FINAL)
+    Q_PROPERTY(bool userHasDraggedWhileLoading MEMBER m_userHasDraggedWhileLoading NOTIFY userHasDraggedWhileLoadingChanged FINAL)
+    Q_PROPERTY(QString favicon MEMBER m_favicon NOTIFY faviconChanged FINAL)
+    Q_PROPERTY(QVariant resurrectedContentRect MEMBER m_resurrectedContentRect NOTIFY resurrectedContentRectChanged)
+
+    // Private
+    Q_PROPERTY(bool _deferredReload MEMBER m_deferredReload NOTIFY _deferredReloadChanged FINAL)
+    Q_PROPERTY(QVariant _deferredLoad MEMBER m_deferredLoad NOTIFY _deferredLoadChanged FINAL)
+
+public:
+    DeclarativeWebPage(QuickMozView *parent = 0);
+    ~DeclarativeWebPage();
+
+signals:
+    void containerChanged();
+    void tabIdChanged();
+    void viewReadyChanged();
+    void loadedChanged();
+    void userHasDraggedWhileLoadingChanged();
+    void faviconChanged();
+    void resurrectedContentRectChanged();
+
+    void _deferredReloadChanged();
+    void _deferredLoadChanged();
+
+protected:
+    void componentComplete();
+
+private:
+    QPointer<DeclarativeWebContainer> m_container;
+    int m_tabId;
+    bool m_viewReady;
+    bool m_loaded;
+    bool m_userHasDraggedWhileLoading;
+    QString m_favicon;
+    QVariant m_resurrectedContentRect;
+
+    bool m_deferredReload;
+    QVariant m_deferredLoad;
+};
+
+QML_DECLARE_TYPE(DeclarativeWebPage)
+
+#endif

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -159,26 +159,17 @@ WebContainer {
 
     Component {
         id: webViewComponent
-        QmlMozView {
-            id: webView
+        WebPage {
+            id: webPage
 
-            property Item container
-            property string favicon
-            readonly property bool loaded: loadProgress === 100
-            property bool userHasDraggedWhileLoading
-            property bool viewReady
-            property int tabId
-            property var resurrectedContentRect
-
-            property bool _deferredReload
-            property var _deferredLoad: null
+            loaded: loadProgress === 100
 
             function loadTab(newUrl, force) {
                 // Always enable chrome when load is called.
                 chrome = true
                 if ((newUrl !== "" && url != newUrl) || force) {
                     resourceController.firstFrameRendered = false
-                    webView.load(newUrl)
+                    webPage.load(newUrl)
                 }
 
                 // This looks like a not needed condition for now. However, if we add a max number of real tabs
@@ -233,8 +224,8 @@ WebContainer {
             }
 
             onBgcolorChanged: {
-                // Update only webView
-                if (container.contentItem === webView) {
+                // Update only webPage
+                if (container.contentItem === webPage) {
                     var bgLightness = WebUtils.getLightness(bgcolor)
                     var dimmerLightness = WebUtils.getLightness(Theme.highlightDimmerColor)
                     var highBgLightness = WebUtils.getLightness(Theme.highlightBackgroundColor)
@@ -296,7 +287,7 @@ WebContainer {
                 if (loading) {
                     userHasDraggedWhileLoading = false
                     container.loadProgress = 0
-                    webView.chrome = true
+                    webPage.chrome = true
                     favicon = ""
                     container.resetHeight(false)
                 }
@@ -347,7 +338,7 @@ WebContainer {
                     break
                 }
                 case "Content:SelectionRange": {
-                    webView.selectionRangeUpdated(data)
+                    webPage.selectionRangeUpdated(data)
                     break
                 }
                 }
@@ -356,7 +347,7 @@ WebContainer {
                 // sender expects that this handler will update `response` argument
                 switch (message) {
                 case "Content:SelectionCopied": {
-                    webView.selectionCopied(data)
+                    webPage.selectionCopied(data)
 
                     if (data.succeeded) {
                         //% "Copied to clipboard"
@@ -368,7 +359,7 @@ WebContainer {
             }
 
             onWindowCloseRequested: {
-                console.log("WebView onWindowCloseRequested:", tabId)
+                console.log("webPage onWindowCloseRequested:", tabId)
                 var parentTabId = model.parentTabId(tabId)
                 // Closing only allowed if window was created by script
                 if (parentTabId) {
@@ -384,7 +375,7 @@ WebContainer {
                 name: "boundHeightControl"
                 when: container.inputPanelVisible || !container.foreground || !visible
                 PropertyChanges {
-                    target: webView
+                    target: webPage
                     height: container.parent.height
                 }
             }

--- a/src/pages/components/WebViewTabCache.js
+++ b/src/pages/components/WebViewTabCache.js
@@ -123,7 +123,8 @@ function _updateActiveTab(tab, resurrect) {
     }
     _activeWebView = tab.view
     if (resurrect) {
-        _activeWebView.resurrectedContentRect = tab.cssContentRect
+        _activeWebView.resurrectedContentRect = Qt.rect(tab.cssContentRect.x, tab.cssContentRect.y,
+                                                        tab.cssContentRect.width, tab.cssContentRect.height)
         _activeTabs[_activeWebView.tabId].cssContentRect = null
     }
 

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -20,8 +20,6 @@
 #include <QScreen>
 #include <QDBusConnection>
 
-//#include "qdeclarativemozview.h"
-#include "quickmozview.h"
 #include "qmozcontext.h"
 
 #include "declarativebookmarkmodel.h"
@@ -34,6 +32,7 @@
 #include "declarativetabmodel.h"
 #include "declarativehistorymodel.h"
 #include "declarativewebcontainer.h"
+#include "declarativewebpage.h"
 #include "declarativewebviewcreator.h"
 
 #ifdef HAS_BOOSTER
@@ -103,6 +102,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterType<DeclarativeHistoryModel>("Sailfish.Browser", 1, 0, "HistoryModel");
     qmlRegisterUncreatableType<DeclarativeTab>("Sailfish.Browser", 1, 0, "Tab", "");
     qmlRegisterType<DeclarativeWebContainer>("Sailfish.Browser", 1, 0, "WebContainer");
+    qmlRegisterType<DeclarativeWebPage>("Sailfish.Browser", 1, 0, "WebPage");
     qmlRegisterType<DeclarativeWebViewCreator>("Sailfish.Browser", 1, 0, "WebViewCreator");
 
     QString componentPath(DEFAULT_COMPONENTS_PATH);

--- a/src/src.pro
+++ b/src/src.pro
@@ -56,6 +56,7 @@ SOURCES += \
     declarativebookmarkmodel.cpp \
     bookmark.cpp \
     declarativewebcontainer.cpp \
+    declarativewebpage.cpp \
     declarativewebutils.cpp \
     declarativewebviewcreator.cpp \
     browserservice.cpp \
@@ -69,6 +70,7 @@ HEADERS += \
     declarativebookmarkmodel.h \
     bookmark.h \
     declarativewebcontainer.h \
+    declarativewebpage.h \
     declarativewebutils.h \
     declarativewebviewcreator.h \
     browserservice.h \

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -18,6 +18,7 @@
 #include "declarativetab.h"
 #include "declarativetabmodel.h"
 #include "declarativewebcontainer.h"
+#include "declarativewebpage.h"
 #include "declarativewebviewcreator.h"
 #include "webUtilsMock.h"
 
@@ -417,6 +418,7 @@ int main(int argc, char *argv[])
     qmlRegisterUncreatableType<DeclarativeTab>("Sailfish.Browser", 1, 0, "Tab", "");
     qmlRegisterType<DeclarativeTabModel>("Sailfish.Browser", 1, 0, "TabModel");
     qmlRegisterType<DeclarativeWebContainer>("Sailfish.Browser", 1, 0, "WebContainer");
+    qmlRegisterType<DeclarativeWebPage>("Sailfish.Browser", 1, 0, "WebPage");
     qmlRegisterType<DeclarativeWebViewCreator>("Sailfish.Browser", 1, 0, "WebViewCreator");
     qmlRegisterSingletonType<WebUtilsMock>("Sailfish.Browser", 1, 0, "WebUtils", WebUtilsMock::singletonApiFactory);
     view.rootContext()->setContextProperty("MozContext", QMozContext::GetInstance());

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -3,9 +3,11 @@ include(../test_common.pri)
 
 SOURCES += tst_webview.cpp \
     webUtilsMock.cpp \
+    ../../../src/declarativewebpage.cpp \
     ../../../src/declarativewebviewcreator.cpp
 
 HEADERS += webUtilsMock.h \
+    ../../../src/declarativewebpage.h \
     ../../../src/declarativewebviewcreator.h
 
 OTHER_FILES = *.qml


### PR DESCRIPTION
Related to task: https://github.com/sailfishos/sailfish-browser/issues/50

Will rename surroundings in follow up PR.
