### PR TITLE
[sailfish-browser] Add unit test cases for suffling tabs

### DIFF
--- a/src/webpages.cpp
+++ b/src/webpages.cpp
@@ -240,6 +240,34 @@ void WebPages::dumpPages() const
     qDebug() << "---- end ------";
 }
 
+QList<int> WebPages::liveTabs()
+{
+    QList<WebPageEntry *> pages = m_activePages.values();
+    QList<int> tabIds;
+    int count = pages.count();
+    for (int i = 0; i < count; ++i) {
+        WebPageEntry *pageEntry = pages.at(i);
+        if (pageEntry->webPage) {
+            tabIds << pageEntry->webPage->tabId();
+        }
+    }
+    return tabIds;
+}
+
+QList<int> WebPages::zombifiedTabs()
+{
+    QMapIterator<int, WebPageEntry*> pages(m_activePages);
+    QList<int> tabIds;
+
+    while (pages.hasNext()) {
+        pages.next();
+        if (!pages.value()->webPage) {
+            tabIds << pages.key();
+        }
+    }
+    return tabIds;
+}
+
 WebPages::WebPageEntry::WebPageEntry(DeclarativeWebPage *webPage, QRectF *cssContentRect)
     : webPage(webPage)
     , cssContentRect(cssContentRect)

--- a/src/webpages.h
+++ b/src/webpages.h
@@ -48,6 +48,10 @@ public:
     int parentTabId(int tabId) const;
     void dumpPages() const;
 
+    // Testability helpers
+    QList<int> liveTabs();
+    QList<int> zombifiedTabs();
+
 private:
     struct WebPageEntry {
         WebPageEntry(DeclarativeWebPage *webPage, QRectF *cssContentRect);

--- a/tests/auto/common/testobject.cpp
+++ b/tests/auto/common/testobject.cpp
@@ -48,7 +48,7 @@ void TestObject::init(const QUrl &url)
 void TestObject::waitSignals(QSignalSpy &spy, int expectedSignalCount) const
 {
     int i = 0;
-    int maxWaits = 10;
+    int maxWaits = qMax(10, expectedSignalCount);
     while (spy.count() < expectedSignalCount && i < maxWaits) {
         spy.wait();
         ++i;

--- a/tests/auto/tests.xml
+++ b/tests/auto/tests.xml
@@ -23,7 +23,7 @@
                <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_dbmanager -platform wayland-egl -iterations 10</step>
            </case>
            <case manual="false" name="webview">
-               <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_webview -platform wayland-egl</step>
+               <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; BROWSER_OFFLINE=1 ./tst_webview</step>
            </case>
            <case manual="false" name="desktopbookmarkwriter">
                <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_desktopbookmarkwriter</step>

--- a/tests/auto/tst_webview/tst_webview.qml
+++ b/tests/auto/tst_webview/tst_webview.qml
@@ -31,6 +31,13 @@ ApplicationWindow {
             active: true
             toolbarHeight: 50
             portrait: true
+            width: parent.width
+            height: parent.height
+
+            onLoadProgressChanged: console.log("progress:", loadProgress, url, tabId)
+            onLoadingChanged: console.log(loading, url, tabId)
+            onUrlChanged: console.log(url, tabId)
+            onContentItemChanged: console.log(contentItem, "url:", (contentItem ? contentItem.url : "no url" ), "tabId:", (contentItem ? contentItem.tabId : -1 ))
 
             HistoryModel {
                 id: historyModel


### PR DESCRIPTION
Aim is to automate a test where a WebPage stops responding. Added
cases do not reproduce that error yet.

Requires: https://github.com/sailfishos/sailfish-browser/pull/208
