### PR TITLE
[sailfish-browser] Fix browser cover switching problems. Fixes JB#30162

### DIFF
--- a/src/declarativewebutils.cpp
+++ b/src/declarativewebutils.cpp
@@ -436,6 +436,8 @@ void DeclarativeWebUtils::setRenderingPreferences()
     // Use external Qt window for rendering content
     mozContext->setPref(QString("gfx.compositor.external-window"), QVariant(true));
     mozContext->setPref(QString("gfx.compositor.clear-context"), QVariant(false));
+    mozContext->setPref(QString("embedlite.compositor.external_gl_context"), QVariant(true));
+    mozContext->setPref(QString("embedlite.compositor.request_external_gl_context_early"), QVariant(true));
 
     // Enable progressive painting.
     mozContext->setPref(QString("layers.progressive-paint"), QVariant(true));


### PR DESCRIPTION
This patchset utilizes the new prefs added in https://github.com/nemomobile-packages/gecko-dev/pull/31 to fix our current problems with browser cover switching.