### PR TITLE
[sailfish-browser] Add max number of tabs argument for openSites script

### DIFF
--- a/tests/manual/openSites.sh
+++ b/tests/manual/openSites.sh
@@ -9,9 +9,18 @@ webSites=`wc -l $SITES | cut -d ' ' -f 1`
 echo "Opening $webSites sites from $SITES"
 i=0
 
+MAX_SITES=100
+if [ $# -gt 1 ]; then
+  MAX_SITES=$2
+fi
+
 for line in `cat $SITES`; do
-  echo "Adding $line ($i/$webSites)"
   sqlite3 /home/nemo/.local/share/org.sailfishos/sailfish-browser/sailfish-browser.sqlite "insert into link (url) values (\"http://$line\");"
   sqlite3 /home/nemo/.local/share/org.sailfishos/sailfish-browser/sailfish-browser.sqlite "insert into tab_history (tab_id, link_id) values ((select max(tab_id)+1 from tab), (select max(link_id) from link)); insert into tab (tab_id, tab_history_id) values ((select max(tab_id)+1 from tab), (select max(id) from tab_history));"
   i=$((i+1))
+  echo "Adding $line ($i/$webSites)"
+
+  if [ $i -ge $MAX_SITES ]; then
+    break
+  fi
 done


### PR DESCRIPTION
The number of tabs written to database can be limited by adding
a 2nd argument for the script.

Use like:
cd /opt/tests/sailfish-browser/manual
./openSites.sh sites.txt 14
