### PR TITLE
[sailfish-browser] Use grid layout for tab view on large screen

### DIFF
--- a/src/pages/components/TabView.qml
+++ b/src/pages/components/TabView.qml
@@ -17,6 +17,7 @@ SilicaGridView {
     id: tabView
 
     property bool portrait
+    readonly property bool largeScreen: Screen.sizeCategory > Screen.Medium
 
     signal hide
     signal enterNewTabUrl
@@ -24,8 +25,11 @@ SilicaGridView {
     signal closeTab(int index)
     signal closeAll
 
-    cellWidth: portrait ? parent.width : parent.width / 3
-    cellHeight: portrait ? Screen.width / 2 : cellWidth
+    readonly property int columns: portrait ? (largeScreen ? 2 : 1) : 3
+
+    cellWidth: parent.width / columns
+    // Only small screen in portrait has one column. Use then none square tab.
+    cellHeight: columns === 1 ? Screen.width / 2 : cellWidth
 
     width: parent.width
     height: parent.height
@@ -39,12 +43,15 @@ SilicaGridView {
     delegate: TabItem {
         id: tabItem
 
+        readonly property bool firstColumn: index % columns === 0
+        readonly property bool lastColumn: index % columns === (columns - 1)
+
         width: tabView.cellWidth
         height: tabView.cellHeight
 
         topMargin: Theme.paddingMedium
-        leftMargin: (portrait || index % 3 === 0) ? Theme.paddingLarge : Theme.paddingMedium
-        rightMargin: (portrait || index % 3 === 2) ? Theme.paddingLarge : Theme.paddingMedium
+        leftMargin: firstColumn ? Theme.paddingLarge : Theme.paddingMedium
+        rightMargin: lastColumn ? Theme.paddingLarge : Theme.paddingMedium
         bottomMargin: Theme.paddingMedium
 
         Behavior on width {


### PR DESCRIPTION
On large screen
- 2 columns on portrait
- 3 columns on landscape