### PR TITLE
Use global symbols as invoker argument

### DIFF
--- a/sailfish-browser.desktop
+++ b/sailfish-browser.desktop
@@ -4,5 +4,5 @@ Name=Web Browser
 X-MeeGo-Logical-Id=sailfish-browser-ap-name
 X-MeeGo-Translation-Catalog=sailfish-browser
 Icon=icon-launcher-browser
-Exec=/usr/bin/sailfish-browser %U
+Exec=invoker --type=qt5 -G /usr/bin/sailfish-browser %U
 Comment=Sailfish UI application


### PR DESCRIPTION
Gecko is full of RTLD_GLOBAL dlopen calls.

Requires: https://github.com/tmeshkova/gecko-dev/pull/13

Dima already added it as patch to https://github.com/nemomobile-packages/gecko-dev/commit/37e6fe7d7813d8b37eacf02b0d9a7f5d52a45890
