### PR TITLE
[sailfish-browser] Switch to grabbed web content while popping tab page

### DIFF
--- a/src/pages/components/TabItem.qml
+++ b/src/pages/components/TabItem.qml
@@ -44,7 +44,10 @@ BackgroundItem {
     contentItem.width: root.implicitWidth - root.leftMargin - root.rightMargin
     contentItem.height: root.implicitHeight - root.topMargin - root.bottomMargin
 
-    onClicked: view.activateTab(index)
+    onClicked: {
+        activeTabIndex = -1
+        view.activateTab(index)
+    }
 
     // contentItem is hidden so this cannot be children of the contentItem.
     // So, making them as siblings of the contentItem.


### PR DESCRIPTION
Previously there was a glimpse of previous active tab visible in the
tab index that will be the new active tab. This happened because
activeTab property change changed texture source to use incorrect
sourceItem. Thus, let's jump to grabbed web content while tab page is animated
away from the pagestack.
