### PR TITLE
[sailfish-browser] Change "Filter" to "Search" in about:config

### DIFF
--- a/src/pages/ConfigDialog.qml
+++ b/src/pages/ConfigDialog.qml
@@ -83,9 +83,9 @@ Dialog {
 
             SearchField {
                 width: prefsList.width
-                //: Placeholder text for config filtering.
-                //% "Filter"
-                placeholderText: qsTrId("sailfish_browser-ph-config-filter")
+                //: Placeholder text for search (used in about:config page).
+                //% "Search"
+                placeholderText: qsTrId("sailfish_browser-ph-search")
                 inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
 
                 EnterKey.onClicked: filterModel(text)


### PR DESCRIPTION
"Search" is now a generic placeholder ("sailfish_browser-ph-search") that
can be used elsewhere in browser as well.
