### PR TITLE
[sailfish-browser] Do not send "memory-pressure" to engine

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -98,12 +98,6 @@ Page {
         }
     }
 
-    onStatusChanged: {
-        if (status === PageStatus.Inactive) {
-            MozContext.sendObserve("memory-pressure", null)
-        }
-    }
-
     HistoryModel {
         id: historyModel
     }

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -117,12 +117,6 @@ WebContainer {
         }
     }
 
-    onBackgroundChanged: {
-        if (background) {
-            MozContext.sendObserve("memory-pressure", "heap-minimize")
-        }
-    }
-
     WebViewCreator {
         activeWebView: contentItem
         // onNewWindowRequested is always handled as synchronous operation (not through newTab).


### PR DESCRIPTION
Let gecko to do gc'ing when needed. Sending "memory-pressure" this
frequently (in common use cases) cause unnecessary page faults. In
addition, this looks to be leading to a higher memory consumption.
