### PR TITLE
[sailfish-browser] Override forced chrome with fullscreen request from the content

### DIFF
--- a/src/declarativewebpage.cpp
+++ b/src/declarativewebpage.cpp
@@ -249,8 +249,8 @@ void DeclarativeWebPage::resetHeight(bool respectContentHeight)
         return;
     }
 
-    // Application active
-    if (respectContentHeight && !m_forcedChrome) {
+    // fullscreen() below in the fullscreen request coming from the web content.
+    if (respectContentHeight && (!m_forcedChrome || fullscreen())) {
         // Handle webPage height over here, BrowserPage.qml loading
         // reset might be redundant as we have also loaded trigger
         // reset. However, I'd leave it there for safety reasons.


### PR DESCRIPTION
The fullscreen request from the web content should override the forceChrome state. The forcedChrome is only used for locking toolbar when find-in-page is active.
