### PR TITLE
[sailfish-browser] Fix failing tst_webview

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -101,8 +101,8 @@ void DeclarativeWebContainer::setWebPage(DeclarativeWebPage *webPage)
     if (m_webPage != webPage) {
         m_webPage = webPage;
         emit contentItemChanged();
-        emit titleChanged();
-        emit urlChanged();
+        updateUrl(url());
+        updateTitle(title());
     }
 }
 
@@ -505,16 +505,33 @@ void DeclarativeWebContainer::onActiveTabChanged(int oldTabId, int activeTabId, 
 
     setThumbnailPath(tab.thumbnailPath());
 
+    updateUrl(tab.url());
 
-    if (m_title != tab.title()) {
-        m_title = tab.title();
-        emit titleChanged();
-    }
-
-    if (m_url != tab.url()) {
-        m_url = tab.url();
-        emit urlChanged();
-    }
+    /**
+     * TODO: We should update title here as well.
+     * Reason not to do so yet is the way how database writes are synchronized to model and
+     * webcontainer states. Currently DeclarativeTabModel do not ignore callbacks from database
+     * worker if another operation made call obsolete.
+     *
+     * For example:
+     * DeclarativeWebPage::loadTab loads an url when the url changes onPageUrlChanged
+     * slot gets called and update url of webcontainer and initiates async write to database without title.
+     * After a while db replies that tab has changed including data.
+     * Right after onPageUrlChanged slot is called, onPageTitleChanged slot is called. The onPageTitleChanged
+     * triggers async write to database with title.
+     * Due to async nature, order of operations might look like (loadTab):
+     *   1) onPageUrlChanged
+     *   2) onPageTitleChanged (so far all would be good)
+     *   3) DB call from to DeclarativeTabModel::tabChanged (with url, callback from 1)
+     *   4) DB call from to DeclarativeTabModel::tabChanged (with url & title, callback from 2)
+     *
+     * Callbacks should be bound to triggered operation allowing other operations
+     * to ignore callback that are not needed anymore. E.g. in above case
+     * 2th step should mark for model that callback coming from onPageUrlChanged 3rd can be
+     * ignored as we know at that moment there is another callback soon coming.
+     */
+    // updateTitle(tab.title());
+    // Reverts title change handling that was introduced in commit ad85e79d.
 
     if (m_tabId != activeTabId) {
         m_tabId = activeTabId;
@@ -688,13 +705,10 @@ void DeclarativeWebContainer::releasePage(int tabId, bool virtualize)
         m_webPages->release(tabId, virtualize);
         // Successfully destroyed. Emit relevant property changes.
         if (!m_webPage) {
-            m_title = "";
-            m_url = "";
             m_tabId = 0;
-
             emit contentItemChanged();
-            emit titleChanged();
-            emit urlChanged();
+            updateUrl("");
+            updateTitle("");
             emit tabIdChanged();
             setThumbnailPath("");
         }
@@ -737,7 +751,7 @@ void DeclarativeWebContainer::onPageUrlChanged()
             webPage->setUrlHasChanged(true);
             webPage->setBackForwardNavigation(false);
             if (activeTab && webPage == m_webPage) {
-                emit urlChanged();
+                updateUrl(url);
             }
         }
     }
@@ -753,7 +767,7 @@ void DeclarativeWebContainer::onPageTitleChanged()
         m_model->updateTitle(tabId, activeTab, title);
 
         if (activeTab && webPage == m_webPage) {
-            emit titleChanged();
+            updateTitle(title);
         }
     }
 }
@@ -823,6 +837,42 @@ void DeclarativeWebContainer::updateVkbHeight()
     }
 #endif
     m_inputPanelOpenHeight = vkbHeight;
+}
+
+/**
+ * Pass the newUrl. This should be used everywhere when
+ * url is about to change. E.g. when updating current contentItem.
+ * When both url and title are about to change call updateUrl first
+ * as it is more natural that way.
+ * @brief DeclarativeWebContainer::updateUrl
+ * @param newUrl
+ *
+ * See also updateTitle
+ */
+void DeclarativeWebContainer::updateUrl(const QString &newUrl)
+{
+    if (m_url != newUrl) {
+        m_url = newUrl;
+        emit urlChanged();
+    }
+}
+
+/**
+ * Pass the newTitle. This should be used everywhere when
+ * title is about to change. E.g. when updating current contentItem.
+ * When both url and title are about to change call updateUrl first
+ * as it is more natural that way.
+ * @brief DeclarativeWebContainer::updateTitle
+ * @param newTitle
+ *
+ * See also updateUrl
+ */
+void DeclarativeWebContainer::updateTitle(const QString &newTitle)
+{
+    if (m_title != newTitle) {
+        m_title = newTitle;
+        emit titleChanged();
+    }
 }
 
 void DeclarativeWebContainer::sendVkbOpenCompositionMetrics()

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -192,6 +192,9 @@ private:
     void updateNavigationStatus(const Tab &tab);
     void updateVkbHeight();
 
+    void updateUrl(const QString &newUrl);
+    void updateTitle(const QString &newTitle);
+
     struct ScreenCapture {
         int tabId;
         QString path;

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -233,10 +233,13 @@ void tst_webview::testActivateTab()
 
     QCOMPARE(webContainer->webPage()->tabId(), newActiveTabId);
     QCOMPARE(webContainer->url(), newActiveUrl);
+    QVERIFY(webContainer->url().endsWith("testpage.html"));
     QCOMPARE(webContainer->title(), newActiveTitle);
+    QCOMPARE(webContainer->title(), QString("TestPage"));
     QCOMPARE(urlChangedSpy.count(), 1);
     QCOMPARE(titleChangedSpy.count(), 1);
     QCOMPARE(webContainer->webPage()->url().toString(), newActiveUrl);
+    QVERIFY(webContainer->webPage()->url().toString().endsWith("testpage.html"));
     QCOMPARE(webContainer->webPage()->title(), newActiveTitle);
 
     // Signaled always when tab is changed.
@@ -267,7 +270,11 @@ void tst_webview::testCloseActiveTab()
     QSignalSpy titleChangedSpy(webContainer, SIGNAL(titleChanged()));
     QSignalSpy contentItemSpy(webContainer, SIGNAL(contentItemChanged()));
 
+    // Close will nullify contentItem and prepares new active tab but doesn't load/change
+    // contentItem item.
     tabModel->closeActiveTab();
+    // Updates contentItem to match index zero.
+    webContainer->activatePage(webContainer->tabId());
     QCOMPARE(activeTabChangedSpy.count(), 1);
     QCOMPARE(tabClosedSpy.count(), 1);
     QList<QVariant> arguments = tabClosedSpy.takeFirst();
@@ -285,14 +292,18 @@ void tst_webview::testCloseActiveTab()
 
     QCOMPARE(webContainer->webPage()->tabId(), newActiveTabId);
     QCOMPARE(webContainer->url(), newActiveUrl);
+    QVERIFY(webContainer->url().endsWith("testnavigation.html"));
     QCOMPARE(webContainer->title(), newActiveTitle);
+    QCOMPARE(webContainer->title(), QString("TestNavigation"));
     // Two signals: closeActiveTab causes contentItem to be destroyed. Thus, both url and title
     // are update signaled. Second url/title changed signal comes
     // when the first item from model is made as active tab.
     QCOMPARE(urlChangedSpy.count(), 2);
     QCOMPARE(titleChangedSpy.count(), 2);
     QCOMPARE(webContainer->webPage()->url().toString(), newActiveUrl);
+    QVERIFY(webContainer->webPage()->url().toString().endsWith("testnavigation.html"));
     QCOMPARE(webContainer->webPage()->title(), newActiveTitle);
+    QCOMPARE(webContainer->webPage()->title(), QString("TestNavigation"));
 
     // Signaled always when tab is changed.
     arguments = activeTabChangedSpy.takeFirst();


### PR DESCRIPTION
Reverts title change handling from DeclarativeWebContainer::onActiveTabChanged that was introduced in commit ad85e79d.

Adds title changed and urlchanged helpers so that we do not emit signals unnecessarily. 

CloseActiveTab does not trigger load anymore (SHA1 ad85e79dda). So, activatePage in test case.
