### PR TITLE
[sailfish-browser] Use silica invoker instead of qt5 invoker

### DIFF
--- a/org.sailfishos.browser.service
+++ b/org.sailfishos.browser.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser
-Exec=/usr/bin/invoker --type=qt5 -G /usr/bin/sailfish-browser
+Exec=/usr/bin/invoker -s --type=silica-qt5 -G /usr/bin/sailfish-browser

--- a/sailfish-browser.desktop
+++ b/sailfish-browser.desktop
@@ -4,5 +4,5 @@ Name=Web Browser
 X-MeeGo-Logical-Id=sailfish-browser-ap-name
 X-MeeGo-Translation-Catalog=sailfish-browser
 Icon=icon-launcher-browser
-Exec=invoker --type=qt5 -G /usr/bin/sailfish-browser %U
+Exec=invoker -s --type=silica-qt5 -G /usr/bin/sailfish-browser %U
 Comment=Sailfish UI application

--- a/tests/manual/test-sailfish-browser.desktop
+++ b/tests/manual/test-sailfish-browser.desktop
@@ -2,5 +2,5 @@
 Type=Application
 Name=Test Web Browser
 Icon=/opt/tests/sailfish-browser/manual/icon-launcher-testbrowser.png
-Exec=/usr/bin/invoker --type=qt5 -G /usr/bin/sailfish-browser file:///opt/tests/sailfish-browser/manual/testpage.html
+Exec=/usr/bin/invoker -s --type=silica-qt5 -G /usr/bin/sailfish-browser file:///opt/tests/sailfish-browser/manual/testpage.html
 Comment=Test Sailfish UI application


### PR DESCRIPTION
At some point silica invoker caused issues to
rendering (don't know why) but those are now history with
threaded rendering.

With V4 precompilation of QML components has become even more important.
This improves sailfish-browser startup time quite significantly
as all Silica components will be compiled by booster.
