### PR TITLE
[sailfish-browser] Migrate history table to browser_history table

### DIFF
--- a/src/dbmanager.cpp
+++ b/src/dbmanager.cpp
@@ -135,10 +135,10 @@ void DBManager::removeAllTabs()
     QMetaObject::invokeMethod(worker, "removeAllTabs", Qt::QueuedConnection);
 }
 
-void DBManager::updateTitle(int tabId, int linkId, QString title)
+void DBManager::updateTitle(int tabId, int linkId, QString url, QString title)
 {
     QMetaObject::invokeMethod(worker, "updateTitle", Qt::QueuedConnection,
-                              Q_ARG(int, tabId), Q_ARG(int, linkId), Q_ARG(QString, title));
+                              Q_ARG(int, tabId), Q_ARG(int, linkId), Q_ARG(QString, url), Q_ARG(QString, title));
 }
 
 void DBManager::updateThumbPath(int tabId, QString path)

--- a/src/dbmanager.h
+++ b/src/dbmanager.h
@@ -39,7 +39,7 @@ public:
     void goBack(int tabId);
 
     void updateThumbPath(int tabId, QString path);
-    void updateTitle(int tabId, int linkId, QString title);
+    void updateTitle(int tabId, int linkId, QString url, QString title);
 
     void clearHistory();
     void getHistory(const QString &filter = "");

--- a/src/dbworker.h
+++ b/src/dbworker.h
@@ -46,7 +46,7 @@ public slots:
     int getMaxTabId();
     int getMaxLinkId();
 
-    void updateTitle(int tabId, int linkId, QString title);
+    void updateTitle(int tabId, int linkId, QString url, QString title);
     void updateThumbPath(int tabId, QString path);
 
     void goForward(int tabId);
@@ -75,7 +75,7 @@ private:
     Link getLink(int linkId);
     Link getLink(QString url);
     void updateLink(int linkId, QString url, QString title, QString thumbPath);
-    HistoryResult addToHistory(int linkId, QString url);
+    HistoryResult addToBrowserHistory(QString url, QString title);
     int addToTabHistory(int tabId, int linkId);
     Link getLinkFromTabHistory(int tabHistoryId);
     Link getCurrentLink(int tabId);
@@ -87,6 +87,7 @@ private:
     Tab getTabData(int tabId, int historyId = 0);
     int tabCount();
     int integerQuery(const QString &statement);
+    void migrateHistory();
 
     QSqlQuery prepare(const QString &statement);
     bool execute(QSqlQuery &query);

--- a/src/declarativetabmodel.cpp
+++ b/src/declarativetabmodel.cpp
@@ -361,7 +361,7 @@ void DeclarativeTabModel::updateUrl(int tabId, bool activeTab, QString url, bool
     }
 }
 
-void DeclarativeTabModel::updateTitle(int tabId, bool activeTab, QString title)
+void DeclarativeTabModel::updateTitle(int tabId, bool activeTab, QString url, QString title)
 {
     int tabIndex = findTabIndex(tabId);
     bool updateDb = false;
@@ -380,7 +380,7 @@ void DeclarativeTabModel::updateTitle(int tabId, bool activeTab, QString title)
     }
 
     if (updateDb) {
-        DBManager::instance()->updateTitle(tabId, linkId, title);
+        DBManager::instance()->updateTitle(tabId, linkId, url, title);
     }
 }
 

--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -79,7 +79,7 @@ public:
     bool contains(int tabId) const;
 
     void updateUrl(int tabId, bool activeTab, QString url, bool backForwardNavigation, bool initialLoad = false);
-    void updateTitle(int tabId, bool activeTab, QString title);
+    void updateTitle(int tabId, bool activeTab, QString url, QString title);
 
 public slots:
     // TODO: Move to be private

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -687,10 +687,11 @@ void DeclarativeWebContainer::onPageTitleChanged()
 {
     DeclarativeWebPage *webPage = qobject_cast<DeclarativeWebPage *>(sender());
     if (webPage && m_model) {
+        QString url = webPage->url().toString();
         QString title = webPage->title();
         int tabId = webPage->tabId();
         bool activeTab = isActiveTab(tabId);
-        m_model->updateTitle(tabId, activeTab, title);
+        m_model->updateTitle(tabId, activeTab, url, title);
 
         if (activeTab && webPage == m_webPage) {
             updateTitle(title);

--- a/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.cpp
+++ b/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.cpp
@@ -230,7 +230,7 @@ void tst_declarativehistorymodel::searchWithSpecialChars_data()
     QTest::newRow("special_site") << "http://www.pöö.com/" << "wierd site" << "pöö" << 1;
     QTest::newRow("special_title") << "http://www.foobar.com/" << "pöö wierd title" << "pöö" << 2;
     QTest::newRow("special_escaped_chars") << "http://www.foobar.com/" << "special title: ';\";ö" << "';\";" << 1;
-    QTest::newRow("special_upper_case_special_char") << "http://www.foobar.com/" << "Ö is wierd char" << "Ö" << 4;
+    QTest::newRow("special_upper_case_special_char") << "http://www.foobar.com/" << "Ö is wierd char" << "Ö" << 2;
 }
 
 void tst_declarativehistorymodel::searchWithSpecialChars()

--- a/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
+++ b/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
@@ -75,7 +75,8 @@ private:
     bool canGoBack();
     bool canGoForward();
 
-    int currentTabId();
+    int currentTabId() const;
+    QString currentTabUrl() const;
 
     DeclarativeTabModel *tabModel;
     QList<TestTab> originalTabOrder;
@@ -357,7 +358,7 @@ void tst_declarativetabmodel::multipleTabsWithSameUrls()
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString(), page2Tab1Url);
     QVERIFY(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString().isEmpty());
 
-    tabModel->updateTitle(tab2, true, page2Tab2Title);
+    tabModel->updateTitle(tab2, true, page2Tab2Url, page2Tab2Title);
     QCOMPARE(tabModel->activeTab().title(), page2Tab2Title);
 
     QTest::qWait(1000);
@@ -469,7 +470,7 @@ void tst_declarativetabmodel::updateTitle()
     QSignalSpy titleChangeSpy(DBManager::instance(), SIGNAL(titleChanged(int,int,QString,QString)));
     int tabId = currentTabId();
     QString title = "A title something";
-    tabModel->updateTitle(tabId, true, title);
+    tabModel->updateTitle(tabId, true, currentTabUrl(), title);
     waitSignals(titleChangeSpy, 1);
 
     QCOMPARE(tabModel->activeTab().title(), title);
@@ -481,7 +482,7 @@ void tst_declarativetabmodel::updateTitle()
     QCOMPARE(tabModel->activeTab().url(), url);
 
     title = "FooBar Title";
-    tabModel->updateTitle(tab1, true, title);
+    tabModel->updateTitle(tab1, true, url, title);
     waitSignals(titleChangeSpy, 2);
     QCOMPARE(tabModel->activeTab().title(), title);
 
@@ -489,7 +490,7 @@ void tst_declarativetabmodel::updateTitle()
     QModelIndex modelIndex = tabModel->createIndex(changedIndex, 0);
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), title);
 
-    tabModel->updateTitle(tab1, true, "");
+    tabModel->updateTitle(tab1, true, currentTabUrl(), "");
     waitSignals(titleChangeSpy, 3);
     QVERIFY(tabModel->activeTab().title().isEmpty());
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), QString(""));
@@ -508,7 +509,7 @@ void tst_declarativetabmodel::updateTitle()
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), title);
 
     title = "FooBar Two";
-    tabModel->updateTitle(tab2, true, title);
+    tabModel->updateTitle(tab2, true, url, title);
     waitSignals(titleChangeSpy, 4);
     QCOMPARE(tabModel->activeTab().title(), title);
 
@@ -519,7 +520,7 @@ void tst_declarativetabmodel::updateTitle()
     QString activeTabTitle = tabModel->activeTab().title();
 
     title = "FooBar non active tab";
-    tabModel->updateTitle(tab1, false, title);
+    tabModel->updateTitle(tab1, false, url, title);
     waitSignals(titleChangeSpy, 5);
     QCOMPARE(tabModel->activeTab().title(), activeTabTitle);
 
@@ -649,12 +650,20 @@ bool tst_declarativetabmodel::canGoForward()
     return tabModel->activeTab().nextLink() > 0;
 }
 
-int tst_declarativetabmodel::currentTabId()
+int tst_declarativetabmodel::currentTabId() const
 {
     if (tabModel->activeTab().isValid()) {
         return tabModel->activeTab().tabId();
     }
     return 0;
+}
+
+QString tst_declarativetabmodel::currentTabUrl() const
+{
+    if (tabModel->activeTab().isValid()) {
+        return tabModel->activeTab().url();
+    }
+    return QString();
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
histroy table is refactored into browser_history table to remove dependency over link table.
This will allow us to manipulate browser history without affecting individual tab histories.
