### PR TITLE
[sailfish-browser] Limit active cover actions to one for Sailfish 2.0

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -23,7 +23,7 @@ BuildRequires:  qt5-qttools-linguist
 BuildRequires:  gdb
 BuildRequires:  oneshot
 
-Requires: sailfishsilica-qt5 >= 0.13.34
+Requires: sailfishsilica-qt5 >= 0.13.35
 Requires: jolla-ambient >= 0.4.18
 Requires: xulrunner-qt5 >= 29.0.1.9
 Requires: embedlite-components-qt5 >= 1.6.4

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -12,6 +12,7 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import Sailfish.Silica.private 1.0
 import Sailfish.Browser 1.0
 import "components" as Browser
 
@@ -143,7 +144,18 @@ Page {
     }
 
     CoverActionList {
-        enabled: browserPage.status === PageStatus.Active && webView.contentItem
+        enabled: browserPage.status === PageStatus.Active && webView.contentItem && (Config.sailfishVersion >= 2.0)
+        iconBackground: true
+
+        CoverAction {
+            iconSource: "image://theme/icon-cover-new"
+            onTriggered: activateNewTabView()
+        }
+    }
+
+    // TODO: remove once we move to sailfish 2.0
+    CoverActionList {
+        enabled: browserPage.status === PageStatus.Active && webView.contentItem && (Config.sailfishVersion < 2.0)
         iconBackground: true
 
         CoverAction {


### PR DESCRIPTION
Rebased: https://github.com/sailfishos/sailfish-browser/pull/290