### PR TITLE
Reset currentIndex of HistoryList to -1 when focused

### DIFF
--- a/src/pages/TabPage.qml
+++ b/src/pages/TabPage.qml
@@ -342,6 +342,7 @@ Page {
                             forceActiveFocus()
                             selectAll()
                             _updateFlickables()
+                            historyList.currentIndex = -1
                         }
 
                         width: parent.width


### PR DESCRIPTION
Fixes issue where backspace hides keyboard
of history items increases.
1) Visit www.sailfishos.org
2) Search "sd" (assuming that you don't have "sd" sites in history)
3) Press backspace once to remove "d"

This regression was introduced within yesterdays TabPage fixes.
