### PR TITLE
[sailfish-browser] Do not allow delete before page initialized

### DIFF
--- a/src/declarativewebpage.cpp
+++ b/src/declarativewebpage.cpp
@@ -85,6 +85,11 @@ void DeclarativeWebPage::setBackForwardNavigation(bool backForwardNavigation)
     m_backForwardNavigation = backForwardNavigation;
 }
 
+bool DeclarativeWebPage::viewReady() const
+{
+    return m_viewReady;
+}
+
 QVariant DeclarativeWebPage::resurrectedContentRect() const
 {
     return m_resurrectedContentRect;

--- a/src/declarativewebpage.h
+++ b/src/declarativewebpage.h
@@ -51,6 +51,8 @@ public:
     bool backForwardNavigation() const;
     void setBackForwardNavigation(bool backForwardNavigation);
 
+    bool viewReady() const;
+
     Q_INVOKABLE void loadTab(QString newUrl, bool force);
 
 signals:

--- a/src/webpages.h
+++ b/src/webpages.h
@@ -55,6 +55,7 @@ private:
 
         DeclarativeWebPage *webPage;
         QRectF *cssContentRect;
+        bool allowPageDelete;
     };
 
     void updateActivePage(WebPageEntry *webPageEntry, bool resurrect);


### PR DESCRIPTION
Don't allow delete to be called if the page is not yet initialized. In case, it is not initialized wait that view is ready and destroy then.

In case of clear we can delete immediately as load will not get triggered.
