### PR TITLE
[sailfish-browser] Make "Add to launcher" less prominent in pulley menu

### DIFF
--- a/src/pages/components/TabPageMenu.qml
+++ b/src/pages/components/TabPageMenu.qml
@@ -35,6 +35,13 @@ Loader {
         }
         MenuItem {
             enabled: shareEnabled
+            //: Add bookmark to launcher menu item. This should be relatively short to fit to the menu.
+            //% "Add to launcher"
+            text: qsTrId("sailfish_browser-me-add_to_launcher")
+            onClicked: tabPageMenuLoader.addToLauncher()
+        }
+        MenuItem {
+            enabled: shareEnabled
             //: Share link from browser pulley menu
             //% "Share"
             text: qsTrId("sailfish_browser-me-share_link")
@@ -44,14 +51,6 @@ Loader {
             //% "New tab"
             text: qsTrId("sailfish_browser-me-new_tab")
             onClicked: pageStack.push(Qt.resolvedUrl("../TabPage.qml"), {"newTab": true, "browserPage": browserPage})
-        }
-
-        MenuItem {
-            enabled: shareEnabled
-            //: Add bookmark to launcher menu item. This should be relatively short to fit to the menu.
-            //% "Add to launcher"
-            text: qsTrId("sailfish_browser-me-add_to_launcher")
-            onClicked: tabPageMenuLoader.addToLauncher()
         }
 
         Component.onCompleted: opacity = 1.0


### PR DESCRIPTION
New order:

4) Close all
3) Add to launcher
2) Share
1) New tab

I forgot this one from the Friday's launcher PR.
