### PR TITLE
Fix initial download url

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -61,6 +61,7 @@ DeclarativeWebContainer::DeclarativeWebContainer(QQuickItem *parent)
 {
     m_webPages.reset(new WebPages(this));
     setFlag(QQuickItem::ItemHasContents, true);
+    connect(DownloadManager::instance(), SIGNAL(initializedChanged()), this, SLOT(initialize()));
     connect(DownloadManager::instance(), SIGNAL(downloadStarted()), this, SLOT(onDownloadStarted()));
     connect(QMozContext::GetInstance(), SIGNAL(onInitialized()), this, SLOT(initialize()));
     connect(this, SIGNAL(portraitChanged()), this, SLOT(resetHeight()));
@@ -534,7 +535,7 @@ void DeclarativeWebContainer::onDownloadStarted()
 {
     // This is not 100% solid. A newTab is called on incoming
     // url (during browser start) if no tabs exist (waitingForNewTab). In slow network
-    // connectivity one can create a a new tab before downloadStarted is emitted
+    // connectivity one can create a new tab before downloadStarted is emitted
     // from DownloadManager. To get this to the 100%, we should add downloadStatus
     // to the QmlMozView containing status of downloading.
     if (m_model->waitingForNewTab())  {
@@ -831,7 +832,7 @@ void DeclarativeWebContainer::updateTitle(const QString &newTitle)
 
 bool DeclarativeWebContainer::canInitialize() const
 {
-    return QMozContext::GetInstance()->initialized() && m_model && m_model->loaded();
+    return QMozContext::GetInstance()->initialized() && DownloadManager::instance()->initialized() && m_model && m_model->loaded();
 }
 
 void DeclarativeWebContainer::loadTab(int tabId, QString url, QString title, bool force)

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -563,6 +563,8 @@ void DeclarativeWebContainer::onDownloadStarted()
 
 void DeclarativeWebContainer::onNewTabRequested(QString url, QString title, int parentId)
 {
+    // TODO: Remove unused title argument.
+    Q_UNUSED(title);
     // An empty tab for cleaning previous navigation status.
     Tab tab;
     updateNavigationStatus(tab);
@@ -574,7 +576,6 @@ void DeclarativeWebContainer::onNewTabRequested(QString url, QString title, int 
 
     if (activatePage(m_model->nextTabId(), false, parentId)) {
         m_webPage->setInitialUrl(url);
-        m_webPage->setInitialTitle(title);
     }
 }
 
@@ -656,7 +657,7 @@ void DeclarativeWebContainer::onPageUrlChanged()
 
         // Initial url should not be considered as navigation request that increases navigation history.
         // Cleanup this.
-        bool initialLoad = !webPage->initialUrl().isEmpty() && !webPage->urlHasChanged();
+        bool initialLoad = !webPage->urlHasChanged();
         // Virtualized pages need to be checked from the model.
         if (webPage->boundToModel() || m_model->contains(tabId)) {
             m_model->updateUrl(tabId, activeTab, url, webPage->backForwardNavigation(), initialLoad);
@@ -665,10 +666,9 @@ void DeclarativeWebContainer::onPageUrlChanged()
             // to the model. We should have downloadStatus(status) and linkClicked(url) signals in QmlMozView.
             // To distinguish linkClicked(url) from downloadStatus(status) the downloadStatus(status) signal
             // should not be emitted when link clicking started downloading or opened (will open) a new window.
-            m_model->addTab(webPage->initialUrl(), webPage->initialTitle());
+            m_model->addTab(url, "");
         }
         webPage->bindToModel();
-        webPage->resetInitialData();
         webPage->setUrlHasChanged(true);
 
         bool wasBackForwardNavigation = webPage->backForwardNavigation();
@@ -837,6 +837,8 @@ bool DeclarativeWebContainer::canInitialize() const
 
 void DeclarativeWebContainer::loadTab(int tabId, QString url, QString title, bool force)
 {
+    // TODO: Remove references to title.
+    Q_UNUSED(title);
     if (activatePage(tabId, true) || force) {
         // Note: active pages containing a "link" between each other (parent-child relationship)
         // are not destroyed automatically e.g. in low memory notification.
@@ -845,7 +847,6 @@ void DeclarativeWebContainer::loadTab(int tabId, QString url, QString title, boo
             m_webPage->loadTab(url, force);
         } else {
             m_webPage->setInitialUrl(url);
-            m_webPage->setInitialTitle(title);
         }
     }
 }

--- a/src/declarativewebpage.cpp
+++ b/src/declarativewebpage.cpp
@@ -122,30 +122,9 @@ void DeclarativeWebPage::setUrlHasChanged(bool urlHasChanged)
     m_urlHasChanged = urlHasChanged;
 }
 
-QString DeclarativeWebPage::initialUrl() const
-{
-    return m_initialUrl;
-}
-
 void DeclarativeWebPage::setInitialUrl(const QString &url)
 {
     m_initialUrl = url;
-}
-
-QString DeclarativeWebPage::initialTitle() const
-{
-    return m_initialTitle;
-}
-
-void DeclarativeWebPage::setInitialTitle(const QString &title)
-{
-    m_initialTitle = title;
-}
-
-void DeclarativeWebPage::resetInitialData()
-{
-    m_initialUrl = "";
-    m_initialTitle = "";
 }
 
 void DeclarativeWebPage::bindToModel()
@@ -300,6 +279,7 @@ void DeclarativeWebPage::onViewInitialized()
 
     if (!m_initialUrl.isEmpty()) {
         loadTab(m_initialUrl, false);
+        m_initialUrl = "";
     }
 }
 

--- a/src/declarativewebpage.h
+++ b/src/declarativewebpage.h
@@ -54,13 +54,7 @@ public:
     bool urlHasChanged() const;
     void setUrlHasChanged(bool urlHasChanged);
 
-    QString initialUrl() const;
     void setInitialUrl(const QString &url);
-
-    QString initialTitle() const;
-    void setInitialTitle(const QString &title);
-
-    void resetInitialData();
 
     void bindToModel();
     bool boundToModel();
@@ -120,7 +114,6 @@ private:
     bool m_backForwardNavigation;
     bool m_boundToModel;
     QString m_initialUrl;
-    QString m_initialTitle;
     QString m_favicon;
     QVariant m_resurrectedContentRect;
     QSharedPointer<QQuickItemGrabResult> m_grabResult;

--- a/src/declarativewebutils.cpp
+++ b/src/declarativewebutils.cpp
@@ -193,7 +193,8 @@ void DeclarativeWebUtils::updateWebEngineSettings()
                              << "media-decoder-info"
                              << "embed:download"
                              << "embed:allprefs"
-                             << "embed:search");
+                             << "embed:search"
+                             << "download-manager-initialized");
 
     // Enable internet search
     mozContext->setPref(QString("keyword.enabled"), QVariant(true));

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -27,6 +27,7 @@ static DownloadManager *gSingleton = 0;
 
 DownloadManager::DownloadManager()
     : QObject()
+    , m_initialized(false)
 {
     m_transferClient = new TransferEngineInterface("org.nemo.transferengine",
                                                    "/org/nemo/transferengine",
@@ -43,7 +44,11 @@ DownloadManager::~DownloadManager()
 
 void DownloadManager::recvObserve(const QString message, const QVariant data)
 {
-    if (message != "embed:download") {
+
+    if (message == "download-manager-initialized" && !m_initialized) {
+        m_initialized = true;
+        emit initializedChanged();
+    } else if (message != "embed:download") {
         // here we are interested in download messages only
         return;
     }
@@ -231,6 +236,11 @@ bool DownloadManager::existActiveTransfers()
         }
     }
     return exists;
+}
+
+bool DownloadManager::initialized()
+{
+    return m_initialized;
 }
 
 void DownloadManager::checkAllTransfers()

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -27,8 +27,10 @@ public:
     static DownloadManager *instance();
 
     bool existActiveTransfers();
+    bool initialized();
 
 signals:
+    void initializedChanged();
     void downloadStarted();
     void allTransfersCompleted();
 
@@ -63,6 +65,7 @@ private:
     QHash<qulonglong, Status> m_statusCache;
 
     TransferEngineInterface *m_transferClient;
+    bool m_initialized;
 };
 
 #endif

--- a/tests/auto/common/downloadmanager.cpp
+++ b/tests/auto/common/downloadmanager.cpp
@@ -24,3 +24,8 @@ DownloadManager *DownloadManager::instance()
     }
     return s_singleton;
 }
+
+bool DownloadManager::initialized()
+{
+    return true;
+}

--- a/tests/auto/common/downloadmanager.h
+++ b/tests/auto/common/downloadmanager.h
@@ -20,8 +20,10 @@ class DownloadManager : public QObject
 
 public:
     static DownloadManager *instance();
+    bool initialized();
 
 signals:
+    void initializedChanged();
     void downloadStarted();
 
 private:


### PR DESCRIPTION
Subject: [sailfish-browser] Do not add initial url to the tab model

Initial url can be a download url.

Subject: [sailfish-browser] At startup wait that Download Manager is initialized

Do not mark DeclarativeWebContainer as initialized before mozilla context,
download manager, web container itself, and tab model are completed/initialized.