### PR TITLE
[sailfish-browser] Resuspend background view after page auto-refresh

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -219,6 +219,12 @@ WebContainer {
                         resurrectedContentRect = null
                     }
                 }
+
+                // Refresh timers (if any) keep working even for suspended views. Hence
+                // suspend the view again explicitly if app window is in background.
+                if (loaded && webView.background) {
+                    suspendView();
+                }
             }
 
             onLoadingChanged: {


### PR DESCRIPTION
Refresh timer created for meta-tags with http-equiv="refresh" keep working for inactive tabs too and are not supposed to be disabled. The problem is that triggered refresh timers run nsDocShell::LoadURI() method which activate a tab and then never deactivate it despite the fact that nsDocShell::mIsActive still keeps false value.

I guess it'd be safer for us to suspend reloaded tabs explicitly in UI-code.
