### PR TITLE
[sailfish-browser] Add org.sailfishos.browser.ui service for UI-specific calls. Contributes to JB#30203

### DIFF
--- a/org.sailfishos.browser.service
+++ b/org.sailfishos.browser.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser
-Exec=/usr/bin/invoker -s --type=browser --desktop-file=sailfish-browser.desktop -G /usr/bin/sailfish-browser
+Exec=/usr/bin/invoker -s --type=browser -G /usr/bin/sailfish-browser

--- a/org.sailfishos.browser.ui.service
+++ b/org.sailfishos.browser.ui.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.sailfishos.browser.ui
+Exec=/usr/bin/invoker -s --type=browser --desktop-file=sailfish-browser.desktop -G /usr/bin/sailfish-browser

--- a/sailfish-browser.pro
+++ b/sailfish-browser.pro
@@ -5,7 +5,8 @@ SUBDIRS += src tests settings
 desktop.files = sailfish-browser.desktop open-url.desktop
 desktop.path = /usr/share/applications
 
-dbus_service.files = org.sailfishos.browser.service
+dbus_service.files = org.sailfishos.browser.service \
+                     org.sailfishos.browser.ui.service
 dbus_service.path = /usr/share/dbus-1/services
 
 chrome_scripts.files = chrome/*.js

--- a/src/browserservice.cpp
+++ b/src/browserservice.cpp
@@ -14,6 +14,7 @@
 #include <QDBusConnection>
 
 #define SAILFISH_BROWSER_SERVICE QLatin1String("org.sailfishos.browser")
+#define SAILFISH_BROWSER_UI_SERVICE QLatin1String("org.sailfishos.browser.ui")
 
 BrowserService::BrowserService(QObject * parent)
     : QObject(parent)
@@ -64,4 +65,41 @@ void BrowserService::restartTransfer(int transferId)
 void BrowserService::dumpMemoryInfo(QString fileName)
 {
     emit dumpMemoryInfoRequested(fileName);
+}
+
+
+BrowserUIService::BrowserUIService(QObject * parent)
+    : QObject(parent)
+    , m_registered(true)
+{
+    new UIServiceDBusAdaptor(this);
+    QDBusConnection connection = QDBusConnection::sessionBus();
+    if(!connection.registerService(SAILFISH_BROWSER_UI_SERVICE) ||
+            !connection.registerObject("/", this)) {
+        m_registered = false;
+    }
+}
+
+bool BrowserUIService::registered() const
+{
+    return m_registered;
+}
+
+QString BrowserUIService::serviceName() const
+{
+    return SAILFISH_BROWSER_UI_SERVICE;
+}
+
+void BrowserUIService::openUrl(QStringList args)
+{
+    if(args.count() > 0) {
+        emit openUrlRequested(args.first());
+    } else {
+        emit openUrlRequested(QString());
+    }
+}
+
+void BrowserUIService::activateNewTabView()
+{
+    emit activateNewTabViewRequested();
 }

--- a/src/browserservice.h
+++ b/src/browserservice.h
@@ -24,8 +24,12 @@ public:
     QString serviceName() const;
 
 public slots:
+    // these two calls are kept in this service for compatibility
+    // but any calls that require the UI to be shown should be added to
+    // the BrowserUIService service instead
     void openUrl(QStringList args);
     void activateNewTabView();
+
     void cancelTransfer(int transferId);
     void restartTransfer(int transferId);
     void dumpMemoryInfo(QString fileName);
@@ -36,6 +40,26 @@ signals:
     void cancelTransferRequested(int transferId);
     void restartTransferRequested(int transferId);
     void dumpMemoryInfoRequested(QString fileName);
+
+private:
+    bool m_registered;
+};
+
+class BrowserUIService : public QObject
+{
+    Q_OBJECT
+public:
+    BrowserUIService(QObject * parent);
+    bool registered() const;
+    QString serviceName() const;
+
+public slots:
+    void openUrl(QStringList args);
+    void activateNewTabView();
+
+signals:
+    void openUrlRequested(QString url);
+    void activateNewTabViewRequested();
 
 private:
     bool m_registered;

--- a/src/dbusadaptor.cpp
+++ b/src/dbusadaptor.cpp
@@ -41,3 +41,20 @@ void DBusAdaptor::dumpMemoryInfo(QString fileName)
 {
     m_BrowserService->dumpMemoryInfo(fileName);
 }
+
+
+UIServiceDBusAdaptor::UIServiceDBusAdaptor(BrowserUIService *browserService)
+    : QDBusAbstractAdaptor(browserService)
+    , m_BrowserService(browserService)
+{
+}
+
+void UIServiceDBusAdaptor::openUrl(QStringList args)
+{
+    m_BrowserService->openUrl(args);
+}
+
+void UIServiceDBusAdaptor::activateNewTabView()
+{
+    m_BrowserService->activateNewTabView();
+}

--- a/src/dbusadaptor.h
+++ b/src/dbusadaptor.h
@@ -24,14 +24,34 @@ public:
     DBusAdaptor(BrowserService *browserService);
 
 public slots:
+    // these two calls are kept in this service for compatibility
+    // but any calls that require the UI to be shown should be added to
+    // the UIServiceDBusAdaptor org.sailfishos.browser.ui service instead
     void openUrl(QStringList args);
     void activateNewTabView();
+
     void cancelTransfer(int transferId);
     void restartTransfer(int transferId);
     void dumpMemoryInfo(QString fileName);
 
 private:
     BrowserService *m_BrowserService;
+};
+
+class UIServiceDBusAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.sailfishos.browser.ui")
+
+public:
+    UIServiceDBusAdaptor(BrowserUIService *browserService);
+
+public slots:
+    void openUrl(QStringList args);
+    void activateNewTabView();
+
+private:
+    BrowserUIService *m_BrowserService;
 };
 
 #endif // DBUSADAPTOR_H

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -110,6 +110,8 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         return 0;
     }
 
+    BrowserUIService *uiService = new BrowserUIService(app.data());
+
     QString translationPath("/usr/share/translations/");
     QTranslator engineeringEnglish;
     engineeringEnglish.load("sailfish-browser_eng_en", translationPath);
@@ -152,6 +154,11 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     utils->connect(service, SIGNAL(dumpMemoryInfoRequested(QString)),
                    utils, SLOT(handleDumpMemoryInfoRequest(QString)));
 
+    utils->connect(uiService, SIGNAL(openUrlRequested(QString)),
+                   utils, SIGNAL(openUrlRequested(QString)));
+    utils->connect(uiService, SIGNAL(activateNewTabViewRequested()),
+                   utils, SIGNAL(activateNewTabViewRequested()));
+
     utils->clearStartupCacheIfNeeded();
     view->rootContext()->setContextProperty("WebUtils", utils);
     view->rootContext()->setContextProperty("MozContext", QMozContext::GetInstance());
@@ -168,6 +175,11 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     QObject::connect(service, SIGNAL(openUrlRequested(QString)),
                      clsEventFilter, SLOT(cancelStopApplication()));
     QObject::connect(service, SIGNAL(activateNewTabViewRequested()),
+                     clsEventFilter, SLOT(cancelStopApplication()));
+
+    QObject::connect(uiService, SIGNAL(openUrlRequested(QString)),
+                     clsEventFilter, SLOT(cancelStopApplication()));
+    QObject::connect(uiService, SIGNAL(activateNewTabViewRequested()),
                      clsEventFilter, SLOT(cancelStopApplication()));
 
 #ifdef USE_RESOURCES


### PR DESCRIPTION
…fic calls. Contributes to JB#30203

Don't set --desktop-file=sailfish-browser.desktop in
org.sailfishos.browser.service as this means the busy-cover is shown
for non-UI calls as well as UI-specific calls. Instead, add a
separate org.sailfishos.browser.ui.service that provides the UI
functionality (openUrl() and activateNewTab()) and sets the
--desktop-file invoker argument.