### PR TITLE
[sailfish-browser] Allow adding new search engines

### DIFF
--- a/common/common.pri
+++ b/common/common.pri
@@ -1,0 +1,19 @@
+isEmpty(EMBEDLITE_CONTENT_PATH) {
+  DEFINES += EMBEDLITE_CONTENT_PATH=\"\\\"/usr/lib/mozembedlite/chrome/embedlite/content/\\\"\"
+} else {
+  DEFINES += EMBEDLITE_CONTENT_PATH=\"\\\"$$EMBEDLITE_CONTENT_PATH\\\"\"
+}
+
+isEmpty(USER_OPENSEARCH_PATH) {
+  DEFINES += USER_OPENSEARCH_PATH=\"\\\"/.local/share/org.sailfishos/sailfish-browser/searchEngines/\\\"\"
+} else {
+  DEFINES += USER_OPENSEARCH_PATH=\"\\\"$$USER_OPENSEARCH_PATH\\\"\"
+}
+
+# C++ sources
+SOURCES += \
+    $$PWD/opensearchconfigs.cpp
+
+# C++ headers
+HEADERS += \
+    $$PWD/opensearchconfigs.h

--- a/common/opensearchconfigs.cpp
+++ b/common/opensearchconfigs.cpp
@@ -1,0 +1,78 @@
+/****************************************************************************
+**
+** Copyright (C) 2015
+** Contact: Siteshwar Vashisht <siteshwar@gmail.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QXmlStreamReader>
+#include "opensearchconfigs.h"
+
+OpenSearchConfigs *OpenSearchConfigs::openSearchConfigs = 0;
+
+OpenSearchConfigs::OpenSearchConfigs(QObject *parent):QObject(parent)
+{
+    m_openSearchPathList << QString(EMBEDLITE_CONTENT_PATH);
+    m_openSearchPathList << QDir::homePath() + USER_OPENSEARCH_PATH;
+}
+
+const StringMap OpenSearchConfigs::parseOpenSearchConfigs()
+{
+    StringMap configs;
+
+    foreach(QString openSearchPath, m_openSearchPathList) {
+        QDir configDir(openSearchPath);
+        configDir.setSorting(QDir::Name);
+
+        foreach (QString fileName, configDir.entryList(QStringList("*.xml"))) {
+            QFile xmlFile(openSearchPath + fileName);
+            xmlFile.open(QIODevice::ReadOnly | QIODevice::Text);
+            QXmlStreamReader xml(&xmlFile);
+            QString searchEngine;
+
+            while (!xml.atEnd()) {
+                xml.readNext();
+                if (xml.isStartElement() && xml.name() == "ShortName") {
+                    xml.readNext();
+                    if (xml.isCharacters()) {
+                        searchEngine = xml.text().toString();
+                    }
+                }
+            }
+
+            if (!xml.hasError()) {
+                configs.insert(searchEngine, openSearchPath + fileName);
+            }
+
+            xmlFile.close();
+        }
+    }
+    return configs;
+}
+
+OpenSearchConfigs* OpenSearchConfigs::getInstance()
+{
+    if (!openSearchConfigs) {
+        openSearchConfigs = new OpenSearchConfigs();
+    }
+    return openSearchConfigs;
+}
+
+const QStringList OpenSearchConfigs::getSearchEngineList()
+{
+    // Return names of search engines
+    return getInstance()->parseOpenSearchConfigs().keys();
+}
+
+const StringMap OpenSearchConfigs::getAvailableOpenSearchConfigs()
+{
+    return getInstance()->parseOpenSearchConfigs();
+}

--- a/common/opensearchconfigs.h
+++ b/common/opensearchconfigs.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+**
+** Copyright (C) 2015
+** Contact: Siteshwar Vashisht <siteshwar@gmail.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+#include <QStringList>
+#include <QMap>
+
+typedef QMap<QString, QString> StringMap;
+
+class OpenSearchConfigs : public QObject {
+
+public:
+    static const StringMap getAvailableOpenSearchConfigs();
+    static const QStringList getSearchEngineList();
+
+private:
+    QStringList m_openSearchPathList;
+
+    static OpenSearchConfigs* getInstance();
+    static OpenSearchConfigs *openSearchConfigs;
+    const StringMap parseOpenSearchConfigs();
+    const QStringList parseSearchEngineList();
+    OpenSearchConfigs(QObject* parent=0);
+};

--- a/settings/browsersettings.cpp
+++ b/settings/browsersettings.cpp
@@ -9,11 +9,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <QDir>
-#include <QXmlStreamReader>
+#include "opensearchconfigs.h"
 #include "browsersettings.h"
-
-static const QString openSearchPath("/usr/lib/mozembedlite/chrome/embedlite/content/");
 
 BrowserSettings::BrowserSettings(QObject *parent)
     : QObject(parent)
@@ -26,32 +23,5 @@ BrowserSettings::~BrowserSettings()
 
 const QStringList BrowserSettings::getSearchEngineList() const
 {
-    QStringList engineList;
-    QDir configDir(openSearchPath);
-    configDir.setSorting(QDir::Name);
-
-    foreach (QString fileName, configDir.entryList(QStringList("*.xml"))) {
-        QFile xmlFile(openSearchPath + fileName);
-        xmlFile.open(QIODevice::ReadOnly | QIODevice::Text);
-        QXmlStreamReader xml(&xmlFile);
-        QString searchEngine;
-
-        while (!xml.atEnd()) {
-            xml.readNext();
-            if (xml.isStartElement() && xml.name() == "ShortName") {
-                xml.readNext();
-                if (xml.isCharacters()) {
-                    searchEngine = xml.text().toString();
-                }
-            }
-        }
-
-        if (!xml.hasError()) {
-            engineList.append(searchEngine);
-        }
-
-        xmlFile.close();
-    }
-
-    return engineList;
+    return OpenSearchConfigs::getSearchEngineList();
 }

--- a/settings/settings.pro
+++ b/settings/settings.pro
@@ -8,9 +8,13 @@ TARGETPATH = $$[QT_INSTALL_QML]/$$MODULENAME
 QT += qml
 CONFIG += plugin
 
+INCLUDEPATH += "../common/"
+
 import.files = qmldir
 import.path = $$TARGETPATH
 target.path = $$TARGETPATH
+
+include(../common/common.pri)
 
 SOURCES += \
         declarative_plugin.cpp \

--- a/src/src.pro
+++ b/src/src.pro
@@ -26,6 +26,8 @@ isEmpty(USE_RESOURCES) {
 
 PKGCONFIG +=  nemotransferengine-qt5 mlite5
 
+INCLUDEPATH += "../common/"
+
 packagesExist(qdeclarative5-boostable) {
     message("Building with qdeclarative-boostable support")
     DEFINES += HAS_BOOSTER
@@ -55,6 +57,7 @@ EE_QM = $$OUT_PWD/sailfish-browser_eng_en.qm
 include(../translations/translations.pri)
 include(history.pri)
 include(bookmarks.pri)
+include(../common/common.pri)
 
 # C++ sources
 SOURCES += \


### PR DESCRIPTION
Fixes #254
Read opensearch descriptors from '/home/nemo/.local/share/org.sailfishos/sailfish-browser/searchEngines/'