### PR TITLE
[sailfish-browser] Position overlay flickables to beginning when overlay is hidden

### DIFF
--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -130,6 +130,9 @@ PanelBackground {
                 } else if (!toolBar.findInPageActive) {
                     searchField.resetUrl(webView.url)
                 }
+
+                favoriteGrid.positionViewAtBeginning()
+                historyList.positionViewAtBeginning()
             }
         }
     }


### PR DESCRIPTION
Position both favorite grid and history list to the beginning when
overlay reaches bottom.