### PR TITLE
[sailfish-browser] Move MOZ_LAYERS_PREFER_OFFSCREEN to browser side. Contributes to JB#27561

### DIFF
--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -48,6 +48,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 {
     setenv("USE_ASYNC", "1", 1);
     setenv("USE_NEMO_GSTREAMER", "1", 1);
+    setenv("MOZ_LAYERS_PREFER_OFFSCREEN", "1", 1);
 
     // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=929879
     setenv("LC_NUMERIC", "C", 1);


### PR DESCRIPTION
Intermediate step so that MOZ_LAYERS_PREFER_OFFSCREEN can be removed
from embedlite with breaking things.