### PR TITLE
Remove explicit DeclartiveWebPage dependency from DeclarativeTabModel

### DIFF
--- a/src/declarativetabmodel.cpp
+++ b/src/declarativetabmodel.cpp
@@ -13,7 +13,6 @@
 
 #include "dbmanager.h"
 #include "declarativetab.h"
-#include "declarativewebcontainer.h"
 #include "linkvalidator.h"
 
 #include <QFile>
@@ -193,7 +192,7 @@ void DeclarativeTabModel::newTab(const QString &url, const QString &title, int p
     emit newTabRequested(url, title, parentId);
 }
 
-void DeclarativeTabModel::newTabData(const QString &url, const QString &title, DeclarativeWebPage *contentItem, int parentId)
+void DeclarativeTabModel::newTabData(const QString &url, const QString &title, QObject *contentItem, int parentId)
 {
     updateNewTabData(new NewTabData(url, title, contentItem, parentId));
 }
@@ -298,7 +297,7 @@ QString DeclarativeTabModel::newTabTitle() const
     return hasNewTabData() ? m_newTabData->title : "";
 }
 
-DeclarativeWebPage *DeclarativeTabModel::newTabPreviousPage() const
+QObject *DeclarativeTabModel::newTabPreviousPage() const
 {
     return hasNewTabData() ? m_newTabData->previousPage : 0;
 }

--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -20,7 +20,6 @@
 #include <QQmlComponent>
 
 #include "tab.h"
-#include "declarativewebcontainer.h"
 
 class DeclarativeTab;
 
@@ -56,7 +55,7 @@ public:
     Q_INVOKABLE void closeActiveTab();
 
     Q_INVOKABLE void newTab(const QString &url, const QString &title, int parentId = 0);
-    Q_INVOKABLE void newTabData(const QString &url, const QString &title, DeclarativeWebPage *contentItem = 0, int parentId = 0);
+    Q_INVOKABLE void newTabData(const QString &url, const QString &title, QObject *contentItem = 0, int parentId = 0);
     Q_INVOKABLE void resetNewTabData();
 
     Q_INVOKABLE void dumpTabs() const;
@@ -93,7 +92,7 @@ public:
     bool backForwardNavigation() const;
     void setBackForwardNavigation(bool backForwardNavigation);
 
-    DeclarativeWebPage* newTabPreviousPage() const;
+    QObject* newTabPreviousPage() const;
     const QList<Tab>& tabs() const;
 
     void updateUrl(int tabId, bool activeTab, QString url);
@@ -127,7 +126,7 @@ private slots:
 
 private:
     struct NewTabData {
-        NewTabData(QString url, QString title, DeclarativeWebPage *previousPage, int parentId)
+        NewTabData(QString url, QString title, QObject *previousPage, int parentId)
             : url(url)
             , title(title)
             , previousPage(previousPage)
@@ -136,7 +135,7 @@ private:
 
         QString url;
         QString title;
-        DeclarativeWebPage *previousPage;
+        QObject *previousPage;
         int parentId;
     };
 

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -562,7 +562,7 @@ void DeclarativeWebContainer::onDownloadStarted()
     // pass windowId of the active window when download is started and close
     // the passed windowId instead.
     if (m_model && m_model->hasNewTabData() && m_model->count() > 0 && m_webPage) {
-        DeclarativeWebPage *previousWebPage = m_model->newTabPreviousPage();
+        DeclarativeWebPage *previousWebPage = qobject_cast<DeclarativeWebPage *>(m_model->newTabPreviousPage());
         releasePage(m_webPage->tabId());
         if (previousWebPage) {
             activatePage(previousWebPage->tabId());

--- a/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
+++ b/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
@@ -18,7 +18,6 @@
 #include "declarativetab.h"
 #include "declarativetabmodel.h"
 #include "declarativewebcontainer.h"
-#include "declarativewebpage.h"
 #include "dbmanager.h"
 
 static const QByteArray QML_SNIPPET = \
@@ -669,7 +668,7 @@ void tst_declarativetabmodel::newTabData()
     QSignalSpy newTabDataChanged(tabModel, SIGNAL(hasNewTabDataChanged()));
     QSignalSpy newTabUrlChanged(tabModel, SIGNAL(newTabUrlChanged()));
     QVERIFY(tabModel->newTabTitle().isEmpty());
-    DeclarativeWebPage page;
+    QObject page;
     tabModel->newTabData("http://foobar.com", "FooBar", &page);
 
     QCOMPARE(newTabDataChanged.count(), 1);
@@ -685,7 +684,7 @@ void tst_declarativetabmodel::resetNewTabData()
     // Old values (see newTabData test):
     // url = "http://foobar.com"
     // title = "FooBar"
-    // previousPage = Temporary DeclarativeWebPage pointer (non zero)
+    // previousPage = Temporary QObject pointer (non zero)
     QSignalSpy newTabDataChanged(tabModel, SIGNAL(hasNewTabDataChanged()));
     QSignalSpy newTabUrlChanged(tabModel, SIGNAL(newTabUrlChanged()));
 


### PR DESCRIPTION
It is still assumed that contentItem can only be DeclarativeWebPage.
