### PR TITLE
[sailfish-browser] Reset page height always when a page is activated

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -359,6 +359,8 @@ bool DeclarativeWebContainer::activatePage(int tabId, bool force)
         WebPageActivationData activationData = m_webPages->page(tabId, m_model->newTabParentId());
         setWebPage(activationData.webPage);
         m_webPage->setChrome(true);
+        // Reset always height so that orentation change is taken into account.
+        resetHeight();
         setLoadProgress(m_webPage->loadProgress());
 
         connect(m_webPage, SIGNAL(imeNotification(int,bool,int,int,QString)),


### PR DESCRIPTION
This is the most lightweight approach (that I can think of) to update height for each inactivate page when orientation has changed. This way there is no need to update height immediately for each page when device rotated.
