### PR TITLE
Don't cache tab thumbnails

### DIFF
--- a/src/pages/components/TabItem.qml
+++ b/src/pages/components/TabItem.qml
@@ -54,6 +54,7 @@ Loader {
             anchors.fill: parent
             asynchronous: true
             source: thumbnailPath
+            cache: false
             sourceSize.width: Screen.width / 2
             visible: status !== Image.Error && thumbnailPath !== ""
         }


### PR DESCRIPTION
When switching from one tab to another, the thumbnail of the
previous active tab might not get updated to the tab page without this fix.
