### PR TITLE
[sailfish-browser] Suspend video when app goes to background

### DIFF
--- a/src/pages/components/ResourceController.qml
+++ b/src/pages/components/ResourceController.qml
@@ -71,7 +71,7 @@ Item {
 
     // This is behind 1000ms timer
     onBackgroundChanged: {
-        if (!audioActive && !videoActive && background) {
+        if (((audioActive && videoActive) || !audioActive) && background) {
             suspendView()
         } else {
             resumeView()


### PR DESCRIPTION
The patch fixes the problem when Browser playing html5 video doesn't suspend it when moved to background. Only audio streams are allowed to continue playback when the app is in background.
