### PR TITLE
Fix installation path of manual navigation pages

### DIFF
--- a/tests/manual/manual.pro
+++ b/tests/manual/manual.pro
@@ -5,15 +5,17 @@ testdata.files = *.txt \
                  *.sh \
                  *.html \
                  *.css \
-                 navigation/*.html \
                  icon-launcher-testbrowser.png
 testdata.path = /opt/tests/sailfish-browser/manual/
+
+testnavigationdata.files = navigation/*.html
+testnavigationdata.path = /opt/tests/sailfish-browser/manual/navigation/
 
 # .desktop file used for functional testing
 testdesktop.files = test-sailfish-browser.desktop
 testdesktop.path = /usr/share/applications
 
-INSTALLS += testdata testdesktop
+INSTALLS += testdata testnavigationdata testdesktop
 
 OTHER_FILES += \
     *.html \


### PR DESCRIPTION
Manual test pages under navigation directory where previously installed to a wrong directory (manual/) while manual/navigation/ should be the directory for these.
