### PR TITLE
Move tab destroy handling to C++ when downloading

### DIFF
--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -16,21 +16,20 @@
 #include <QHash>
 #include <QString>
 #include <QVariant>
-#include "browserservice.h"
-#include <transferengineinterface.h>
-#include <transfertypes.h>
 
+class TransferEngineInterface;
 
 class DownloadManager : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit DownloadManager(BrowserService *service, QObject *parent = 0);
+    static DownloadManager *instance();
 
     bool existActiveTransfers();
 
 signals:
+    void downloadStarted();
     void allTransfersCompleted();
 
 public slots:
@@ -42,6 +41,9 @@ private slots:
     void restartTransfer(int transferId);
 
 private:
+    explicit DownloadManager();
+    ~DownloadManager();
+
     enum Status {
         DownloadStarted,
         DownloadDone,

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -56,8 +56,11 @@ WebContainer {
         }
 
         // Bookmarks and history items pass url and title as arguments.
-        currentTab.url = url
-        currentTab.title = title
+        // Only set url and title if title exists.
+        if (title) {
+            currentTab.title = title
+            currentTab.url = url
+        }
 
         if (!model.hasNewTabData || force || !model.activatePage(model.nextTabId)) {
             // First contentItem will be created once tab activated.
@@ -153,8 +156,6 @@ WebContainer {
         onBrowsingChanged: if (browsing) captureScreen()
 
         onTriggerLoad: webView.load(url, title)
-
-        Component.onCompleted: console.log("TabModel Component.onCompleted")
     }
 
     Component {
@@ -401,31 +402,6 @@ WebContainer {
         visible: contentItem && contentItem.contentWidth > contentItem.width && !contentItem.pinching && !popupActive
         opacity: contentItem && contentItem.horizontalScrollDecorator.moving ? 1.0 : 0.0
         Behavior on opacity { NumberAnimation { properties: "opacity"; duration: 400 } }
-    }
-
-    Connections {
-        target: MozContext
-        onRecvObserve: {
-            if (message === "embed:download") {
-                switch (data.msg) {
-                    case "dl-fail":
-                    case "dl-done": {
-                        var previousContentItem = model.newTabPreviousView
-                        // TODO: Move releaseTab C++ public but not exposed to QML once
-                        // download handling pushed to C++.
-                        model.releaseTab(contentItem.tabId)
-                        if (previousContentItem) {
-                            model.activatePage(previousContentItem.tabId)
-                        } else if (model.count === 0) {
-                            // Download doesn't add tab to model. Mimic
-                            // model change in case tabs count goes to zero.
-                            model.countChanged()
-                        }
-                        break
-                    }
-                }
-            }
-        }
     }
 
     ConnectionHelper {

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -19,6 +19,8 @@
 #include <QDir>
 #include <QScreen>
 #include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusPendingCall>
 
 #include "qmozcontext.h"
 
@@ -119,7 +121,12 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     view->rootContext()->setContextProperty("WebUtils", utils);
     view->rootContext()->setContextProperty("MozContext", QMozContext::GetInstance());
 
-    DownloadManager  * dlMgr = new DownloadManager(service, app.data());
+    DownloadManager *dlMgr = DownloadManager::instance();
+    dlMgr->connect(service, SIGNAL(cancelTransferRequested(int)),
+            dlMgr, SLOT(cancelTransfer(int)));
+    dlMgr->connect(service, SIGNAL(restartTransferRequested(int)),
+            dlMgr, SLOT(restartTransfer(int)));
+
     CloseEventFilter * clsEventFilter = new CloseEventFilter(dlMgr, app.data());
     view->installEventFilter(clsEventFilter);
     QObject::connect(service, SIGNAL(openUrlRequested(QString)),

--- a/tests/auto/common/downloadmanager.cpp
+++ b/tests/auto/common/downloadmanager.cpp
@@ -1,0 +1,26 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "downloadmanager.h"
+
+DownloadManager::DownloadManager()
+    : QObject()
+{
+}
+
+DownloadManager *DownloadManager::instance()
+{
+    static DownloadManager *s_singleton = 0;
+    if (!s_singleton) {
+        s_singleton = new DownloadManager();
+    }
+    return s_singleton;
+}

--- a/tests/auto/common/downloadmanager.h
+++ b/tests/auto/common/downloadmanager.h
@@ -1,0 +1,31 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef DOWNLOADMANAGER_H
+#define DOWNLOADMANAGER_H
+
+#include <QObject>
+
+class DownloadManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    static DownloadManager *instance();
+
+signals:
+    void downloadStarted();
+
+private:
+    explicit DownloadManager();
+};
+
+#endif

--- a/tests/auto/common/downloadmanager_mock.pri
+++ b/tests/auto/common/downloadmanager_mock.pri
@@ -1,0 +1,6 @@
+# Mock interface for DownloadManager. Interface is not complete.
+# Currently it includes only methods needed at runtime.
+# This pri is included indirectly from unit tests cases that
+# are at the same level in the file hierarchy.
+SOURCES += ../common/downloadmanager.cpp
+HEADERS += ../common/downloadmanager.h

--- a/tests/auto/test_common.pri
+++ b/tests/auto/test_common.pri
@@ -7,6 +7,7 @@ INCLUDEPATH += ../../../src
 
 include(../../src/common.pri)
 include(../../src/history.pri)
+include(common/downloadmanager_mock.pri)
 
 HEADERS += ../../../src/declarativewebcontainer.h \
     ../../../src/declarativewebpage.h

--- a/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
+++ b/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
@@ -18,6 +18,7 @@
 #include "declarativetab.h"
 #include "declarativetabmodel.h"
 #include "declarativewebcontainer.h"
+#include "declarativewebpage.h"
 #include "dbmanager.h"
 
 static const QByteArray QML_SNIPPET = \
@@ -670,14 +671,15 @@ void tst_declarativetabmodel::newTab()
     QSignalSpy newTabDataChanged(tabModel, SIGNAL(hasNewTabDataChanged()));
     QSignalSpy newTabUrlChanged(tabModel, SIGNAL(newTabUrlChanged()));
     QSignalSpy newTabTitleChanged(tabModel, SIGNAL(newTabTitleChanged()));
-    QSignalSpy newTabPreviousViewChanged(tabModel, SIGNAL(newTabPreviousViewChanged()));
 
+    DeclarativeWebPage *previousPage = tabModel->newTabPreviousPage();
     tabModel->newTab("http://foobar.com", "FooBar");
 
     QCOMPARE(newTabDataChanged.count(), 1);
     QCOMPARE(newTabUrlChanged.count(), 1);
     QCOMPARE(newTabTitleChanged.count(), 1);
-    QCOMPARE(newTabPreviousViewChanged.count(), 0);
+    QVERIFY(!previousPage);
+    QCOMPARE(tabModel->newTabPreviousPage(), previousPage);
 
     QCOMPARE(tabModel->newTabUrl(), QString("http://foobar.com"));
     QCOMPARE(tabModel->newTabTitle(), QString("FooBar"));
@@ -690,19 +692,17 @@ void tst_declarativetabmodel::newTabData()
     QSignalSpy newTabDataChanged(tabModel, SIGNAL(hasNewTabDataChanged()));
     QSignalSpy newTabUrlChanged(tabModel, SIGNAL(newTabUrlChanged()));
     QSignalSpy newTabTitleChanged(tabModel, SIGNAL(newTabTitleChanged()));
-    QSignalSpy newTabPreviousViewChanged(tabModel, SIGNAL(newTabPreviousViewChanged()));
 
-    QQuickItem item;
-    tabModel->newTabData("http://foobar.com", "FooBar", &item);
+    DeclarativeWebPage page;
+    tabModel->newTabData("http://foobar.com", "FooBar", &page);
 
     QCOMPARE(newTabDataChanged.count(), 1);
     QCOMPARE(newTabUrlChanged.count(), 1);
     QCOMPARE(newTabTitleChanged.count(), 1);
-    QCOMPARE(newTabPreviousViewChanged.count(), 1);
 
     QCOMPARE(tabModel->newTabUrl(), QString("http://foobar.com"));
     QCOMPARE(tabModel->newTabTitle(), QString("FooBar"));
-    QCOMPARE(tabModel->newTabPreviousView(), &item);
+    QCOMPARE(tabModel->newTabPreviousPage(), &page);
 }
 
 void tst_declarativetabmodel::resetNewTabData()
@@ -710,23 +710,23 @@ void tst_declarativetabmodel::resetNewTabData()
     // Old values (see newTabData test):
     // url = "http://foobar.com"
     // title = "FooBar"
-    // previousView = Temporary QQuickItem pointer (non zero)
+    // previousPage = Temporary DeclarativeWebPage pointer (non zero)
     QSignalSpy newTabDataChanged(tabModel, SIGNAL(hasNewTabDataChanged()));
     QSignalSpy newTabUrlChanged(tabModel, SIGNAL(newTabUrlChanged()));
     QSignalSpy newTabTitleChanged(tabModel, SIGNAL(newTabTitleChanged()));
-    QSignalSpy newTabPreviousViewChanged(tabModel, SIGNAL(newTabPreviousViewChanged()));
+
+    QVERIFY(tabModel->newTabPreviousPage());
 
     tabModel->resetNewTabData();
 
     QCOMPARE(newTabDataChanged.count(), 1);
     QCOMPARE(newTabUrlChanged.count(), 1);
     QCOMPARE(newTabTitleChanged.count(), 1);
-    QCOMPARE(newTabPreviousViewChanged.count(), 1);
 
     QVERIFY(!tabModel->hasNewTabData());
     QVERIFY(tabModel->newTabUrl().isEmpty());
     QVERIFY(tabModel->newTabTitle().isEmpty());
-    QVERIFY(!tabModel->newTabPreviousView());
+    QVERIFY(!tabModel->newTabPreviousPage());
 }
 
 void tst_declarativetabmodel::clear()

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -1,6 +1,8 @@
 TARGET = tst_webview
 include(../test_common.pri)
 
+# TODO : Move webUtilsMock.cpp/h to own pri-file.
+
 SOURCES += tst_webview.cpp \
     webUtilsMock.cpp \
     ../../../src/declarativewebviewcreator.cpp


### PR DESCRIPTION
We create always a new tab when an external url is received
either via dbus or commandline. A new tab is used to resolve the url,
the new url might be a download url. In case the url triggered
download, we need to destroy the new orphan tab and
activate the tab that used to be visible (active top most).
Download urls are not persisted to the tab database.

DownloadManager is used for handling downloads.
