### PR TITLE
[sailfish-browser] Do not load home page when first usage is not done

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -365,7 +365,7 @@ void DeclarativeWebContainer::loadNewTab(QString url, QString title, int parentI
 
 void DeclarativeWebContainer::captureScreen()
 {
-    if (!m_webPage) {
+    if (!m_webPage || !isVisible()) {
         return;
     }
 
@@ -562,9 +562,10 @@ void DeclarativeWebContainer::onModelLoaded()
 {
     // This signal handler is responsible for activating
     // the first page.
-    if (m_model->hasNewTabData() || m_model->count() == 0) {
+    bool firstUseDone = DeclarativeWebUtils::instance()->firstUseDone();
+    if (m_model->hasNewTabData() || (m_model->count() == 0 && firstUseDone)) {
         activatePage(m_model->nextTabId(), true);
-    } else {
+    } else if (m_model->count() > 0) {
         const Tab &tab = m_model->activeTab();
         activatePage(tab.tabId(), true);
     }

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -137,7 +137,7 @@ Page {
         Browser.StatusBar {
             width: parent.width
             height: visible ? toolBarContainer.height * 3 : 0
-            visible: isPortrait
+            visible: isPortrait && !firstUseOverlay
             opacity: progressBar.opacity
             title: webView.title
             url: webView.url
@@ -153,6 +153,7 @@ Page {
             Browser.ProgressBar {
                 id: progressBar
                 anchors.fill: parent
+                visible: !firstUseOverlay
                 opacity: webView.loading ? 1.0 : 0.0
                 progress: webView.loadProgress / 100.0
             }
@@ -220,6 +221,10 @@ Page {
                     id: tabPageButton
                     source: "image://theme/icon-m-tabs"
                     onClicked: {
+                        if (firstUseOverlay) {
+                            firstUseOverlay.visible = false
+                            firstUseOverlay.destroy()
+                        }
                         if (!WebUtils.firstUseDone) WebUtils.firstUseDone = true
                         controlArea.openTabPage(false, false, PageStackAction.Animated)
                     }
@@ -295,11 +300,6 @@ Page {
             }
             if (browserPage.status !== PageStatus.Active) {
                 pageStack.pop(browserPage, PageStackAction.Immediate)
-            }
-        }
-        onFirstUseDoneChanged: {
-            if (WebUtils.firstUseDone && firstUseOverlay) {
-                firstUseOverlay.destroy()
             }
         }
     }

--- a/tests/auto/common/declarativewebutils.cpp
+++ b/tests/auto/common/declarativewebutils.cpp
@@ -16,6 +16,7 @@ static DeclarativeWebUtils *gSingleton = 0;
 DeclarativeWebUtils::DeclarativeWebUtils(QObject *parent)
     : QObject(parent)
     , m_homePage("file:///opt/tests/sailfish-browser/manual/testpage.html")
+    , m_firstUseDone(true)
 {
 }
 
@@ -32,6 +33,16 @@ QString DeclarativeWebUtils::displayableUrl(QString fullUrl) const
 QString DeclarativeWebUtils::homePage() const
 {
     return m_homePage;
+}
+
+bool DeclarativeWebUtils::firstUseDone() const
+{
+    return m_firstUseDone;
+}
+
+void DeclarativeWebUtils::setFirstUseDone(bool firstUseDone)
+{
+    m_firstUseDone = firstUseDone;
 }
 
 DeclarativeWebUtils *DeclarativeWebUtils::instance()

--- a/tests/auto/common/declarativewebutils.h
+++ b/tests/auto/common/declarativewebutils.h
@@ -31,12 +31,15 @@ public:
     static DeclarativeWebUtils *instance();
 
     QString homePage() const;
+    bool firstUseDone() const;
+    void setFirstUseDone(bool firstUseDone);
 
 signals:
     void homePageChanged();
 
 private:
     QString m_homePage;
+    bool m_firstUseDone;
 };
 
 QML_DECLARE_TYPE(DeclarativeWebUtils)


### PR DESCRIPTION
Key changes:
- Hide first usage overlay immediately when tabs icon is clicked
- Do not allow screen capturing when web container is invisible (first usage not done)
- Hide status bar when first usage not done
  - clear first time usage
  - xdg-open link A
  - close browser
  - start browser from application grid
  - Link A is loaded but is invisible
