### PR TITLE
[sailfish-browser] Don't load tab content from tab page as it can make engine unresponsive

### DIFF
--- a/src/declarativetabmodel.cpp
+++ b/src/declarativetabmodel.cpp
@@ -61,7 +61,7 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title) {
         endInsertRows();
     }
 
-    updateActiveTab(tab);
+    updateActiveTab(tab, true);
     emit countChanged();
     emit tabAdded(tabId);
 
@@ -126,7 +126,7 @@ bool DeclarativeTabModel::activateTab(const QString& url)
     return false;
 }
 
-bool DeclarativeTabModel::activateTab(int index)
+bool DeclarativeTabModel::activateTab(int index, bool loadActiveTab)
 {
     if (index >= 0 && index < m_tabs.count()) {
         Tab newActiveTab = m_tabs.at(index);
@@ -147,7 +147,7 @@ bool DeclarativeTabModel::activateTab(int index)
             endInsertRows();
         }
 
-        updateActiveTab(newActiveTab);
+        updateActiveTab(newActiveTab, loadActiveTab);
         return true;
     }
     return false;
@@ -170,12 +170,12 @@ void DeclarativeTabModel::closeActiveTab()
 #endif
         // Clear active tab data and try to active a tab from the first model index.
         int activeTabId = m_activeTab.tabId();
-        // Invalidate
+        // Invalidate so that it will not back to model.
         m_activeTab.setTabId(0);
         removeTab(activeTabId, m_activeTab.thumbnailPath());
-        if (!activateTab(0)) {
+        if (!activateTab(0, false)) {
             // Last active tab got closed.
-            emit activeTabChanged(activeTabId, 0);
+            emit activeTabChanged(activeTabId, 0, false);
         }
     }
 }
@@ -345,7 +345,7 @@ void DeclarativeTabModel::tabChanged(const Tab &tab)
     qDebug() << "new tab data:" << &tab;
 #endif
     if (m_activeTab.tabId() == tab.tabId()) {
-        updateActiveTab(tab);
+        updateActiveTab(tab, true);
     } else {
         int i = m_tabs.indexOf(tab); // match based on tab_id
         if (i > -1) {
@@ -486,7 +486,7 @@ void DeclarativeTabModel::loadTabOrder()
         }
     }
 }
-void DeclarativeTabModel::updateActiveTab(const Tab &activeTab)
+void DeclarativeTabModel::updateActiveTab(const Tab &activeTab, bool loadActiveTab)
 {
 #ifdef DEBUG_LOGS
     qDebug() << "old active tab: " << &m_activeTab << m_tabs.count();
@@ -495,7 +495,7 @@ void DeclarativeTabModel::updateActiveTab(const Tab &activeTab)
     if (m_activeTab != activeTab) {
         int oldTabId = m_activeTab.tabId();
         m_activeTab = activeTab;
-        emit activeTabChanged(oldTabId, activeTab.tabId());
+        emit activeTabChanged(oldTabId, activeTab.tabId(), loadActiveTab);
         saveTabOrder();
     }
 }

--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -46,7 +46,7 @@ public:
     Q_INVOKABLE void remove(int index);
     Q_INVOKABLE void clear();
     Q_INVOKABLE bool activateTab(const QString &url);
-    Q_INVOKABLE bool activateTab(int index);
+    Q_INVOKABLE bool activateTab(int index, bool loadActiveTab = true);
     Q_INVOKABLE void closeActiveTab();
 
     Q_INVOKABLE void newTab(const QString &url, const QString &title);
@@ -97,7 +97,7 @@ public slots:
 
 signals:
     void countChanged();
-    void activeTabChanged(int oldTabId, int activeTabId);
+    void activeTabChanged(int oldTabId, int activeTabId, bool loadActiveTab = true);
     void tabAdded(int tabId);
     void tabClosed(int tabId);
     void tabsCleared();
@@ -133,7 +133,7 @@ private:
     int findTabIndex(int tabId) const;
     void saveTabOrder();
     void loadTabOrder();
-    void updateActiveTab(const Tab &activeTab);
+    void updateActiveTab(const Tab &activeTab, bool loadActiveTab);
     void updateTabUrl(int tabId, bool activeTab, const QString &url, bool navigate);
 
     void updateNewTabData(NewTabData *newTabData);

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -53,6 +53,7 @@ class DeclarativeWebContainer : public QQuickItem {
     Q_PROPERTY(bool canGoForward READ canGoForward NOTIFY canGoForwardChanged FINAL)
     Q_PROPERTY(bool canGoBack READ canGoBack NOTIFY canGoBackChanged FINAL)
 
+    Q_PROPERTY(int tabId READ tabId NOTIFY tabIdChanged FINAL)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged FINAL)
     Q_PROPERTY(QString url READ url NOTIFY urlChanged FINAL)
     Q_PROPERTY(QString initialUrl MEMBER m_initialUrl NOTIFY initialUrlChanged FINAL)
@@ -97,6 +98,7 @@ public:
     bool canGoBack() const;
     void setCanGoBack(bool canGoBack);
 
+    int tabId() const;
     QString title() const;
     QString url() const;
     QString thumbnailPath() const;
@@ -138,6 +140,7 @@ signals:
     void canGoForwardChanged();
     void canGoBackChanged();
 
+    void tabIdChanged();
     void titleChanged();
     void urlChanged();
     void initialUrlChanged();
@@ -159,7 +162,7 @@ private slots:
     void windowVisibleChanged(bool visible);
     void handleWindowChanged(QQuickWindow *window);
     void screenCaptureReady();
-    void onActiveTabChanged(int oldTabId, int activeTabId);
+    void onActiveTabChanged(int oldTabId, int activeTabId, bool loadActiveTab);
     void onModelLoaded();
     void onDownloadStarted();
     void onNewTabRequested(QString url, QString title);
@@ -218,6 +221,10 @@ private:
     QString m_favicon;
     QString m_thumbnailPath;
     QString m_initialUrl;
+
+    QString m_url;
+    QString m_title;
+    int m_tabId;
 
     bool m_loading;
     int m_loadProgress;

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -186,8 +186,12 @@ Page {
 
                 Browser.IconButton {
                     visible: isLandscape
+                    enabled: webView.tabModel.count > 0
                     icon.source: "image://theme/icon-m-close"
-                    onClicked: webView.tabModel.closeActiveTab()
+                    onClicked: {
+                        webView.tabModel.closeActiveTab()
+                        webView.activatePage(webView.tabId, true)
+                    }
                 }
 
                 // Spacer

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -100,7 +100,7 @@ WebContainer {
     fullscreenMode: (contentItem && contentItem.chromeGestureEnabled && !contentItem.chrome) || webView.inputPanelVisible || !webView.foreground || (contentItem && contentItem.fullscreen) || firstUseFullscreen
     _readyToLoad: contentItem && contentItem.viewReady && tabModel.loaded
 
-    loading: contentItem ? contentItem.loading : false
+    loading: contentItem ? contentItem.loading : tabModel.count > 0
     favicon: contentItem ? contentItem.favicon : ""
 
     webPageComponent: webPageComponent
@@ -111,6 +111,12 @@ WebContainer {
     }
 
     onTriggerLoad: webView.load(url, title)
+
+    onActiveChanged: {
+        if (active && !contentItem && tabModel && !tabModel.hasNewTabData && tabId > 0) {
+            activatePage(tabId, true)
+        }
+    }
 
     onBackgroundChanged: {
         if (background) {

--- a/src/webpages.cpp
+++ b/src/webpages.cpp
@@ -202,7 +202,7 @@ void WebPages::updateActivePage(WebPageEntry *webPageEntry, bool resurrect)
         m_activePage->cssContentRect = new QRectF(activeWebPage->contentRect());
         activeWebPage->setVisible(false);
 
-        // Allow subpending only current active is not creator (parent).
+        // Allow suspending only the current active page if it is not the creator (parent).
         if (webPageEntry->webPage->parentId() != (int)activeWebPage->uniqueID()) {
              if (activeWebPage->loading()) {
                  activeWebPage->stop();


### PR DESCRIPTION
Open more than five tabs (3 top most are kept alive). Close all tabs
one by one from active tab's close button from tab page. After this loading
of a new tab is failing / tabs stop loading at tab page.

Root cause is still a bit of mystery, but I think that this has
something to do with active state of web page (and/or suspend/resume).
Visibility of a web page is hidden at tab page but it should not make
a difference. What happens is that I cannot see any traces after
EmbedLiteApp::CreateView. To be more precise looks like SendCreateView
that is send through EmbedLiteAppThreadParent of EmbedLiteApp (from CreateView)
don't reach EmbedLiteAppThreadChild's RecvCreateView.
