### PR TITLE
[sailfish-browser] Pop TabPage before loading an incoming new url.

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -306,13 +306,15 @@ Page {
                 firstUseOverlay.destroy()
                 webView.visible = true
             }
+
+            if (browserPage.status !== PageStatus.Active) {
+                pageStack.pop(browserPage, PageStackAction.Immediate)
+            }
+
             webView.captureScreen()
             if (!webView.tabModel.activateTab(url)) {
                 // Not found in tabs list, create newtab and load
                 webView.load(url)
-            }
-            if (browserPage.status !== PageStatus.Active) {
-                pageStack.pop(browserPage, PageStackAction.Immediate)
             }
         }
     }


### PR DESCRIPTION
Without tabs the new web page remains inactive when an incoming url
is received so that TabPage is active and browser is at background.
