### PR TITLE
Update ids of WebView and WebPage to be more descriptive

### DIFF
--- a/src/pages/components/WebPopupHandler.js
+++ b/src/pages/components/WebPopupHandler.js
@@ -12,7 +12,7 @@
 .pragma library
 .import QtQuick 2.1 as QtQuick
 
-var webViewContainer
+var webView
 var popups
 var pageStack
 var auxTimer
@@ -47,7 +47,7 @@ var _authData = null
 
 function _hideVirtualKeyboard() {
     if (Qt.inputMethod.visible) {
-        webViewContainer.parent.focus = true
+        webView.parent.focus = true
     }
 }
 
@@ -89,7 +89,7 @@ function openAuthDialog(input) {
                                         "passwordOnly": data.passwordOnly
                                     })
         dialog.accepted.connect(function () {
-            webViewContainer.sendAsyncMessage("authresponse",
+            webView.sendAsyncMessage("authresponse",
                                            {
                                                "winid": winid,
                                                "accepted": true,
@@ -98,7 +98,7 @@ function openAuthDialog(input) {
                                            })
         })
         dialog.rejected.connect(function() {
-            webViewContainer.sendAsyncMessage("authresponse",
+            webView.sendAsyncMessage("authresponse",
                                            {"winid": winid, "accepted": false})
         })
     }
@@ -109,14 +109,14 @@ function openSelectDialog(data) {
                                 {
                                     "options": data.options,
                                     "multiple": data.multiple,
-                                    "webview": webViewContainer.contentItem
+                                    "webview": webView.contentItem
                                 })
 }
 
 function openPasswordManagerDialog(data) {
     pageStack.push(_passwordManagerComponentUrl,
                    {
-                       "webView": webViewContainer.contentItem,
+                       "webView": webView.contentItem,
                        "requestId": data.id,
                        "notificationType": data.name,
                        "formData": data.formdata
@@ -126,8 +126,8 @@ function openPasswordManagerDialog(data) {
 function openContextMenu(data) {
     // Possible path that leads to a new tab. Thus, capturing current
     // view before opening context menu.
-    webViewContainer.captureScreen()
-    webViewContainer.contentItem.contextMenuRequested(data)
+    webView.captureScreen()
+    webView.contentItem.contextMenuRequested(data)
     if (data.types.indexOf("image") !== -1 || data.types.indexOf("link") !== -1) {
         var linkHref = data.linkURL
         var imageSrc = data.mediaURL
@@ -142,18 +142,18 @@ function openContextMenu(data) {
         } else {
             contextMenuComponent = Qt.createComponent(_contextMenuComponentUrl)
             if (contextMenuComponent.status !== QtQuick.Component.Error) {
-                _contextMenu = contextMenuComponent.createObject(webViewContainer.parent,
+                _contextMenu = contextMenuComponent.createObject(webView.parent,
                                                         {
                                                             "linkHref": linkHref,
                                                             "imageSrc": imageSrc,
                                                             "linkTitle": linkTitle.trim(),
                                                             "contentType": contentType,
                                                             "tabModel": tabModel,
-                                                            "viewId": webViewContainer.contentItem.uniqueID()
+                                                            "viewId": webView.contentItem.uniqueID()
                                                         })
                 _hideVirtualKeyboard()
 
-                webViewContainer.popupActive = Qt.binding(function() { return (_contextMenu.active) })
+                webView.popupActive = Qt.binding(function() { return (_contextMenu.active) })
                 _contextMenu.show()
             } else {
                 console.log("Can't load BrowserContextMenu.qml")
@@ -164,21 +164,21 @@ function openContextMenu(data) {
 
 function openLocationDialog(data) {
     // Ask for location permission
-    var url = webViewContainer.contentItem.url
+    var url = webView.contentItem.url
     if (isAcceptedGeolocationUrl(url)) {
-        webViewContainer.sendAsyncMessage("embedui:premissions", {
+        webView.sendAsyncMessage("embedui:premissions", {
                              allow: true,
                              checkedDontAsk: false,
                              id: data.id })
     } else if (isRejectedGeolocationUrl(url)) {
-        webViewContainer.sendAsyncMessage("embedui:premissions", {
+        webView.sendAsyncMessage("embedui:premissions", {
                              allow: false,
                              checkedDontAsk: false,
                              id: data.id })
     } else {
         var dialog = pageStack.push(_locationComponentUrl, {})
         dialog.accepted.connect(function() {
-            webViewContainer.sendAsyncMessage("embedui:premissions", {
+            webView.sendAsyncMessage("embedui:premissions", {
                                                allow: true,
                                                checkedDontAsk: false,
                                                id: data.id })
@@ -186,7 +186,7 @@ function openLocationDialog(data) {
             rejectedGeolocationUrl = ""
         })
         dialog.rejected.connect(function() {
-            webViewContainer.sendAsyncMessage("embedui:premissions", {
+            webView.sendAsyncMessage("embedui:premissions", {
                                                allow: false,
                                                checkedDontAsk: false,
                                                id: data.id })
@@ -202,7 +202,7 @@ function openAlert(data) {
                                 {"text": data.text})
     // TODO: also the Async message must be sent when window gets closed
     dialog.done.connect(function() {
-        webViewContainer.sendAsyncMessage("alertresponse", {"winid": winid})
+        webView.sendAsyncMessage("alertresponse", {"winid": winid})
     })
 }
 
@@ -212,11 +212,11 @@ function openConfirm(data) {
                                 {"text": data.text})
     // TODO: also the Async message must be sent when window gets closed
     dialog.accepted.connect(function() {
-        webViewContainer.sendAsyncMessage("confirmresponse",
+        webView.sendAsyncMessage("confirmresponse",
                          {"winid": winid, "accepted": true})
     })
     dialog.rejected.connect(function() {
-        webViewContainer.sendAsyncMessage("confirmresponse",
+        webView.sendAsyncMessage("confirmresponse",
                          {"winid": winid, "accepted": false})
     })
 }
@@ -227,7 +227,7 @@ function openPrompt(data) {
                                 {"text": data.text, "value": data.defaultValue})
     // TODO: also the Async message must be sent when window gets closed
     dialog.accepted.connect(function() {
-        webViewContainer.sendAsyncMessage("promptresponse",
+        webView.sendAsyncMessage("promptresponse",
                          {
                              "winid": winid,
                              "accepted": true,
@@ -235,7 +235,7 @@ function openPrompt(data) {
                          })
     })
     dialog.rejected.connect(function() {
-        webViewContainer.sendAsyncMessage("promptresponse",
+        webView.sendAsyncMessage("promptresponse",
                          {"winid": winid, "accepted": false})
     })
 }

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -18,7 +18,7 @@ import "WebPopupHandler.js" as PopupHandler
 import "." as Browser
 
 WebContainer {
-    id: webContainer
+    id: webView
 
     // TODO: Push this to C++ if possible. Check if TabModel is feasible to merged to DeclarativeTabModel
     property alias tabModel: model
@@ -100,7 +100,7 @@ WebContainer {
     foreground: Qt.application.active
     inputPanelHeight: window.pageStack.panelSize
     inputPanelOpenHeight: window.pageStack.imSize
-    fullscreenMode: (contentItem && contentItem.chromeGestureEnabled && !contentItem.chrome) || webContainer.inputPanelVisible || !webContainer.foreground
+    fullscreenMode: (contentItem && contentItem.chromeGestureEnabled && !contentItem.chrome) || webView.inputPanelVisible || !webView.foreground
     _firstFrameRendered: resourceController.firstFrameRendered
     _readyToLoad: contentItem && contentItem.viewReady && tabModel.loaded
 
@@ -123,10 +123,10 @@ WebContainer {
         } else if (model.count > 0) {
             // First tab is actived when tabs are loaded to the tabs model.
             model.resetNewTabData()
-            webContainer.load(currentTab.url, currentTab.title)
+            webView.load(currentTab.url, currentTab.title)
         } else {
             // This can happen only during startup.
-            webContainer.load(WebUtils.homePage, "")
+            webView.load(WebUtils.homePage, "")
         }
     }
 
@@ -145,16 +145,16 @@ WebContainer {
     Browser.TabModel {
         id: model
 
-        webViewComponent: webViewComponent
-        webViewContainer: webContainer
+        webPageComponent: webPageComponent
+        webView: webView
 
         // Enable browsing after new tab actually created or it was not even requested
-        browsing: webContainer.active && !hasNewTabData && contentItem && contentItem.loaded
+        browsing: webView.active && !hasNewTabData && contentItem && contentItem.loaded
         onBrowsingChanged: if (browsing) captureScreen()
     }
 
     Component {
-        id: webViewComponent
+        id: webPageComponent
         WebPage {
             id: webPage
 
@@ -400,7 +400,7 @@ WebContainer {
         width: contentItem ? contentItem.horizontalScrollDecorator.size : 0
         height: 5
         x: contentItem ? contentItem.horizontalScrollDecorator.position : 0
-        y: webContainer.parent.height - (fullscreenMode ? 0 : toolbarHeight) - height
+        y: webView.parent.height - (fullscreenMode ? 0 : toolbarHeight) - height
         z: 1
         color: _decoratorColor
         smooth: true
@@ -445,7 +445,7 @@ WebContainer {
                 url = contentItem._deferredLoad["url"]
                 title = contentItem._deferredLoad["title"]
                 contentItem._deferredLoad = null
-                webContainer.load(url, title, true)
+                webView.load(url, title, true)
             } else if (contentItem && contentItem._deferredReload) {
                 contentItem._deferredReload = false
                 contentItem.reload()
@@ -463,7 +463,7 @@ WebContainer {
     ResourceController {
         id: resourceController
         webView: contentItem
-        background: webContainer.background
+        background: webView.background
 
         onWebViewSuspended: connectionHelper.closeNetworkSession()
         onFirstFrameRenderedChanged: {
@@ -483,7 +483,7 @@ WebContainer {
     Component.onCompleted: {
         PopupHandler.auxTimer = auxTimer
         PopupHandler.pageStack = pageStack
-        PopupHandler.webViewContainer = webContainer
+        PopupHandler.webView = webView
         PopupHandler.resourceController = resourceController
         PopupHandler.WebUtils = WebUtils
         PopupHandler.tabModel = tabModel

--- a/src/pages/components/WebViewTabCache.js
+++ b/src/pages/components/WebViewTabCache.js
@@ -15,7 +15,7 @@ var initialized = false
 var count
 
 // Private
-var _webViewComponent
+var _webPageComponent
 var _arguments
 var _parent
 
@@ -26,14 +26,14 @@ var debug = false
 
 function init(args, component, container) {
     _arguments = args
-    _webViewComponent = component
+    _webPageComponent = component
     _parent = container
     initialized = true
     count = 0
 }
 
 function getTab(tabId, parentId) {
-    if (!_webViewComponent || (_activeWebView && _activeWebView.tabId === tabId)) {
+    if (!_webPageComponent || (_activeWebView && _activeWebView.tabId === tabId)) {
         _activeWebView.resumeView()
         _activeWebView.visible = true
         return { "view": _activeWebView, "activated": false }
@@ -46,7 +46,7 @@ function getTab(tabId, parentId) {
     if (!tab || tab && !tab.view){
         _arguments.parentId = parentId
         _arguments.tabId = tabId
-        var webView = _webViewComponent.createObject(_parent, _arguments)
+        var webView = _webPageComponent.createObject(_parent, _arguments)
         if (debug) console.log("New view id: ", webView.uniqueID(), parentId, "tab id:", tabId)
         if (!tab) {
             tab = { "view": webView, "cssContentRect": null }


### PR DESCRIPTION
Idea is that we have a WebView that owns a TabModel and the WebView (throuhg model) creates WebPages.

In our case MozView is quite close conceptually a page meaning that each Tab is a page that can be navigated. Could be also something like Tab but that is already used and in addition WebPage is not exposed outside. One conceptual positive thing is that this is quite close to QQuickWebView that owns a QQuickWebPage. In our case ownership is one-to-many.

Unfortunately I was not able to isolate this more so this is on top of following PRs:
- https://github.com/sailfishos/sailfish-browser/pull/57
- https://github.com/sailfishos/sailfish-browser/pull/58
