### PR TITLE
[sailfish-browser] Fix favorite grid overlay edges for bigger screens.

### DIFF
--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -329,13 +329,15 @@ PanelBackground {
             }
 
             // Below the HistoryList and FavoriteGrid to let dragging to work
-            // when finding from the page
+            // when finding from the page active or favorite grid enabled (at top).
+            // On large screens favorite grid is not covering fullscreen. Thus,
+            // this needs to be enabled so that overlay can be dragged from edges.
             MouseArea {
                 anchors {
                     fill: historyList
                     topMargin: searchField.height
                 }
-                enabled: toolBar.findInPageActive
+                enabled: toolBar.findInPageActive || favoriteGrid.enabled
 
                 ViewPlaceholder {
                     // The parent is a sibling of the historyList. Hence,
@@ -344,7 +346,7 @@ PanelBackground {
                     x: (historyList.width - width) / 2
                     y: historyList.originY + (historyList.height - height) / 2
 
-                    enabled: parent.enabled && searchField.text
+                    enabled: toolBar.findInPageActive && searchField.text
 
                     //: View placeholder text for find-in-page search.
                     //% "Press enter to search"


### PR DESCRIPTION
Closing the favorite grid overlay from the space between right edge of screen and right-most icon is not allowing dragging gesture, similar at the left edge.

