### PR TITLE
Improve loaded binding

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -162,7 +162,7 @@ WebContainer {
         WebPage {
             id: webPage
 
-            loaded: loadProgress === 100
+            loaded: loadProgress === 100 && !loading
 
             function loadTab(newUrl, force) {
                 // Always enable chrome when load is called.


### PR DESCRIPTION
Load progress can fluctuate when loading and peek to 100% before
the page is actually loaded. Both condition must be met so that
the web page can be considered as loaded.
