### PR TITLE
[sailfish-browser] Enable special gstreamer plugin usage.

### DIFF
--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -45,6 +45,7 @@
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {
     setenv("USE_ASYNC", "1", 1);
+    setenv("USE_NEMO_GSTREAMER", "1", 1);
 
     // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=929879
     setenv("LC_NUMERIC", "C", 1);


### PR DESCRIPTION
gecko need to know which gstreamer plugin to use.
see https://github.com/tmeshkova/gecko-dev/blob/embedlite/content/media/gstreamer/GStreamerReader.cpp#L70
