### PR TITLE
[sailfish-browser] Fix invoker launching

### DIFF
--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -60,6 +60,11 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 #endif
     app->setQuitOnLastWindowClosed(false);
 
+    // GRE_HOME must be set before QMozContext is initialized.
+    // With invoker PWD is empty.
+    QByteArray binaryPath = QCoreApplication::applicationDirPath().toLocal8Bit();
+    setenv("GRE_HOME", binaryPath.constData(), 1);
+
     // TODO : Remove this and set custom user agent always
     // Don't set custom user agent string when arguments contains -developerMode, give url as last argument
     if (!app->arguments().contains("-developerMode")) {


### PR DESCRIPTION
Both PWD and GRE_HOME were not set to env when launching from
application grid through invoker. So, let's set GRE_HOME
over here.

Due to above XRE_GetEmbedLite() (Gecko embedlite) function was not
found when launching through invoker.
