### PR TITLE
[sailfish-browser] Use new paint throttling functionality. Fixes JB#30183

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -79,6 +79,7 @@ WebContainer {
 
             fullscreenHeight: container.fullscreenHeight
             toolbarHeight: container.toolbarHeight
+            throttlePainting: !foreground && !resourceController.videoActive
 
             enabled: webView.enabled
 


### PR DESCRIPTION
This should limit the number of content updates/repaints performed by
gecko layout engine when the browser is minimized and no video content
is being played. This should significantly lower browser CPU usage when
it's swiped to the application switcher. The downside is the low fps
mode will also be enabled for pages with non-video animated content
(canvas, webgl, css animations, animated gifs etc). Currently we have no
means of recognizing pages with such content.