### PR TITLE
[sailfish-browser] Open content dimmer when private browsing mode changed. Fixes JB#30226

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -191,6 +191,7 @@ void DeclarativeWebContainer::setTabModel(DeclarativeTabModel *model)
         if (m_model) {
             disconnect(m_model, 0, 0, 0);
             oldCount = m_model->count();
+            m_model->setWaitingForNewTab(false);
         }
 
         m_model = model;
@@ -205,6 +206,11 @@ void DeclarativeWebContainer::setTabModel(DeclarativeTabModel *model)
         emit tabModelChanged();
         if (oldCount != newCount) {
             emit m_model->countChanged();
+        }
+
+        // Set waiting for a tab.
+        if (m_model) {
+            m_model->setWaitingForNewTab(true);
         }
     }
 }

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -63,14 +63,17 @@ Background {
         overlayAnimator.showOverlay(action === PageStackAction.Immediate)
     }
 
-    function dismiss() {
+    function dismiss(canShowChrome) {
         toolBar.resetFind()
         if (webView.contentItem && webView.contentItem.fullscreen) {
             // Web content is in fullscreen mode thus we don't show chrome
             overlay.animator.updateState("fullscreenWebPage")
-        } else {
+        } else if (canShowChrome) {
             overlay.animator.showChrome()
+        } else {
+            overlay.animator.hide()
         }
+        searchField.enteringNewTabUrl = false
     }
 
     y: webView.fullscreenHeight - toolBar.toolsHeight
@@ -165,7 +168,7 @@ Background {
                 if (overlay.y < dragThreshold) {
                     overlayAnimator.showOverlay(false)
                 } else {
-                    dismiss()
+                    dismiss(true)
                 }
             } else {
                 // Store previous end state
@@ -426,7 +429,9 @@ Background {
                         overlay.enterNewTabUrl(PageStackAction.Immediate)
                     } else if (!overlayAnimator.atBottom) {
                         // Hide overlay while switching to non-empty tabmodel
-                        dismiss()
+                        // Dismiss overlay so that chrome gets hidden.
+                        // Chrome is animated back when BrowserPage's activates.
+                        dismiss(false)
                     }
                 }
 

--- a/src/pages/components/OverlayAnimator.qml
+++ b/src/pages/components/OverlayAnimator.qml
@@ -110,18 +110,6 @@ Item {
         }
     }
 
-    Connections {
-        target: webView && webView.tabModel || null
-        ignoreUnknownSignals: true
-        onCountChanged: {
-            if (webView.completed && webView.tabModel.count === 0) {
-                updateState("fullscreenOverlay")
-            }
-
-            window.setBrowserCover(webView.tabModel)
-        }
-    }
-
     states: [
         State {
             name: "fullscreenWebPage"


### PR DESCRIPTION
Fix revealed following problems that needed to fixed in context of
this PR.

1) When browsing mode is changed, wait for a tab. Waiting is cleared from the
old model.

2) Share some logic for both model change and model count change for showing
overlay and updating the cover.

3) When switching from normal browsing to private browsing (not tabs) and back
to normal browsing enteringNewTabUrl was left to true. This made browser
page activation failing to show chrome. When the overlay is dismissed,
set the enteringNewTabUrl to false.

4) When changing from normal browsing to private browsing, the overlay was
dismissed so that chrome was revealed. This broken chrome showing animation.
So, when switching between browsing modes and overlay is dismissed it is
dismissed so that chrome is hidden. Thus, allowing browser page
activation to animate the chrome back to visible.