### PR TITLE
[sailfish-browser] Remove pull up gesture to open the overlay

### DIFF
--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -166,7 +166,7 @@ PanelBackground {
 
         width: parent.width
         height: historyContainer.height
-        enabled: !webView.fullscreenMode && (webView.tabModel.count > 0 || firstUseOverlay)
+        enabled: !webView.fullscreenMode && !overlayAnimator.atBottom && (webView.tabModel.count > 0 || firstUseOverlay)
 
         drag.target: overlay
         drag.filterChildren: true


### PR DESCRIPTION
Overlay can be only opened by tapping the address field.

Reasoning being that this overloads the events view opening
gesture.
