### PR TITLE
[sailfishbrowser] Store home page in a configuration file.

### DIFF
--- a/src/declarativewebutils.cpp
+++ b/src/declarativewebutils.cpp
@@ -29,7 +29,7 @@ static DeclarativeWebUtils *gSingleton = 0;
 
 DeclarativeWebUtils::DeclarativeWebUtils()
     : QObject()
-    , m_homePage("http://www.jolla.com")
+    , m_homePage("/apps/sailfish-browser/settings/home_page", this)
     , m_debugMode(qApp->arguments().contains("-debugMode"))
 {
     connect(QMozContext::GetInstance(), SIGNAL(onInitialized()),
@@ -39,6 +39,8 @@ DeclarativeWebUtils::DeclarativeWebUtils()
 
     QString path = QStandardPaths::writableLocation(QStandardPaths::DataLocation) + QStringLiteral("/.firstUseDone");
     m_firstUseDone = fileExists(path);
+
+    connect(&m_homePage, SIGNAL(valueChanged()), this, SIGNAL(homePageChanged()));
 }
 
 DeclarativeWebUtils::~DeclarativeWebUtils()
@@ -192,7 +194,7 @@ bool DeclarativeWebUtils::firstUseDone() const {
 
 QString DeclarativeWebUtils::homePage() const
 {
-    return m_homePage;
+    return m_homePage.value("http://jolla.com").value<QString>();
 }
 
 DeclarativeWebUtils *DeclarativeWebUtils::instance()

--- a/src/declarativewebutils.h
+++ b/src/declarativewebutils.h
@@ -18,6 +18,7 @@
 #include <QVariant>
 #include "browserservice.h"
 #include <QProcess>
+#include <MGConfItem>
 
 class DeclarativeWebUtils : public QObject
 {
@@ -62,7 +63,7 @@ private:
     explicit DeclarativeWebUtils();
     ~DeclarativeWebUtils();
 
-    QString m_homePage;
+    MGConfItem m_homePage;
     bool m_firstUseDone;
     bool m_debugMode;
 };


### PR DESCRIPTION
So that it can be read by other apps, e.g. simkit needs this.
