### PR TITLE
[sailfish-browser] Remove redundant tabsCleared signal JB#26644

### DIFF
--- a/src/dbmanager.cpp
+++ b/src/dbmanager.cpp
@@ -129,12 +129,6 @@ void DBManager::removeTab(int tabId)
                               Q_ARG(int, tabId));
 }
 
-void DBManager::removeAllTabs()
-{
-    m_maxTabId = 0;
-    QMetaObject::invokeMethod(worker, "removeAllTabs", Qt::QueuedConnection);
-}
-
 void DBManager::updateTitle(int tabId, int linkId, QString url, QString title)
 {
     QMetaObject::invokeMethod(worker, "updateTitle", Qt::QueuedConnection,

--- a/src/dbmanager.h
+++ b/src/dbmanager.h
@@ -32,7 +32,6 @@ public:
     void getTab(int tabId);
     void getAllTabs();
     void removeTab(int tabId);
-    void removeAllTabs();
     void navigateTo(int tabId, QString url, QString title = "", QString path = "");
     void updateTab(int tabId, QString url, QString title = "", QString path = "");
     void goForward(int tabId);

--- a/src/dbworker.cpp
+++ b/src/dbworker.cpp
@@ -571,7 +571,6 @@ HistoryResult DBWorker::addToBrowserHistory(QString url, QString title)
 
 void DBWorker::clearHistory()
 {
-    int oldTabCount = tabCount();
     QSqlQuery query = prepare("DELETE FROM browser_history;");
     execute(query);
     removeAllTabs();
@@ -580,10 +579,6 @@ void DBWorker::clearHistory()
 
     QList<Link> linkList;
     emit historyAvailable(linkList);
-    if (oldTabCount != 0) {
-        QList<Tab> tabList;
-        emit tabsAvailable(tabList);
-    }
 }
 
 int DBWorker::addToTabHistory(int tabId, int linkId)

--- a/src/dbworker.h
+++ b/src/dbworker.h
@@ -38,7 +38,6 @@ public slots:
     void createTab(int tabId);
     int createLink(int tabId, QString url, QString title);
     void removeTab(int tabId);
-    void removeAllTabs();
     void getTab(int tabId);
     void getAllTabs();
     void navigateTo(int tabId, QString url, QString title, QString path);
@@ -89,6 +88,7 @@ private:
     int integerQuery(const QString &statement);
     void migrateTo_1();
     void setUserVersion(int userVersion);
+    void removeAllTabs();
 
     QSqlQuery prepare(const QString &statement);
     bool execute(QSqlQuery &query);

--- a/src/declarativetabmodel.cpp
+++ b/src/declarativetabmodel.cpp
@@ -313,12 +313,6 @@ void DeclarativeTabModel::removeTab(int tabId, const QString &thumbnail, int ind
 
     emit countChanged();
     emit tabClosed(tabId);
-
-    // This guarantees that view will reset its internal state
-    // when the last tab got closed.
-    if (m_tabs.isEmpty()) {
-        emit tabsCleared();
-    }
 }
 
 int DeclarativeTabModel::findTabIndex(int tabId) const

--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -87,7 +87,6 @@ signals:
     // only for testing purposes.
     void tabAdded(int tabId);
     void tabClosed(int tabId);
-    void tabsCleared();
     void nextTabIdChanged();
     void loadedChanged();
     void waitingForNewTabChanged();

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -639,11 +639,6 @@ void DeclarativeWebContainer::releasePage(int tabId, bool virtualize)
         m_webPages->release(tabId, virtualize);
         // Successfully destroyed. Emit relevant property changes.
         if (!m_webPage || m_model->count() == 0) {
-            if (m_tabId != 0) {
-                m_tabId = 0;
-                emit tabIdChanged();
-            }
-
             if (m_canGoBack) {
                 m_canGoBack = false;
                 emit canGoBackChanged();
@@ -657,6 +652,11 @@ void DeclarativeWebContainer::releasePage(int tabId, bool virtualize)
             emit contentItemChanged();
             updateUrl("");
             updateTitle("");
+
+            if (m_tabId != 0) {
+                m_tabId = 0;
+                emit tabIdChanged();
+            }
 
             emit loadingChanged();
             setLoadProgress(0);

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -146,7 +146,6 @@ void DeclarativeWebContainer::setTabModel(DeclarativeTabModel *model)
             connect(m_model, SIGNAL(activeTabChanged(int,int,bool)), this, SLOT(onActiveTabChanged(int,int,bool)));
             connect(m_model, SIGNAL(loadedChanged()), this, SLOT(initialize()));
             connect(m_model, SIGNAL(tabClosed(int)), this, SLOT(releasePage(int)));
-            connect(m_model, SIGNAL(tabsCleared()), this, SLOT(onTabsCleared()));
             connect(m_model, SIGNAL(newTabRequested(QString,QString,int)), this, SLOT(onNewTabRequested(QString,QString,int)));
         }
         emit tabModelChanged();
@@ -626,22 +625,6 @@ void DeclarativeWebContainer::onNewTabRequested(QString url, QString title, int 
     }
 }
 
-void DeclarativeWebContainer::onTabsCleared()
-{
-    // Trigger contentItem changed and then reset title, url, and tabId.
-    emit contentItemChanged();
-    updateTitle("");
-    updateUrl("");
-
-    if (m_tabId != 0) {
-        m_tabId = 0;
-        emit tabIdChanged();
-    }
-
-    emit loadingChanged();
-    setLoadProgress(0);
-}
-
 int DeclarativeWebContainer::parentTabId(int tabId) const
 {
     if (m_webPages) {
@@ -655,8 +638,12 @@ void DeclarativeWebContainer::releasePage(int tabId, bool virtualize)
     if (m_webPages) {
         m_webPages->release(tabId, virtualize);
         // Successfully destroyed. Emit relevant property changes.
-        if (!m_webPage) {
-            m_tabId = 0;
+        if (!m_webPage || m_model->count() == 0) {
+            if (m_tabId != 0) {
+                m_tabId = 0;
+                emit tabIdChanged();
+            }
+
             if (m_canGoBack) {
                 m_canGoBack = false;
                 emit canGoBackChanged();
@@ -670,7 +657,9 @@ void DeclarativeWebContainer::releasePage(int tabId, bool virtualize)
             emit contentItemChanged();
             updateUrl("");
             updateTitle("");
-            emit tabIdChanged();
+
+            emit loadingChanged();
+            setLoadProgress(0);
         }
     }
 }

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -163,7 +163,6 @@ private slots:
     void onActiveTabChanged(int oldTabId, int activeTabId, bool loadActiveTab);
     void onDownloadStarted();
     void onNewTabRequested(QString url, QString title, int parentId);
-    void onTabsCleared();
     void releasePage(int tabId, bool virtualize = false);
     void closeWindow();
     void onPageUrlChanged();

--- a/src/persistenttabmodel.cpp
+++ b/src/persistenttabmodel.cpp
@@ -37,10 +37,10 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
     beginResetModel();
     int oldCount = count();
 
-    if (tabs.isEmpty()) {
-        clear();
-    } else {
-        m_tabs.clear();
+    // Clear always previous tabs
+    clear();
+
+    if (tabs.count() > 0) {
         m_tabs = tabs;
         QString activeTabId = DBManager::instance()->getSetting("activeTabId");
         bool ok = false;

--- a/src/persistenttabmodel.cpp
+++ b/src/persistenttabmodel.cpp
@@ -36,10 +36,12 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
 {
     beginResetModel();
     int oldCount = count();
-    m_tabs.clear();
-    m_tabs = tabs;
 
-    if (m_tabs.count() > 0) {
+    if (tabs.isEmpty()) {
+        clear();
+    } else {
+        m_tabs.clear();
+        m_tabs = tabs;
         QString activeTabId = DBManager::instance()->getSetting("activeTabId");
         bool ok = false;
         int tabId = activeTabId.toInt(&ok);
@@ -51,8 +53,6 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
             m_activeTab = m_tabs[0];
         }
         emit activeTabIndexChanged();
-    } else {
-        emit tabsCleared();
     }
 
     endResetModel();

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -610,11 +610,14 @@ void tst_webview::forwardBackwardNavigation()
 
 void tst_webview::clear()
 {
-    QSignalSpy tabsCleared(tabModel, SIGNAL(tabsCleared()));
+    QSignalSpy tabClosed(tabModel, SIGNAL(tabClosed(int)));
     historyModel->clear();
     tabModel->clear();
     QTest::qWait(1000);
-    waitSignals(tabsCleared, 1);
+    waitSignals(tabClosed, 7);
+
+    // From the previous case there should be 7 tabs to close
+    QCOMPARE(tabClosed.count(), 7);
     QVERIFY(historyModel->rowCount() == 0);
     QVERIFY(webContainer->m_webPages->count() == 0);
     QVERIFY(webContainer->m_webPages->m_activePages.count() == 0);


### PR DESCRIPTION
The slot DeclarativeWebContainer::onTabsCleared() is redundant as
for every deleted webview DeclarativeWebContainer::releasePage() is
called and in this method we can do the same resets upon emptying
the current tabs model (DeclarativeWebContainer::m_model).

Since DeclarativeWebContainer::onTabsCleared() is the only client
for DeclarativeTabModel::tabsCleared() signal the signal has been
removed as well.

Also DBManager::removeAllTabs() has been removed as unused.