### PR TITLE
[sailfish-browser] Improve non-numeric / numeric search field text handling

### DIFF
--- a/src/pages/TabPage.qml
+++ b/src/pages/TabPage.qml
@@ -385,14 +385,15 @@ Page {
 
                         EnterKey.iconSource: "image://theme/icon-m-enter-accept"
                         EnterKey.onClicked: {
-                            Qt.inputMethod.hide()
                             // let gecko figure out how to handle malformed URLs
-
                             // Non number
-                            if (isNaN(searchField.text)) {
-                                page.load(searchField.text)
-                            } else {
-                                page.load("\"" + searchField.text + "\"")
+                            var searchString = searchField.text
+                            if (isNaN(searchString)) {
+                                Qt.inputMethod.hide()
+                                page.load(searchString)
+                            } else if (searchString.trim()){
+                                Qt.inputMethod.hide()
+                                page.load("\"" + searchString.trim() + "\"")
                             }
                         }
 


### PR DESCRIPTION
Improve non-numeric / numberic search field text handling.

1) Numeric field cannot empty
2) Numeric field is always trimmed from both ends
3) Only accepted field can hide keyboard
