### PR TITLE
[sailfish-browser] While activating a tab do not use page's title and url

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -46,6 +46,7 @@ DeclarativeWebContainer::DeclarativeWebContainer(QQuickItem *parent)
     , m_popupActive(false)
     , m_portrait(true)
     , m_fullScreenMode(false)
+    , m_activatingTab(false)
     , m_fullScreenHeight(0.0)
     , m_inputPanelVisible(false)
     , m_inputPanelHeight(0.0)
@@ -117,6 +118,7 @@ void DeclarativeWebContainer::setWebPage(DeclarativeWebPage *webPage)
         } else {
             m_tabId = 0;
         }
+        m_activatingTab = false;
 
         emit contentItemChanged();
         emit tabIdChanged();
@@ -283,12 +285,14 @@ int DeclarativeWebContainer::tabId() const
 
 QString DeclarativeWebContainer::title() const
 {
-    return m_webPage ? m_webPage->title() : m_title;
+    // While switching tab do not return title of the previous page.
+    return m_webPage && !m_activatingTab ? m_webPage->title() : m_title;
 }
 
 QString DeclarativeWebContainer::url() const
 {
-    return m_webPage ? m_webPage->url().toString() : m_url;
+    // While switching tab do not return url of the previous page.
+    return m_webPage && !m_activatingTab ? m_webPage->url().toString() : m_url;
 }
 
 bool DeclarativeWebContainer::isActiveTab(int tabId)
@@ -710,6 +714,7 @@ void DeclarativeWebContainer::onPageUrlChanged()
         webPage->setBackForwardNavigation(false);
 
         if (activeTab && webPage == m_webPage) {
+            m_activatingTab = false;
             updateUrl(url);
 
             if (!initialLoad && !wasBackForwardNavigation) {
@@ -731,6 +736,7 @@ void DeclarativeWebContainer::onPageTitleChanged()
         m_model->updateTitle(tabId, activeTab, url, title);
 
         if (activeTab && webPage == m_webPage) {
+            m_activatingTab = false;
             updateTitle(title);
         }
     }
@@ -765,6 +771,8 @@ void DeclarativeWebContainer::setActiveTabData()
 #endif
 
     updateNavigationStatus(tab);
+    m_activatingTab = m_tabId != tab.tabId() || tab.url() != url() || tab.title() != title();
+
     updateUrl(tab.url());
     updateTitle(tab.title());
 

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -203,6 +203,7 @@ private:
     bool m_popupActive;
     bool m_portrait;
     bool m_fullScreenMode;
+    bool m_activatingTab;
     qreal m_fullScreenHeight;
     bool m_inputPanelVisible;
     qreal m_inputPanelHeight;


### PR DESCRIPTION
While we are in process of activating a tab, do not pass title and url
of the active page through as it is already out dated. Previously this
caused an issue when cached url / title (m_url / m_title) got updated
and matching change signals were emitted right after new tab data became
available. When QML side tried to read updated value we returned
the value of the previous page.

As all title and url updates are done through updateTitle and updateUrl, when setWebPage
got called m_title and m_url were already up-to-date. Thus, change signals
didn't get emitted again.