### PR TITLE
[sailfish-browser] Add a custom cover when no tabs

### DIFF
--- a/src/browser.qml
+++ b/src/browser.qml
@@ -2,6 +2,7 @@
 **
 ** Copyright (C) 2013 Jolla Ltd.
 ** Contact: Vesa-Matti Hartikainen <vesa-matti.hartikainen@jollamobile.com>
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
 **
 ****************************************************************************/
 
@@ -11,14 +12,33 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import Sailfish.Browser 1.0
 import "pages"
 
 ApplicationWindow {
     id: window
 
+    signal newTab
+
+    function setBrowserCover(model) {
+        if (model && model.count === 0) {
+            cover = Qt.resolvedUrl("cover/NoTabsCover.qml")
+        } else {
+            cover = null
+        }
+    }
+
     allowedOrientations: WebUtils.firstUseDone && Qt.application.active ? Orientation.Landscape | Orientation.Portrait | Orientation.LandscapeInverted : Orientation.Portrait
     _defaultPageOrientations: allowedOrientations
-    initialPage: Component {BrowserPage {}}
-    cover: undefined
-}
+    cover: null
+    initialPage: Component {
+        BrowserPage {
+            id: browserPage
 
+            Connections {
+                target: window
+                onNewTab: browserPage.activateNewTabView()
+            }
+        }
+    }
+}

--- a/src/cover/NoTabsCover.qml
+++ b/src/cover/NoTabsCover.qml
@@ -1,0 +1,29 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.1
+import Sailfish.Silica 1.0
+
+CoverBackground {
+    CoverActionList {
+        CoverAction {
+            iconSource: "image://theme/icon-cover-new"
+            onTriggered: window.newTab()
+        }
+    }
+
+    CoverPlaceholder {
+        //: Create a new tab cover text
+        //% "Create a new tab"
+        text: qsTrId("sailfish_browser-he-create_new_tab")
+        icon.source: "image://theme/icon-launcher-browser"
+    }
+}

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -40,6 +40,12 @@ Page {
         }
     }
 
+    function activateNewTabView() {
+        pageStack.pop(browserPage, PageStackAction.Immediate);
+        overlay.enterNewTabUrl(PageStackAction.Immediate)
+        bringToForeground()
+    }
+
     // Safety clipping. There is clipping in ApplicationWindow that should react upon focus changes.
     // This clipping can handle also clipping of QmlMozView. When this page is active we do not need to clip
     // if input method is not visible.
@@ -142,10 +148,7 @@ Page {
 
         CoverAction {
             iconSource: "image://theme/icon-cover-new"
-            onTriggered: {
-                overlay.enterNewTabUrl(PageStackAction.Immediate)
-                bringToForeground()
-            }
+            onTriggered: activateNewTabView()
         }
 
         CoverAction {
@@ -156,19 +159,6 @@ Page {
                 } else {
                     webView.reload()
                 }
-            }
-        }
-    }
-
-    CoverActionList {
-        enabled: browserPage.status === PageStatus.Active && !webView.contentItem
-        iconBackground: true
-
-        CoverAction {
-            iconSource: "image://theme/icon-cover-new"
-            onTriggered: {
-                overlay.enterNewTabUrl(PageStackAction.Immediate)
-                activate()
             }
         }
     }

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -425,8 +425,8 @@ PanelBackground {
                     pageStack.pop()
                 }
                 onActivateTab: {
-                    pageStack.pop()
                     webView.tabModel.activateTab(index)
+                    pageStack.pop()
                 }
                 onCloseTab: {
                     webView.tabModel.remove(index)
@@ -440,7 +440,12 @@ PanelBackground {
                     enterNewTabUrl()
                 }
 
-                Component.onCompleted: positionViewAtIndex(webView.tabModel.activeTabIndex, ListView.Center)
+                Component.onCompleted: {
+                    positionViewAtIndex(tabPage.activeTabIndex, ListView.Center)
+                    window.setBrowserCover(webView.tabModel)
+                }
+
+                Component.onDestruction: window.setBrowserCover(webView.tabModel)
             }
         }
     }

--- a/src/pages/components/OverlayAnimator.qml
+++ b/src/pages/components/OverlayAnimator.qml
@@ -85,7 +85,7 @@ Item {
             } else {
                 updateState("chromeVisible", true)
             }
-        } else {
+        } else if (webView.tabModel.count > 0) {
             updateState("fullscreenWebPage", true)
         }
     }
@@ -124,6 +124,8 @@ Item {
             if (webView.completed && webView.tabModel.count === 0) {
                 updateState("fullscreenOverlay")
             }
+
+            window.setBrowserCover(webView.tabModel)
         }
     }
 

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -69,47 +69,6 @@ WebContainer {
         onNewWindowRequested: tabModel.newTab(url, "", parentId)
     }
 
-    Label {
-        id: coverLabel
-
-        property bool allowedToShow: !background.visible && tabModel.count === 0
-
-        font.pixelSize: Theme.fontSizeExtraLarge * 2
-        horizontalAlignment: Text.AlignHCenter
-        x: Theme.paddingLarge * 2
-        width: parent.width - x * 2
-        anchors.verticalCenterOffset: -Theme.paddingLarge * 4
-        anchors.verticalCenter: parent.verticalCenter
-        wrapMode: Text.WordWrap
-        visible: false
-
-        //: Create a new tab cover text
-        //% "Create a new tab"
-        text: qsTrId("sailfish_browser-he-create_new_tab")
-
-        onAllowedToShowChanged: {
-            if (!allowedToShow) {
-                visible = false
-            } else {
-                showTimer.restart()
-            }
-        }
-
-        // Delay showing of the "Creating a new tab" text when Browser is pushed to switcher.
-        // Without this there is a small blink of the text when pushed to cover quickly.
-        // Note: This should be removed when switching to real cover and label moved to the cover.
-        Timer {
-            id: showTimer
-            interval: 200
-
-            onTriggered: {
-                if (coverLabel.allowedToShow) {
-                    coverLabel.visible = true
-                }
-            }
-        }
-    }
-
     Rectangle {
         id: background
         anchors.fill: parent

--- a/src/sailfish-browser.qrc
+++ b/src/sailfish-browser.qrc
@@ -1,6 +1,7 @@
 <!DOCTYPE RCC><RCC version="1.0">
 <qresource>
     <file>browser.qml</file>
+    <file>cover/NoTabsCover.qml</file>
     <file>pages/BrowserPage.qml</file>
     <file>pages/ShareLinkPage.qml</file>
     <file>pages/components/ConfigDialog.qml</file>

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -50,6 +50,9 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=929879
     setenv("LC_NUMERIC", "C", 1);
     setlocale(LC_NUMERIC, "C");
+
+    QQuickWindow::setDefaultAlphaBuffer(true);
+
 #ifdef HAS_BOOSTER
     QScopedPointer<QGuiApplication> app(MDeclarativeCache::qApplication(argc, argv));
     QScopedPointer<QQuickView> view(MDeclarativeCache::qQuickView());

--- a/src/src.pro
+++ b/src/src.pro
@@ -13,7 +13,7 @@ isEmpty(USE_RESOURCES) {
   DEPLOYMENT_PATH = /usr/share/$$TARGET
   # QML files and folders
   qml.path = $$DEPLOYMENT_PATH
-  qml.files = *.qml pages
+  qml.files = *.qml pages cover
 
 
   DEFINES += DEPLOYMENT_PATH=\"\\\"\"$${DEPLOYMENT_PATH}/\"\\\"\"
@@ -90,6 +90,7 @@ HEADERS += \
     declarativefileuploadfilter.h
 
 OTHER_FILES = *.qml \
+              cover/*.qml \
               pages/*.qml \
               pages/components/*.qml \
               pages/components/*.js \


### PR DESCRIPTION
There is a small blink in upper part when using new tab cover action to create tab (no existing tabs).
