### PR TITLE
[sailfish-browser] Fix rotation when overlays are opened over the browse...

### DIFF
--- a/src/browser.qml
+++ b/src/browser.qml
@@ -28,7 +28,7 @@ ApplicationWindow {
         }
     }
 
-    allowedOrientations: WebUtils.firstUseDone && Qt.application.active ? defaultAllowedOrientations : Orientation.Portrait
+    allowedOrientations: defaultAllowedOrientations
     _defaultPageOrientations: Orientation.All
     cover: null
     initialPage: Component {


### PR DESCRIPTION
...r.

Overwrite the window page orientation so the orientation reported to the
compositor isn't forced to portrait when the window isn't active.

@rainemak 