### PR TITLE
[sailfish-browser] Virtualize background tabs when another application is opened

### DIFF
--- a/src/webpages.h
+++ b/src/webpages.h
@@ -55,6 +55,7 @@ public:
 private slots:
     void handleMemNotify(const QString &memoryLevel);
     void updateBackgroundTimestamp();
+    void virtualizeInactive();
 
 private:
     void updateStates(DeclarativeWebPage *oldActivePage, DeclarativeWebPage *newActivePage);


### PR DESCRIPTION
Current implementation virtualizes backgrounded tabs when low memory
notification (warning / critical) is received even if the browser is
at foreground. Virtualizing backgrounded tabs when another application
is brought foreground guarantees that there are no background tabs
when another application is running regardless of low memory
notification.
