### PR TITLE
[sailfish-browser] Rebase text selection feature to latest master

### DIFF
--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -20,6 +20,7 @@
 #include <QPointer>
 #include <QImage>
 #include <QFutureWatcher>
+#include <QColor>
 
 class QTimerEvent;
 class DeclarativeTabModel;
@@ -43,6 +44,7 @@ class DeclarativeWebContainer : public QQuickItem {
     Q_PROPERTY(qreal inputPanelOpenHeight MEMBER m_inputPanelOpenHeight NOTIFY inputPanelOpenHeightChanged FINAL)
     Q_PROPERTY(qreal toolbarHeight MEMBER m_toolbarHeight NOTIFY toolbarHeightChanged FINAL)
     Q_PROPERTY(bool background READ background NOTIFY backgroundChanged FINAL)
+    Q_PROPERTY(QColor decoratorColor MEMBER m_decoratorColor NOTIFY decoratorColorChanged FINAL)
 
     Q_PROPERTY(QString favicon MEMBER m_favicon NOTIFY faviconChanged)
 
@@ -130,6 +132,7 @@ signals:
     void inputPanelHeightChanged();
     void inputPanelOpenHeightChanged();
     void toolbarHeightChanged();
+    void decoratorColorChanged();
 
     void faviconChanged();
     void loadingChanged();
@@ -214,6 +217,7 @@ private:
     qreal m_inputPanelHeight;
     qreal m_inputPanelOpenHeight;
     qreal m_toolbarHeight;
+    QColor m_decoratorColor;
 
     QString m_favicon;
     QString m_thumbnailPath;

--- a/src/pages/components/TextSelectionController.qml
+++ b/src/pages/components/TextSelectionController.qml
@@ -9,32 +9,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import QtQuick 2.0
+import QtQuick 2.1
 import Sailfish.Silica 1.0
 
 Item {
 
     property bool selectionVisible: false
+    property color color
 
-    property Item _webContent: parent
-    property variant _engine: _webContent.child
+    property Item _webPage: parent
     // keep selection range we get from engine to move the draggers with
     // selection together when panning or zooming
     property variant _cssRange
 
     anchors.fill: parent
 
-    function onViewAreaChanged() {
-        var newOffset = _engine.scrollableOffset
-        var resolution = _engine.resolution
+    function onScrollableOffsetChanged() {
+        var newOffset = _webPage.scrollableOffset
+        var resolution = _webPage.resolution
+        var zoom = resolution / _cssRange.origResolution
 
-        var diffX = newOffset.x - _cssRange.origOffsetX
-        var diffY = newOffset.y - _cssRange.origOffsetY
+        var diffX = newOffset.x - _cssRange.origOffsetX * zoom
+        var diffY = newOffset.y - _cssRange.origOffsetY * zoom
 
-        start.x = (_cssRange.startX - diffX) * resolution - start.width
-        start.y = (_cssRange.startY - diffY) * resolution
-        end.x = (_cssRange.endX - diffX) * resolution
-        end.y = (_cssRange.endY - diffY) * resolution
+        start.x = _cssRange.startX * resolution - diffX - start.width
+        start.y = (_cssRange.startY - _cssRange.startHeightShift) * resolution - diffY
+        end.x = _cssRange.endX * resolution - diffX
+        end.y = (_cssRange.endY - _cssRange.endHeightShift) * resolution - diffY
 
         timer.restart()
     }
@@ -44,20 +45,25 @@ Item {
             return
         }
 
-        var resolution = _engine.resolution
+        var resolution = _webPage.resolution
+        var startHeightShift = data.start.height / 2
+        var endHeightShift = data.end.height / 2
 
         start.x = (data.start.xPos * resolution) - start.width
-        start.y = data.start.yPos * resolution
+        start.y = (data.start.yPos - startHeightShift) * resolution
         end.x = data.end.xPos * resolution
-        end.y = data.end.yPos * resolution
+        end.y = (data.end.yPos - endHeightShift) * resolution
 
         _cssRange = {
             "startX": data.start.xPos,
             "startY": data.start.yPos,
             "endX": data.end.xPos,
             "endY": data.end.yPos,
-            "origOffsetX": _engine.scrollableOffset.x,
-            "origOffsetY": _engine.scrollableOffset.y,
+            "startHeightShift": startHeightShift,
+            "endHeightShift": endHeightShift,
+            "origOffsetX": _webPage.scrollableOffset.x,
+            "origOffsetY": _webPage.scrollableOffset.y,
+            "origResolution": resolution
         }
 
         selectionVisible = true
@@ -66,47 +72,50 @@ Item {
     function onSelectionCopied(data) {
         selectionVisible = false
         _cssRange = null
-        _engine.sendAsyncMessage("Browser:SelectionClose",
+        _webPage.sendAsyncMessage("Browser:SelectionClose",
                                  {
                                      "clearSelection": true
                                  })
     }
 
     function onContextMenuRequested(data) {
-        if (data.types.indexOf("content-text") !== -1) {
+        if (data.types.indexOf("content-text") !== -1 ||
+            (data.types.indexOf("input-text") !== -1 && data.string)) {
             // we want to select some content text
-            _engine.sendAsyncMessage("Browser:SelectionStart", {"xPos": data.xPos, "yPos": data.yPos})
+            _webPage.sendAsyncMessage("Browser:SelectionStart", {"xPos": data.xPos, "yPos": data.yPos})
         }
     }
 
     onSelectionVisibleChanged: {
         if (selectionVisible) {
-            _engine.viewAreaChanged.connect(onViewAreaChanged)
+            _webPage.scrollableOffsetChanged.connect(onScrollableOffsetChanged)
         } else {
-            _engine.viewAreaChanged.disconnect(onViewAreaChanged)
+            _webPage.scrollableOffsetChanged.disconnect(onScrollableOffsetChanged)
         }
     }
 
     TextSelectionHandle {
         id: start
 
+        color: parent.color
         type: "start"
-        content: _webContent
+        content: _webPage
         visible: selectionVisible
     }
 
     TextSelectionHandle {
         id: end
 
+        color: parent.color
         type: "end"
-        content: _webContent
+        content: _webPage
         visible: selectionVisible
     }
 
     Component.onCompleted: {
-        _webContent.selectionRangeUpdated.connect(onSelectionRangeUpdated)
-        _webContent.selectionCopied.connect(onSelectionCopied)
-        _webContent.contextMenuRequested.connect(onContextMenuRequested)
+        _webPage.selectionRangeUpdated.connect(onSelectionRangeUpdated)
+        _webPage.selectionCopied.connect(onSelectionCopied)
+        _webPage.contextMenuRequested.connect(onContextMenuRequested)
     }
 
     Timer {
@@ -116,7 +125,7 @@ Item {
 
         onTriggered: {
             if (selectionVisible) {
-                _engine.sendAsyncMessage("Browser:SelectionUpdate", {})
+                _webPage.sendAsyncMessage("Browser:SelectionUpdate", {})
             }
         }
     }

--- a/src/pages/components/TextSelectionController.qml
+++ b/src/pages/components/TextSelectionController.qml
@@ -78,14 +78,6 @@ Item {
                                  })
     }
 
-    function onContextMenuRequested(data) {
-        if (data.types.indexOf("content-text") !== -1 ||
-            (data.types.indexOf("input-text") !== -1 && data.string)) {
-            // we want to select some content text
-            _webPage.sendAsyncMessage("Browser:SelectionStart", {"xPos": data.xPos, "yPos": data.yPos})
-        }
-    }
-
     onSelectionVisibleChanged: {
         if (selectionVisible) {
             _webPage.scrollableOffsetChanged.connect(onScrollableOffsetChanged)
@@ -115,7 +107,6 @@ Item {
     Component.onCompleted: {
         _webPage.selectionRangeUpdated.connect(onSelectionRangeUpdated)
         _webPage.selectionCopied.connect(onSelectionCopied)
-        _webPage.contextMenuRequested.connect(onContextMenuRequested)
     }
 
     Timer {

--- a/src/pages/components/TextSelectionHandle.qml
+++ b/src/pages/components/TextSelectionHandle.qml
@@ -27,6 +27,8 @@ Item {
     property bool moving
     property bool dragActive: mouseArea.drag.active
 
+    property int xAnimationLength: Theme.itemSizeExtraLarge
+
     function getJson() {
         var resolution = content.child.resolution
         var json = {
@@ -46,6 +48,12 @@ Item {
         } else {
             content.child.sendAsyncMessage("Browser:SelectionMoveEnd", handle.getJson())
             moving = false
+        }
+    }
+
+    onVisibleChanged: {
+        if (visible) {
+            showAnimationId.restart()
         }
     }
 
@@ -109,5 +117,22 @@ Item {
         id: timer
 
         interval: 200
+    }
+
+    ParallelAnimation {
+        id: showAnimationId
+        FadeAnimation {
+            target: handle
+            from: 0
+            to: 1
+        }
+        NumberAnimation {
+            target: handle
+            property: "x"
+            from: handle.type === "start" ? handle.x - xAnimationLength : handle.x + xAnimationLength
+            to: handle.x
+            duration: 200
+            easing.type: Easing.InOutQuad
+        }
     }
 }

--- a/src/pages/components/TextSelectionHandle.qml
+++ b/src/pages/components/TextSelectionHandle.qml
@@ -76,8 +76,8 @@ Item {
         Rectangle {
             color: Theme.primaryColor
             width: {
-                var wdth = parent.width - (Theme.paddingSmall * 2)
-                return width > 0 ? width : Theme.paddingSmall
+                var _width = parent.width - (Theme.paddingSmall * 2)
+                return _width > 0 ? _width : Theme.paddingSmall
             }
             height: width
             radius: width / 2

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -136,6 +136,7 @@ WebContainer {
 
             property int iconSize
             property string iconType
+            property Item textSelectionController: null
 
             loaded: loadProgress === 100 && !loading
             enabled: container.active
@@ -328,11 +329,15 @@ WebContainer {
                     break
                 }
                 case "Content:SelectionRange": {
+                    if (textSelectionController === null) {
+                        textSelectionController = textSelectionControllerComponent.createObject(webPage)
+                    }
                     webPage.selectionRangeUpdated(data)
                     break
                 }
                 }
             }
+
             onRecvSyncMessage: {
                 // sender expects that this handler will update `response` argument
                 switch (message) {
@@ -348,7 +353,13 @@ WebContainer {
                 }
             }
 
-            TextSelectionController { color: decoratorColor }
+            onContextMenuRequested: {
+                if (data.types.indexOf("content-text") !== -1 ||
+                     (data.types.indexOf("input-text") !== -1 && data.string)) {
+                   // we want to select some content text
+                   webPage.sendAsyncMessage("Browser:SelectionStart", {"xPos": data.xPos, "yPos": data.yPos})
+                }
+            }
 
             states: State {
                 name: "boundHeightControl"
@@ -359,6 +370,12 @@ WebContainer {
                 }
             }
         }
+    }
+
+    Component {
+        id: textSelectionControllerComponent
+
+        TextSelectionController { color: decoratorColor }
     }
 
     Rectangle {

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -20,7 +20,6 @@ import "." as Browser
 WebContainer {
     id: webView
 
-    property color _decoratorColor: Theme.highlightDimmerColor
     property bool firstUseFullscreen
 
     function stop() {
@@ -98,6 +97,7 @@ WebContainer {
     inputPanelOpenHeight: window.pageStack.imSize
     fullscreenMode: (contentItem && contentItem.chromeGestureEnabled && !contentItem.chrome) || webView.inputPanelVisible || !webView.foreground || (contentItem && contentItem.fullscreen) || firstUseFullscreen
     _readyToLoad: contentItem && contentItem.viewReady && tabModel.loaded
+    decoratorColor: Theme.highlightDimmerColor
 
     loading: contentItem ? contentItem.loading : false
     favicon: contentItem ? contentItem.favicon : ""
@@ -187,9 +187,9 @@ WebContainer {
                     var highBgLightness = WebUtils.getLightness(Theme.highlightBackgroundColor)
 
                     if (Math.abs(bgLightness - dimmerLightness) > Math.abs(bgLightness - highBgLightness)) {
-                        container._decoratorColor = Theme.highlightDimmerColor
+                        container.decoratorColor = Theme.highlightDimmerColor
                     } else {
-                        container._decoratorColor =  Theme.highlightBackgroundColor
+                        container.decoratorColor =  Theme.highlightBackgroundColor
                     }
 
                     sendAsyncMessage("Browser:SelectionColorUpdate",
@@ -348,9 +348,8 @@ WebContainer {
                 }
             }
 
-            // We decided to disable "text selection" until we understand how it
-            // should look like in Sailfish.
-            // TextSelectionController {}
+            TextSelectionController { color: decoratorColor }
+
             states: State {
                 name: "boundHeightControl"
                 when: container.inputPanelVisible || !container.foreground
@@ -370,7 +369,7 @@ WebContainer {
         y: contentItem ? contentItem.verticalScrollDecorator.position : 0
         z: 1
         anchors.right: contentItem ? contentItem.right: undefined
-        color: _decoratorColor
+        color: decoratorColor
         smooth: true
         radius: 2.5
         visible: contentItem && contentItem.contentHeight > contentItem.height && !contentItem.pinching && !popupActive
@@ -386,7 +385,7 @@ WebContainer {
         x: contentItem ? contentItem.horizontalScrollDecorator.position : 0
         y: webView.height - height
         z: 1
-        color: _decoratorColor
+        color: decoratorColor
         smooth: true
         radius: 2.5
         visible: contentItem && contentItem.contentWidth > contentItem.width && !contentItem.pinching && !popupActive

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -354,8 +354,7 @@ WebContainer {
             }
 
             onContextMenuRequested: {
-                if (data.types.indexOf("content-text") !== -1 ||
-                     (data.types.indexOf("input-text") !== -1 && data.string)) {
+                if (data.types.indexOf("content-text") !== -1) {
                    // we want to select some content text
                    webPage.sendAsyncMessage("Browser:SelectionStart", {"xPos": data.xPos, "yPos": data.yPos})
                 }

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -192,11 +192,6 @@ WebContainer {
                     } else {
                         container.decoratorColor =  Theme.highlightBackgroundColor
                     }
-
-                    sendAsyncMessage("Browser:SelectionColorUpdate",
-                                     {
-                                         "color": Theme.secondaryHighlightColor
-                                     })
                 }
             }
 
@@ -356,6 +351,8 @@ WebContainer {
             onContextMenuRequested: {
                 if (data.types.indexOf("content-text") !== -1) {
                    // we want to select some content text
+
+                   MozContext.setPref("ui.textSelectBackground", Theme.secondaryHighlightColor + "")
                    webPage.sendAsyncMessage("Browser:SelectionStart", {"xPos": data.xPos, "yPos": data.yPos})
                 }
             }


### PR DESCRIPTION
This PR depends on https://github.com/tmeshkova/embedlite-components/pull/53

Comparing to the previous PR (https://github.com/sailfishos/sailfish-browser/pull/78) here
1. selection handles are positioned vertically centred to text lines;
2. the handles are concentric circles;
3. WebContainer got one new member decoratorColor.
