### PR TITLE
[sailfish-browser] Limit history size to 2000 entries

### DIFF
--- a/src/dbworker.cpp
+++ b/src/dbworker.cpp
@@ -31,6 +31,8 @@
 #define QUOTE(arg) #arg
 #define STR(arg) QUOTE(arg)
 
+#define MAX_BROWSER_HISTORY_SIZE 2000
+
 static const char * const create_table_tab =
         "CREATE TABLE tab (tab_id INTEGER PRIMARY KEY,\n"
         "tab_history_id INTEGER\n"
@@ -106,6 +108,13 @@ void DBWorker::init()
         for (int i = 0; i < db_schema_count; ++i) {
             QSqlQuery query = prepare(db_schema[i]);
             execute(query);
+        }
+    } else {
+        // Limit history size to 2000 entries
+        QSqlQuery cleanupHistory = prepare("DELETE FROM browser_history WHERE id NOT IN (SELECT id from browser_history"\
+                                           " ORDER BY date DESC LIMIT " STR(MAX_BROWSER_HISTORY_SIZE) ");");
+        if (!execute(cleanupHistory)) {
+            qWarning() << "Failed to clear older history items";
         }
     }
 


### PR DESCRIPTION
Fixes #199