### PR TITLE
Delay showing of the "Create a new tab" cover text

### DIFF
--- a/src/pages/components/OverlayAnimator.qml
+++ b/src/pages/components/OverlayAnimator.qml
@@ -52,6 +52,15 @@ Item {
     // Wrapper from updating the state. Handy for debugging.
     function updateState(newState, immediate) {
         _immediate = immediate || false
+        // Verify that we return back to opacity 1.0
+        // For instance, push to switcher from new-tab-creation overlay
+        if (newState === "fullscreenWebPage" || newState === "chromeVisible") {
+            if (webView && webView.contentItem) {
+                webView.contentItem.visible = true
+                webView.contentItem.opacity = 1.0
+            }
+        }
+
         state = newState
     }
 
@@ -59,9 +68,10 @@ Item {
 
     // TODO: Fix real cover. Once that is fixed, we should remove this block.
     onActiveChanged: {
-        // When activating and state is already "fullscreenOverlay" don't do anything.
+        // When activating and state already changed to something else than
+        // "fullscreenWebPage" we should not alter the state.
         // For instance "new-tab" cover action triggers this state change.
-        if (active && state === "fullscreenOverlay") {
+        if (active && state !== "fullscreenWebPage") {
             return
         }
 

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -70,26 +70,50 @@ WebContainer {
     }
 
     Label {
+        id: coverLabel
+
+        property bool allowedToShow: !background.visible && tabModel.count === 0
+
         font.pixelSize: Theme.fontSizeExtraLarge * 2
         horizontalAlignment: Text.AlignHCenter
         x: Theme.paddingLarge * 2
         width: parent.width - x * 2
         anchors.verticalCenterOffset: -Theme.paddingLarge * 4
         anchors.verticalCenter: parent.verticalCenter
-        opacity: !background.visible && !foreground ? 1.0 : 0.0
         wrapMode: Text.WordWrap
+        visible: false
 
         //: Create a new tab cover text
         //% "Create a new tab"
         text: qsTrId("sailfish_browser-he-create_new_tab")
 
-        Behavior on opacity { FadeAnimation {} }
+        onAllowedToShowChanged: {
+            if (!allowedToShow) {
+                visible = false
+            } else {
+                showTimer.restart()
+            }
+        }
+
+        // Delay showing of the "Creating a new tab" text when Browser is pushed to switcher.
+        // Without this there is a small blink of the text when pushed to cover quickly.
+        // Note: This should be removed when switching to real cover and label moved to the cover.
+        Timer {
+            id: showTimer
+            interval: 200
+
+            onTriggered: {
+                if (coverLabel.allowedToShow) {
+                    coverLabel.visible = true
+                }
+            }
+        }
     }
 
     Rectangle {
         id: background
         anchors.fill: parent
-        visible: foreground && contentItem
+        visible: foreground || contentItem
         color: contentItem && contentItem.bgcolor ? contentItem.bgcolor : "white"
     }
 


### PR DESCRIPTION
Delay showing of the "Creating a new tab" text when Browser is pushed to switcher. Without this there is a small blink of the text when pushed to cover quickly.

Note: This should be removed when switching to real cover and label moved to the cover.
