### PR TITLE
[sailfish-browser] Do not allow item grab if content is not painted

### DIFF
--- a/src/declarativewebpage.cpp
+++ b/src/declarativewebpage.cpp
@@ -200,7 +200,7 @@ void DeclarativeWebPage::loadTab(QString newUrl, bool force)
 
 void DeclarativeWebPage::grabToFile()
 {
-    if (!m_viewReady || backForwardNavigation() || !active())
+    if (!m_viewReady || backForwardNavigation() || !active() || !isPainted())
         return;
 
     emit clearGrabResult();


### PR DESCRIPTION
Requires: https://github.com/tmeshkova/qtmozembed/pull/102