### PR TITLE
Build with multiple cores when using mb2.

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -86,7 +86,7 @@ Unit tests and additional data needed for functional tests
 
 %qmake5
 
-make %{?jobs:-j%jobs}
+make %{_smp_mflags}
 
 # >> build post
 # << build post


### PR DESCRIPTION
jobs is non-standard and won't use multiple cores when building under mb2, unlike _smp_mflags.