### PR TITLE
Move load from QML to C++ side

### DIFF
--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -56,7 +56,6 @@ class DeclarativeWebContainer : public QQuickItem {
     Q_PROPERTY(int tabId READ tabId NOTIFY tabIdChanged FINAL)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged FINAL)
     Q_PROPERTY(QString url READ url NOTIFY urlChanged FINAL)
-    Q_PROPERTY(QString initialUrl MEMBER m_initialUrl NOTIFY initialUrlChanged FINAL)
 
     Q_PROPERTY(QQmlComponent* webPageComponent MEMBER m_webPageComponent NOTIFY webPageComponentChanged FINAL)
 
@@ -106,6 +105,7 @@ public:
 
     bool isActiveTab(int tabId);
 
+    Q_INVOKABLE void load(QString url = "", QString title = "", bool force = false);
     Q_INVOKABLE void goForward();
     Q_INVOKABLE void goBack();
     Q_INVOKABLE bool activatePage(int tabId, bool force = false);
@@ -141,13 +141,11 @@ signals:
     void tabIdChanged();
     void titleChanged();
     void urlChanged();
-    void initialUrlChanged();
     void thumbnailPathChanged();
 
     void _readyToLoadChanged();
 
     void webPageComponentChanged();
-    void triggerLoad(QString url, QString title);
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -30,26 +30,6 @@ WebContainer {
         }
     }
 
-    function load(url, title, force) {
-        // Modify url and title to string
-        title = title ? "" + title : ""
-        url = url ? "" + url : ""
-
-        // This guarantees at that least one webview exists.
-        if (tabModel.count == 0 && !tabModel.hasNewTabData) {
-            tabModel.newTabData(url, title, null)
-        }
-
-        if (!tabModel.hasNewTabData || force || !webView.activatePage(tabModel.nextTabId)) {
-            // First contentItem will be created once tab activated.
-            if (contentItem && contentItem.viewReady) {
-                contentItem.loadTab(url, force)
-            } else {
-                webView.initialUrl = url
-            }
-        }
-    }
-
     function reload() {
         if (!contentItem) {
             return
@@ -89,8 +69,6 @@ WebContainer {
     tabModel: TabModel {
         id: tabs
     }
-
-    onTriggerLoad: webView.load(url, title)
 
     visible: WebUtils.firstUseDone
 

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -362,7 +362,7 @@ void tst_webview::testUrlLoading()
     QString newTitle = "TestUrlScheme";
 
     // Mimic favorite opening to already opened tab.
-    emit webContainer->triggerLoad(newUrl, newTitle);
+    webContainer->load(newUrl, newTitle);
     waitSignals(loadingChanged, 2);
 
     QCOMPARE(contentItemSpy.count(), 0);


### PR DESCRIPTION
See also https://github.com/sailfishos/sailfish-browser/pull/236

This is one steps closer to cleanup old and partially deadcode in new tab creation code path that is currently causing some issues.
