### PR TITLE
[sailfish-browser] Run startup cache cleanup on browser installation

### DIFF
--- a/cleanup-browser-startup-cache
+++ b/cleanup-browser-startup-cache
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -rf /home/$USER/.mozilla/mozembed/startupCache

--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -21,6 +21,8 @@ BuildRequires:  pkgconfig(qdeclarative5-boostable)
 BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  gdb
+BuildRequires:  oneshot
+
 Requires: sailfishsilica-qt5 >= 0.11.8
 Requires: jolla-ambient >= 0.3.24
 Requires: xulrunner-qt5 >= 29.0.1.9
@@ -35,6 +37,8 @@ Requires: qt5-qtgraphicaleffects
 Requires: nemo-qml-plugin-contextkit-qt5
 Requires: nemo-qml-plugin-connectivity
 Requires: sailfish-components-media-qt5
+
+%{_oneshot_requires_post}
 
 %description
 Sailfish Web Browser
@@ -91,6 +95,7 @@ rm -rf %{buildroot}
 # >> install pre
 # << install pre
 %qmake5_install
+chmod +x %{buildroot}/%{_oneshotdir}/*
 
 # >> install post
 # << install post
@@ -98,6 +103,11 @@ rm -rf %{buildroot}
 %post
 # >> post
 /usr/bin/update-desktop-database -q
+
+# Upgrade, count is 2 or higher (depending on the number of versions installed)
+if [ "$1" -ge 2 ]; then
+%{_bindir}/add-oneshot --user --now cleanup-browser-startup-cache
+fi
 # << post
 
 %files
@@ -109,6 +119,7 @@ rm -rf %{buildroot}
 %{_datadir}/%{name}/*
 %{_datadir}/translations/sailfish-browser_eng_en.qm
 %{_datadir}/dbus-1/services/*.service
+%{_oneshotdir}/cleanup-browser-startup-cache
 # << files
 
 %files settings

--- a/sailfish-browser.pro
+++ b/sailfish-browser.pro
@@ -14,7 +14,10 @@ chrome_scripts.path = /usr/lib/mozembedlite/chrome/embedlite/content
 content.files = content/*
 content.path = /usr/share/sailfish-browser/content
 
-INSTALLS += desktop dbus_service chrome_scripts content
+oneshots.files = cleanup-browser-startup-cache
+oneshots.path  = /usr/lib/oneshot.d
+
+INSTALLS += desktop dbus_service chrome_scripts content oneshots
 
 OTHER_FILES += \
     rpm/*.spec \


### PR DESCRIPTION
Decided to add this to browser side as we need to add profile support
in future. Then this starts to make sense to be here. Currently
we have only one profile.
