### PR TITLE
[sailfish-browser] Fix loading of external url to the active tab

### DIFF
--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -54,6 +54,7 @@ class DeclarativeWebContainer : public QQuickItem {
 
     Q_PROPERTY(QString title READ title NOTIFY titleChanged FINAL)
     Q_PROPERTY(QString url READ url NOTIFY urlChanged FINAL)
+    Q_PROPERTY(QString initialUrl MEMBER m_initialUrl NOTIFY initialUrlChanged FINAL)
     Q_PROPERTY(QString thumbnailPath READ thumbnailPath NOTIFY thumbnailPathChanged FINAL)
 
     Q_PROPERTY(QQmlComponent* webPageComponent MEMBER m_webPageComponent NOTIFY webPageComponentChanged FINAL)
@@ -137,6 +138,7 @@ signals:
 
     void titleChanged();
     void urlChanged();
+    void initialUrlChanged();
     void thumbnailPathChanged();
 
     void deferredReloadChanged();
@@ -212,6 +214,7 @@ private:
 
     QString m_favicon;
     QString m_thumbnailPath;
+    QString m_initialUrl;
 
     bool m_loading;
     int m_loadProgress;

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -56,7 +56,11 @@ WebContainer {
 
         if (!tabModel.hasNewTabData || force || !webView.activatePage(tabModel.nextTabId)) {
             // First contentItem will be created once tab activated.
-            if (contentItem) contentItem.loadTab(url, force)
+            if (contentItem && contentItem.viewReady) {
+                contentItem.loadTab(url, force)
+            } else {
+                webView.initialUrl = url
+            }
         }
     }
 


### PR DESCRIPTION
When external url is requested so that browser is not running
requested url is loaded once engine is ready to load urls. In this
case requested url is considered as a navigation request so that browser
side tab history gets updated.
