### PR TITLE
[sailfish-browser] Fix incorrect chrome gesture enabled binding

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -145,7 +145,7 @@ WebContainer {
 
             // There needs to be enough content for enabling chrome gesture
             chromeGestureThreshold: container.toolbarHeight / 2
-            chromeGestureEnabled: contentHeight > container.height + container.toolbarHeight
+            chromeGestureEnabled: contentHeight > container.fullscreenHeight + container.toolbarHeight
 
             signal selectionRangeUpdated(variant data)
             signal selectionCopied(variant data)


### PR DESCRIPTION
Now that we are animating toolbar in y-axis and container height
changes, chromeGestureEnabled cannot be bound to container height.
Instead it must be bound to the fullscreenHeight that is following device
orienatation.
