### PR TITLE
[sailfish-browser] Do not limit dragging of overlay in fullscreen mode

### DIFF
--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -177,7 +177,7 @@ PanelBackground {
 
         width: parent.width
         height: historyContainer.height
-        enabled: !webView.fullscreenMode && !overlayAnimator.atBottom && (webView.tabModel.count > 0 || firstUseOverlay)
+        enabled: !overlayAnimator.atBottom && (webView.tabModel.count > 0 || firstUseOverlay)
 
         drag.target: overlay
         drag.filterChildren: true


### PR DESCRIPTION
Overlay cannot be opened by dragging meaning that dragging can be only used
to lower the overlay. Thus, we should not disable dragging in fullscreen
mode.

For instance, when playing a video in fullscreen and a new tab requested
from cover it should be possible to close the overlay by dragging it.