### PR TITLE
[sailfish-browser] Add loadNewTab that loads immediately

### DIFF
--- a/src/declarativetabmodel.cpp
+++ b/src/declarativetabmodel.cpp
@@ -177,9 +177,10 @@ void DeclarativeTabModel::closeActiveTab()
     }
 }
 
-void DeclarativeTabModel::newTab(const QString &url, const QString &title, int parentId)
+void DeclarativeTabModel::newTab(const QString &url, const QString &title)
 {
-    emit newTabRequested(url, title, parentId);
+    // TODO: This doesn't really fit in here. We should consider adding of custom event for new tab creation.
+    emit newTabRequested(url, title);
 }
 
 void DeclarativeTabModel::newTabData(const QString &url, const QString &title, QObject *contentItem, int parentId)
@@ -376,7 +377,7 @@ void DeclarativeTabModel::updateUrl(int tabId, bool activeTab, QString url)
     if (m_backForwardNavigation && activeTab)
     {
         updateTabUrl(tabId, activeTab, url, false);
-    } else if (!hasNewTabData() && activeTab) {
+    } else if (!hasNewTabData()) {
         updateTabUrl(tabId, activeTab, url, true);
     } else {
         addTab(url, newTabTitle());

--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -49,7 +49,8 @@ public:
     Q_INVOKABLE bool activateTab(int index);
     Q_INVOKABLE void closeActiveTab();
 
-    Q_INVOKABLE void newTab(const QString &url, const QString &title, int parentId = 0);
+    Q_INVOKABLE void newTab(const QString &url, const QString &title);
+    // This should be only for C++ side. But there is one depending move to QML side (see WebView::load())
     Q_INVOKABLE void newTabData(const QString &url, const QString &title, QObject *contentItem = 0, int parentId = 0);
     Q_INVOKABLE void resetNewTabData();
 
@@ -107,7 +108,7 @@ signals:
     void browsingChanged();
     void hasNewTabDataChanged();
     void newTabUrlChanged();
-    void newTabRequested(QString url, QString title, int parentId);
+    void newTabRequested(QString url, QString title);
     void updateActiveThumbnail();
 
 private slots:

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -106,6 +106,7 @@ public:
     Q_INVOKABLE void goForward();
     Q_INVOKABLE void goBack();
     Q_INVOKABLE bool activatePage(int tabId, bool force = false);
+    Q_INVOKABLE void loadNewTab(QString url, QString title, int parentId);
 
     Q_INVOKABLE void captureScreen();
     Q_INVOKABLE void dumpPages() const;
@@ -157,7 +158,7 @@ private slots:
     void onActiveTabChanged(int oldTabId, int activeTabId);
     void onModelLoaded();
     void onDownloadStarted();
-    void onNewTabRequested(QString url, QString title, int parentId);
+    void onNewTabRequested(QString url, QString title);
     void onReadyToLoad();
     void manageMaxTabCount();
     void releasePage(int tabId, bool virtualize = false);

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -109,7 +109,8 @@ WebContainer {
 
     WebViewCreator {
         activeWebView: contentItem
-        onNewWindowRequested: tabModel.newTab(url, "", parentId)
+        // onNewWindowRequested is always handled as synchronous operation (not through newTab).
+        onNewWindowRequested: webView.loadNewTab(url, "", parentId)
     }
 
     Rectangle {

--- a/tests/manual/testwindowopen.html
+++ b/tests/manual/testwindowopen.html
@@ -25,7 +25,7 @@
     </div>
 
     <div id="div" style="width:400px;height:150px">
-      <a href="javascript:void(0)" onclick="window.close()"><h1>Close this window</h1></a>
+      <a href="javascript:void(0)" onclick="window.close()"><h1>Try to close this window, root window cannot close itself</h1></a>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This method is only used when a new window is requested from
the web page.
