### PR TITLE
[sailfish-browser] Move SettingManager to ownership of DeclarativeWebContainer

### DIFF
--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -12,6 +12,7 @@
 #ifndef DECLARATIVEWEBCONTAINER_H
 #define DECLARATIVEWEBCONTAINER_H
 
+#include "settingmanager.h"
 #include "tab.h"
 #include "webpages.h"
 
@@ -195,6 +196,7 @@ private:
     QPointer<DeclarativeTabModel> m_model;
     QPointer<QQmlComponent> m_webPageComponent;
     QScopedPointer<WebPages> m_webPages;
+    QScopedPointer<SettingManager> m_settingManager;
     bool m_foreground;
     bool m_background;
     bool m_windowVisible;

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -28,7 +28,6 @@
 #include "declarativewebutils.h"
 #include "browserservice.h"
 #include "downloadmanager.h"
-#include "settingmanager.h"
 #include "closeeventfilter.h"
 #include "declarativetabmodel.h"
 #include "declarativehistorymodel.h"
@@ -137,10 +136,6 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     view->installEventFilter(clsEventFilter);
     QObject::connect(service, SIGNAL(openUrlRequested(QString)),
                      clsEventFilter, SLOT(cancelStopApplication()));
-
-    SettingManager * settingMgr = new SettingManager(app.data());
-    QObject::connect(QMozContext::GetInstance(), SIGNAL(onInitialized()),
-                     settingMgr, SLOT(initialize()));
 
 #ifdef USE_RESOURCES
     view->setSource(QUrl("qrc:///browser.qml"));

--- a/src/settingmanager.cpp
+++ b/src/settingmanager.cpp
@@ -9,16 +9,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <QVariant>
-#include "qmozcontext.h"
 #include "settingmanager.h"
 #include "dbmanager.h"
+
+#include <qmozcontext.h>
+#include <QVariant>
 
 SettingManager::SettingManager(QObject *parent)
     : QObject(parent)
 {
     m_clearPrivateDataConfItem = new MGConfItem("/apps/sailfish-browser/actions/clear_private_data", this);
     m_searchEngineConfItem = new MGConfItem("/apps/sailfish-browser/settings/search_engine", this);
+}
+
+bool SettingManager::clearPrivateDataRequested() const
+{
+    return m_clearPrivateDataConfItem->value(QVariant(false)).toBool();
 }
 
 void SettingManager::initialize()
@@ -34,9 +40,7 @@ void SettingManager::initialize()
 
 void SettingManager::clearPrivateData()
 {
-    bool actionNeeded = m_clearPrivateDataConfItem->value(QVariant(false)).toBool();
-
-    if (actionNeeded) {
+    if (clearPrivateDataRequested()) {
         QMozContext::GetInstance()->sendObserve(QString("clear-private-data"), QString("passwords"));
         QMozContext::GetInstance()->sendObserve(QString("clear-private-data"), QString("cookies"));
         QMozContext::GetInstance()->sendObserve(QString("clear-private-data"), QString("cache"));

--- a/src/settingmanager.h
+++ b/src/settingmanager.h
@@ -21,7 +21,7 @@ class SettingManager : public QObject
 public:
     explicit SettingManager(QObject *parent = 0);
 
-public slots:
+    bool clearPrivateDataRequested() const;
     void initialize();
 
 private slots:

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -4,6 +4,8 @@ include(../common/testobject.pri)
 
 CONFIG += link_pkgconfig
 
+PKGCONFIG += mlite5
+
 # WebContainer need this
 isEmpty(QTEMBED_LIB) {
   PKGCONFIG += qt5embedwidget
@@ -15,11 +17,13 @@ SOURCES += tst_webview.cpp \
     ../../../src/declarativewebcontainer.cpp \
     ../../../src/declarativewebpage.cpp \
     ../../../src/declarativewebviewcreator.cpp \
+    ../../../src/settingmanager.cpp \
     ../../../src/webpages.cpp
 
 HEADERS += ../../../src/declarativewebcontainer.h \
     ../../../src/declarativewebpage.h \
     ../../../src/declarativewebviewcreator.h \
+    ../../../src/settingmanager.h \
     ../../../src/webpages.h
 
 OTHER_FILES = *.qml


### PR DESCRIPTION
In case there is some initialization steps that requires that the first
web page is created, we can use DeclarativeWebContainer::setReadyToLoad
for handling those.

Initially added BrowserReady event that was send when we were ready to load. As status of the clear private data was needed before setting manager was initialized, decided to move the setting manager to the ownership of the DeclarativeWebContainer. In future, we can add an event like BrowserReady that would be send once from setReadyToLoad to let other components to do their initialization steps knowing that gecko is ready.
