### PR TITLE
[sailfish-browser] Use invoker when launching through D-Bus

### DIFF
--- a/org.sailfishos.browser.service
+++ b/org.sailfishos.browser.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser
-Exec=/usr/bin/sailfish-browser
+Exec=/usr/bin/invoker --type=qt5 -G /usr/bin/sailfish-browser


### PR DESCRIPTION
Matches the command from the .desktop file.
