### PR TITLE
Move properties from TabModel to C++ side

### DIFF
--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -62,6 +62,7 @@ public:
     DeclarativeWebContainer(QQuickItem *parent = 0);
     ~DeclarativeWebContainer();
 
+    // TODO: Rename these
     QuickMozView *webView() const;
     void setWebView(QuickMozView *webView);
 

--- a/src/pages/components/TabModel.qml
+++ b/src/pages/components/TabModel.qml
@@ -14,38 +14,6 @@ import Sailfish.Browser 1.0
 import "WebViewTabCache.js" as TabCache
 
 TabModel {
-    property Component webPageComponent
-    property Item webView
-
-    readonly property bool hasNewTabData: _newTabData && _newTabData.url
-    readonly property string newTabUrl: hasNewTabData ? _newTabData.url : ""
-    readonly property string newTabTitle: hasNewTabData ? _newTabData.title : ""
-    readonly property Item newTabPreviousView: hasNewTabData ? _newTabData.previousView : null
-
-    // Load goes so that we first use engine load to resolve url
-    // and then save that resolved url to the history. This way
-    // urls that resolve to download urls won't get saved to the
-    // history (as those won't trigger url change). By doing this way
-    // a redirected url will be saved with the redirected url not with
-    // the input url.
-    property var _newTabData: null
-
-    function newTab(url, title, parentId) {
-        newTabData(url, title, webView.contentItem, parentId)
-        webView.load(url, title)
-    }
-
-    function newTabData(url, title, contentItem, parentId) {
-        // Url is not need in model._newTabData as we let engine to resolve
-        // the url and use the resolved url.
-        parentId = parentId ? parentId : 0
-        _newTabData = { "url": url, "title": title, "previousView": contentItem, "parentId": parentId }
-    }
-
-    function resetNewTabData() {
-        _newTabData = null
-    }
-
     // TODO: Check could this be merged with activateTab(tabId)
     // TabModel could keep also TabCache internally.
     function activateView(tabId, force) {
@@ -54,7 +22,7 @@ TabModel {
         }
 
         if ((loaded || force) && tabId > 0) {
-            var activationObject = TabCache.getTab(tabId, hasNewTabData ? _newTabData.parentId : 0)
+            var activationObject = TabCache.getTab(tabId, _newTabParentId)
             webView.contentItem = activationObject.view
             webView.contentItem.chrome = true
             webView.loadProgress = webView.contentItem.loadProgress

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -216,7 +216,6 @@ WebContainer {
                 }
 
                 model.updateUrl(tabId, url)
-                model.resetNewTabData()
             }
 
             onBgcolorChanged: {

--- a/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
+++ b/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
@@ -70,6 +70,10 @@ private slots:
 
     void updateTitle();
 
+    void newTab();
+    void newTabData();
+    void resetNewTabData();
+
     void clear();
 
 private:
@@ -657,6 +661,72 @@ void tst_declarativetabmodel::updateTitle()
     tabModel->updateTitle(tab2, title);
     QCOMPARE(currentTabTitleSpy.count(), 5);
     QCOMPARE(webContainerTitleSpy.count(), 5);
+}
+
+void tst_declarativetabmodel::newTab()
+{
+    tabModel->resetNewTabData();
+
+    QSignalSpy newTabDataChanged(tabModel, SIGNAL(hasNewTabDataChanged()));
+    QSignalSpy newTabUrlChanged(tabModel, SIGNAL(newTabUrlChanged()));
+    QSignalSpy newTabTitleChanged(tabModel, SIGNAL(newTabTitleChanged()));
+    QSignalSpy newTabPreviousViewChanged(tabModel, SIGNAL(newTabPreviousViewChanged()));
+
+    tabModel->newTab("http://foobar.com", "FooBar");
+
+    QCOMPARE(newTabDataChanged.count(), 1);
+    QCOMPARE(newTabUrlChanged.count(), 1);
+    QCOMPARE(newTabTitleChanged.count(), 1);
+    QCOMPARE(newTabPreviousViewChanged.count(), 0);
+
+    QCOMPARE(tabModel->newTabUrl(), QString("http://foobar.com"));
+    QCOMPARE(tabModel->newTabTitle(), QString("FooBar"));
+}
+
+void tst_declarativetabmodel::newTabData()
+{
+    tabModel->resetNewTabData();
+
+    QSignalSpy newTabDataChanged(tabModel, SIGNAL(hasNewTabDataChanged()));
+    QSignalSpy newTabUrlChanged(tabModel, SIGNAL(newTabUrlChanged()));
+    QSignalSpy newTabTitleChanged(tabModel, SIGNAL(newTabTitleChanged()));
+    QSignalSpy newTabPreviousViewChanged(tabModel, SIGNAL(newTabPreviousViewChanged()));
+
+    QQuickItem item;
+    tabModel->newTabData("http://foobar.com", "FooBar", &item);
+
+    QCOMPARE(newTabDataChanged.count(), 1);
+    QCOMPARE(newTabUrlChanged.count(), 1);
+    QCOMPARE(newTabTitleChanged.count(), 1);
+    QCOMPARE(newTabPreviousViewChanged.count(), 1);
+
+    QCOMPARE(tabModel->newTabUrl(), QString("http://foobar.com"));
+    QCOMPARE(tabModel->newTabTitle(), QString("FooBar"));
+    QCOMPARE(tabModel->newTabPreviousView(), &item);
+}
+
+void tst_declarativetabmodel::resetNewTabData()
+{
+    // Old values (see newTabData test):
+    // url = "http://foobar.com"
+    // title = "FooBar"
+    // previousView = Temporary QQuickItem pointer (non zero)
+    QSignalSpy newTabDataChanged(tabModel, SIGNAL(hasNewTabDataChanged()));
+    QSignalSpy newTabUrlChanged(tabModel, SIGNAL(newTabUrlChanged()));
+    QSignalSpy newTabTitleChanged(tabModel, SIGNAL(newTabTitleChanged()));
+    QSignalSpy newTabPreviousViewChanged(tabModel, SIGNAL(newTabPreviousViewChanged()));
+
+    tabModel->resetNewTabData();
+
+    QCOMPARE(newTabDataChanged.count(), 1);
+    QCOMPARE(newTabUrlChanged.count(), 1);
+    QCOMPARE(newTabTitleChanged.count(), 1);
+    QCOMPARE(newTabPreviousViewChanged.count(), 1);
+
+    QVERIFY(!tabModel->hasNewTabData());
+    QVERIFY(tabModel->newTabUrl().isEmpty());
+    QVERIFY(tabModel->newTabTitle().isEmpty());
+    QVERIFY(!tabModel->newTabPreviousView());
 }
 
 void tst_declarativetabmodel::clear()

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -133,10 +133,7 @@ void tst_webview::testNewTab()
 
     // Mimic favorite opening to a new tab. Favorites can have both url and title and when entering
     // url through virtual keyboard only url is provided.
-    QMetaObject::invokeMethod(tabModel, "newTab", Qt::DirectConnection,
-                              Q_ARG(QVariant, newUrl),
-                              Q_ARG(QVariant, newTitle),
-                              Q_ARG(QVariant, 0));
+    tabModel->newTab(newUrl, newTitle);
 
     // Wait for MozView instance change.
     waitSignals(contentItemSpy, 1);

--- a/tests/auto/tst_webview/tst_webview.qml
+++ b/tests/auto/tst_webview/tst_webview.qml
@@ -28,6 +28,9 @@ ApplicationWindow {
         active: true
         toolbarHeight: 50
         portrait: true
+
+        // Mimic onOpenUrlRequested handler of BrowserPage
+        Component.onCompleted: tabModel.newTab(WebUtils.homePage, "")
     }
 
     cover: undefined


### PR DESCRIPTION
...7328

This commit has the same renamings as https://github.com/sailfishos/sailfish-browser/pull/59.
That is just to avoid merge conflicts.

After this is merged we can push rest of TabModel and TabViewCache pragma lib to C++ side.
