### PR TITLE
[sailfish-browser] Don't instantiate an abstract class. JB#27654

### DIFF
--- a/src/pages/components/BrowserContextMenu.qml
+++ b/src/pages/components/BrowserContextMenu.qml
@@ -20,7 +20,7 @@ Rectangle {
     property string linkTitle
     property string imageSrc
     property string contentType
-    property TabModel tabModel
+    property var tabModel
     property PageStack pageStack
     property WebView webView
 


### PR DESCRIPTION
For some reason QML thinks that a property declaration is the same as class instantiation. And since TabModel is an abstract class QML fails to load BrowserContextMenu.qml.