### PR TITLE
[sailfish-browser] Fix broken initial tab order

### DIFF
--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -132,7 +132,7 @@ private:
     void removeTab(int tabId, const QString &thumbnail, int index = -1);
     int findTabIndex(int tabId) const;
     void saveTabOrder();
-    int loadTabOrder();
+    void loadTabOrder();
     void updateActiveTab(const Tab &activeTab);
     void updateTabUrl(int tabId, bool activeTab, const QString &url, bool navigate);
 

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -527,7 +527,7 @@ void DeclarativeWebContainer::screenCaptureReady()
 {
     ScreenCapture capture = m_screenCapturer.result();
 #ifdef DEBUG_LOGS
-    qDebug() << capture.tabId << capture.path << capture.url;
+    qDebug() << capture.tabId << capture.path << capture.url << isActiveTab(capture.tabId);
 #endif
     if (capture.tabId != -1) {
         // Update immediately without dbworker round trip.
@@ -554,10 +554,13 @@ void DeclarativeWebContainer::triggerLoad()
 
 void DeclarativeWebContainer::onModelLoaded()
 {
-    // Load placeholder when no pages exist. If a page exists,
-    // it gets initialized by onActiveTabChanged.
-    if (!webPage()) {
+    // This signal handler is responsible for activating
+    // the first page.
+    if (m_model->hasNewTabData() || m_model->count() == 0) {
         activatePage(m_model->nextTabId(), true);
+    } else {
+        const Tab &tab = m_model->activeTab();
+        activatePage(tab.tabId(), true);
     }
 }
 


### PR DESCRIPTION
Fix commit fixes the issue caused by commit cff5aa5683b

Wrong tab was loaded when browser was restarted. This also caused that tabIds were not correct as the first wrong tab got accidentally next available tab id.
