### PR TITLE
[sailfish-browser] Add error handling for favorite icons.

### DIFF
--- a/src/pages/components/FavoriteIcon.qml
+++ b/src/pages/components/FavoriteIcon.qml
@@ -30,4 +30,10 @@ Image {
             return 'image://theme/' + icon
         }
     }
+
+    onStatusChanged: {
+        if (status === Image.Error) {
+            icon = "icon-launcher-bookmark"
+        }
+    }
 }


### PR DESCRIPTION
In case the server is not responding or favorite icon is not found
from server icon will be replaced by default icon.