### PR TITLE
[sailfish-browser] Fix page loading on the TabPage

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -301,7 +301,7 @@ WebContainer {
             // TextSelectionController {}
             states: State {
                 name: "boundHeightControl"
-                when: container.inputPanelVisible || !container.foreground || !visible
+                when: container.inputPanelVisible || !container.foreground
                 PropertyChanges {
                     target: webPage
                     height: container.parent.height


### PR DESCRIPTION
In case active tab is closed from the TabPage and you have
multiple tabs, the next available tab is activated and loaded.
In above case, we need to be able to resetHeight for the page.

Normally, height is reset when loading starts and
when loading ends. When container is invisible
we should not go to the "boundHeightControl" state as it
blocks resetHeight.
