### PR TITLE
[sailfish-browser] Fix favorite grid context menu issues

### DIFF
--- a/src/pages/components/FavoriteGrid.qml
+++ b/src/pages/components/FavoriteGrid.qml
@@ -45,6 +45,13 @@ SilicaGridView {
     cellHeight: Math.round(Screen.height / 6)
     displaced: Transition { NumberAnimation { properties: "x,y"; easing.type: Easing.InOutQuad; duration: 200 } }
 
+    onVisibleChanged: {
+        if (!visible && contextMenuActive) {
+            contextMenu.hide()
+        }
+    }
+
+    readonly property bool contextMenuActive: contextMenu && contextMenu.active
     property Item contextMenu: currentItem ? currentItem._menuItem : null
     // Figure out which delegates need to be moved down to make room
     // for the context menu when it's open.

--- a/src/pages/components/FavoriteGrid.qml
+++ b/src/pages/components/FavoriteGrid.qml
@@ -82,6 +82,9 @@ SilicaGridView {
         menu: favoriteContextMenu
         down: favoriteItem.down
         showMenuOnPressAndHold: false
+        // Do not capture mouse events here. This ListItem only handles
+        // menu creation and destruction.
+        enabled: false
 
         onVisibleChanged: {
             if (!visible && remorse) {

--- a/src/pages/components/FavoriteGrid.qml
+++ b/src/pages/components/FavoriteGrid.qml
@@ -86,6 +86,15 @@ SilicaGridView {
         // menu creation and destruction.
         enabled: false
 
+        // Update menu position upon orientation change. Delegate's x might change when
+        // orientation changes as there are 4 columns in portrait and 7 in landscape.
+        // This breaks binding that exists in ContextMenu.
+        onXChanged: {
+            if (_menuItem && _menuItem.active) {
+                _menuItem.x = -x
+            }
+        }
+
         onVisibleChanged: {
             if (!visible && remorse) {
                 remorse.destroy()

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -177,7 +177,7 @@ PanelBackground {
 
         width: parent.width
         height: historyContainer.height
-        enabled: !overlayAnimator.atBottom && (webView.tabModel.count > 0 || firstUseOverlay)
+        enabled: !overlayAnimator.atBottom && (webView.tabModel.count > 0 || firstUseOverlay) && !favoriteGrid.contextMenuActive
 
         drag.target: overlay
         drag.filterChildren: true


### PR DESCRIPTION
If ContextMenu is active when FavoriteGrid changes invisible
ContextMenu is explicitly hidden / closed.