### PR TITLE
[sailfish-browser] Add do not track option for browser settings

### DIFF
--- a/settings/Privacy.qml
+++ b/settings/Privacy.qml
@@ -38,7 +38,20 @@ Page {
                 title: qsTrId("settings_browser-ph-privacy")
             }
 
-            // Add do not track switch here.
+            TextSwitch {
+                id: doNotTrack
+
+                checked: doNotTrackConfig.value
+
+                //: Tell sites that I do not want to be tracked.
+                //% "Do not track"
+                text: qsTrId("settings_browser-la-tracking")
+                //: Tell sites that I do not want to be tracked.
+                //% "Tell sites that I do not want to be tracked"
+                description: qsTrId("settings_browser-la-tracking_description")
+
+                onCheckedChanged: doNotTrackConfig.value = checked
+            }
 
             SectionHeader {
                 //: Clear private data section header
@@ -117,6 +130,13 @@ Page {
                 }
             }
         }
+    }
+
+    ConfigurationValue {
+        id: doNotTrackConfig
+
+        key: "/apps/sailfish-browser/settings/do_not_track"
+        defaultValue: false
     }
 
     ConfigurationValue {

--- a/src/settingmanager.cpp
+++ b/src/settingmanager.cpp
@@ -12,6 +12,7 @@
 #include "settingmanager.h"
 #include "dbmanager.h"
 
+#include <MGConfItem>
 #include <qmozcontext.h>
 #include <QVariant>
 
@@ -24,6 +25,7 @@ SettingManager::SettingManager(QObject *parent)
     m_clearPasswordsConfItem = new MGConfItem("/apps/sailfish-browser/actions/clear_passwords", this);
     m_clearCacheConfItem = new MGConfItem("/apps/sailfish-browser/actions/clear_cache", this);
     m_searchEngineConfItem = new MGConfItem("/apps/sailfish-browser/settings/search_engine", this);
+    m_doNotTrackConfItem = new MGConfItem("/apps/sailfish-browser/settings/do_not_track", this);
 }
 
 bool SettingManager::clearHistoryRequested() const
@@ -41,6 +43,7 @@ void SettingManager::initialize()
         clearCache();
     }
     setSearchEngine();
+    doNotTrack();
 
     connect(m_clearPrivateDataConfItem, SIGNAL(valueChanged()),
             this, SLOT(clearPrivateData()));
@@ -54,6 +57,8 @@ void SettingManager::initialize()
             this, SLOT(clearCache()));
     connect(m_searchEngineConfItem, SIGNAL(valueChanged()),
             this, SLOT(setSearchEngine()));
+    connect(m_doNotTrackConfItem, SIGNAL(valueChanged()),
+            this, SLOT(doNotTrack()));
 }
 
 bool SettingManager::clearPrivateData()
@@ -109,4 +114,10 @@ void SettingManager::setSearchEngine()
 {
     QVariant searchEngine = m_searchEngineConfItem->value(QVariant(QString("Google")));
     QMozContext::GetInstance()->setPref(QString("browser.search.defaultenginename"), searchEngine);
+}
+
+void SettingManager::doNotTrack()
+{
+    QMozContext::GetInstance()->setPref(QString("privacy.donottrackheader.enabled"),
+                                        m_doNotTrackConfItem->value(false));
 }

--- a/src/settingmanager.h
+++ b/src/settingmanager.h
@@ -12,7 +12,9 @@
 #ifndef SETTINGMANAGER_H
 #define SETTINGMANAGER_H
 
-#include <MGConfItem>
+#include <QObject>
+
+class MGConfItem;
 
 class SettingManager : public QObject
 {
@@ -31,6 +33,7 @@ private slots:
     void clearPasswords();
     void clearCache();
     void setSearchEngine();
+    void doNotTrack();
 
 private:
     MGConfItem *m_clearPrivateDataConfItem;
@@ -39,6 +42,7 @@ private:
     MGConfItem *m_clearPasswordsConfItem;
     MGConfItem *m_clearCacheConfItem;
     MGConfItem *m_searchEngineConfItem;
+    MGConfItem *m_doNotTrackConfItem;
 };
 
 #endif


### PR DESCRIPTION
Requires: https://github.com/sailfishos/sailfish-browser/pull/110

Above means that browser main settings page is fixed in PR 110.
