### PR TITLE
Minor cleanups

### DIFF
--- a/src/dbmanager.cpp
+++ b/src/dbmanager.cpp
@@ -38,7 +38,6 @@ DBManager::DBManager(QObject *parent)
     connect(worker, SIGNAL(tabsAvailable(QList<Tab>)), this, SLOT(tabListAvailable(QList<Tab>)));
     connect(worker, SIGNAL(historyAvailable(QList<Link>)), this, SIGNAL(historyAvailable(QList<Link>)));
     connect(worker, SIGNAL(tabHistoryAvailable(int,QList<Link>)), this, SIGNAL(tabHistoryAvailable(int,QList<Link>)));
-    connect(worker, SIGNAL(tabAvailable(Tab)), this, SIGNAL(tabAvailable(Tab)));
     connect(worker, SIGNAL(titleChanged(int,int,QString,QString)), this, SIGNAL(titleChanged(int,int,QString,QString)));
     connect(worker, SIGNAL(thumbPathChanged(int,QString)), this, SIGNAL(thumbPathChanged(int,QString)));
     connect(worker, SIGNAL(nextLinkId(int)), this, SLOT(updateNextLinkId(int)));
@@ -83,12 +82,6 @@ int DBManager::createLink(int tabId, QString url, QString title)
     }
 
     return linkId;
-}
-
-void DBManager::getTab(int tabId)
-{
-    QMetaObject::invokeMethod(worker, "getTab", Qt::QueuedConnection,
-                              Q_ARG(int, tabId));
 }
 
 void DBManager::navigateTo(int tabId, QString url, QString title, QString path)

--- a/src/dbmanager.h
+++ b/src/dbmanager.h
@@ -29,7 +29,6 @@ public:
 
     int createTab();
     int createLink(int tabId, QString url, QString title);
-    void getTab(int tabId);
     void getAllTabs();
     void removeTab(int tabId);
     void navigateTo(int tabId, QString url, QString title = "", QString path = "");
@@ -54,7 +53,6 @@ public slots:
     void tabListAvailable(QList<Tab> tabs);
 
 signals:
-    void tabAvailable(Tab tab);
     void tabsAvailable(QList<Tab> tab);
     void historyAvailable(QList<Link> links);
     void tabHistoryAvailable(int tabId, QList<Link> links);

--- a/src/dbworker.cpp
+++ b/src/dbworker.cpp
@@ -274,12 +274,10 @@ Tab DBWorker::getTabData(int tabId, int historyId)
     }
 
     Link link = getLinkFromTabHistory(hId);
-    int nextId = getNextLinkIdFromTabHistory(hId);
-    int previousId = getPreviousLinkIdFromTabHistory(hId);
 #if DEBUG_LOGS
-    qDebug() << tabId << historyId << "next link id:" << nextId << "previous link id:" << previousId << link.linkId()<< link.title() << link.url();
+    qDebug() << tabId << historyId << link.linkId()<< link.title() << link.url();
 #endif
-    return Tab(tabId, link, nextId, previousId);
+    return Tab(tabId, link);
 }
 
 void DBWorker::removeTab(int tabId)
@@ -484,19 +482,6 @@ Link DBWorker::getLinkFromTabHistory(int tabHistoryId)
     return Link();
 }
 
-int DBWorker::getPreviousLinkIdFromTabHistory(int tabHistoryId)
-{
-    QSqlQuery query = prepare("SELECT link_id FROM tab_history WHERE tab_id = (SELECT tab_id FROM tab_history WHERE id = ?) AND id < ? ORDER BY id DESC LIMIT 1;");
-    query.bindValue(0, tabHistoryId);
-    query.bindValue(1, tabHistoryId);
-    if (execute(query)) {
-        if (query.first()) {
-            return query.value(0).toInt();
-        }
-    }
-    return 0;
-}
-
 void DBWorker::clearDeprecatedTabHistory(int tabId, int currentLinkId) {
 #if DEBUG_LOGS
     qDebug() << "tab id:" << tabId << "current link id:" << currentLinkId;
@@ -505,19 +490,6 @@ void DBWorker::clearDeprecatedTabHistory(int tabId, int currentLinkId) {
     query.bindValue(0, tabId);
     query.bindValue(1, currentLinkId);
     execute(query);
-}
-
-int DBWorker::getNextLinkIdFromTabHistory(int tabHistoryId)
-{
-    QSqlQuery query = prepare("SELECT link_id FROM tab_history WHERE tab_id = (SELECT tab_id FROM tab_history WHERE id = ?) AND id > ? ORDER BY id ASC LIMIT 1;");
-    query.bindValue(0, tabHistoryId);
-    query.bindValue(1, tabHistoryId);
-    if (execute(query)) {
-        if (query.first()) {
-            return query.value(0).toInt();
-        }
-    }
-    return 0;
 }
 
 // Adds url to table history if it is not already there

--- a/src/dbworker.cpp
+++ b/src/dbworker.cpp
@@ -330,23 +330,6 @@ void DBWorker::removeAllTabs()
     }
 }
 
-void DBWorker::getTab(int tabId)
-{
-    QSqlQuery query = prepare("SELECT tab_id, tab_history_id FROM tab WHERE tab_id = ?;");
-    query.bindValue(0, tabId);
-    if (!execute(query)) {
-        return;
-    }
-
-    if (query.first()) {
-#if DEBUG_LOGS
-        Tab tab = getTabData(query.value(0).toInt(), query.value(1).toInt());
-        qDebug() << query.value(0).toInt() << query.value(1).toInt() << tab.title() << tab.url();
-#endif
-        emit tabAvailable(getTabData(query.value(0).toInt(), query.value(1).toInt()));
-    }
-}
-
 void DBWorker::getAllTabs()
 {
     QList<Tab> tabList;

--- a/src/dbworker.h
+++ b/src/dbworker.h
@@ -38,7 +38,6 @@ public slots:
     void createTab(int tabId);
     int createLink(int tabId, QString url, QString title);
     void removeTab(int tabId);
-    void getTab(int tabId);
     void getAllTabs();
     void navigateTo(int tabId, QString url, QString title, QString path);
     int getMaxTabId();
@@ -58,7 +57,6 @@ public slots:
     void deleteSetting(QString name);
 
 signals:
-    void tabAvailable(Tab tab);
     void tabsAvailable(QList<Tab> tabs);
     void thumbPathChanged(int tabId, QString path);
     void titleChanged(int tabId, int linkId, QString url, QString title);

--- a/src/dbworker.h
+++ b/src/dbworker.h
@@ -73,8 +73,6 @@ private:
     int addToTabHistory(int tabId, int linkId);
     Link getLinkFromTabHistory(int tabHistoryId);
     Link getCurrentLink(int tabId);
-    int getNextLinkIdFromTabHistory(int tabHistoryId);
-    int getPreviousLinkIdFromTabHistory(int tabHistoryId);
     void clearDeprecatedTabHistory(int tabId, int currentLinkId);
     int createLink(QString url, QString title = "", QString thumbPath = "");
     void updateTab(int tabId, int tabHistoryId);

--- a/src/declarativetabmodel.cpp
+++ b/src/declarativetabmodel.cpp
@@ -53,7 +53,7 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title) {
     int tabId = createTab();
     int linkId = createLink(tabId, url, title);
 
-    Tab tab(tabId, Link(linkId, url, "", title), 0, 0);
+    Tab tab(tabId, Link(linkId, url, "", title));
 #if DEBUG_LOGS
     qDebug() << "new tab data:" << &tab;
 #endif
@@ -274,9 +274,6 @@ void DeclarativeTabModel::updateUrl(int tabId, bool activeTab, const QString &ur
         m_tabs[tabIndex].setUrl(url);
 
         if (!initialLoad) {
-            m_tabs[tabIndex].setNextLink(0);
-            int currentLinkId = m_tabs.at(tabIndex).currentLink();
-            m_tabs[tabIndex].setPreviousLink(currentLinkId);
             m_tabs[tabIndex].setCurrentLink(nextLinkId());
             updateDb = true;
         }

--- a/src/declarativewebpage.cpp
+++ b/src/declarativewebpage.cpp
@@ -115,18 +115,18 @@ void DeclarativeWebPage::setContainer(DeclarativeWebContainer *container)
 
 int DeclarativeWebPage::tabId() const
 {
-    return m_tab.tabId();
+    return m_initialTab.tabId();
 }
 
-void DeclarativeWebPage::setTab(const Tab& tab)
+void DeclarativeWebPage::setInitialTab(const Tab& tab)
 {
-    Q_ASSERT(m_tab.tabId() == 0);
+    Q_ASSERT(m_initialTab.tabId() == 0);
 
-    m_tab = tab;
+    m_initialTab = tab;
     emit tabIdChanged();
     connect(DBManager::instance(), SIGNAL(tabHistoryAvailable(int, QList<Link>)),
             this, SLOT(onTabHistoryAvailable(int, QList<Link>)));
-    DBManager::instance()->getTabHistory(m_tab.tabId());
+    DBManager::instance()->getTabHistory(tabId());
 }
 
 void DeclarativeWebPage::onUrlChanged()
@@ -136,9 +136,9 @@ void DeclarativeWebPage::onUrlChanged()
     restoreHistory();
 }
 
-void DeclarativeWebPage::onTabHistoryAvailable(const int& tabId, const QList<Link>& links)
+void DeclarativeWebPage::onTabHistoryAvailable(const int& historyTabId, const QList<Link>& links)
 {
-    if (tabId == m_tab.tabId()) {
+    if (historyTabId == tabId()) {
         m_restoredTabHistory = links;
 
         std::reverse(m_restoredTabHistory.begin(), m_restoredTabHistory.end());
@@ -158,13 +158,13 @@ void DeclarativeWebPage::restoreHistory() {
     int i(0);
     foreach (Link link, m_restoredTabHistory) {
         urls << link.url();
-        if (link.linkId() == m_tab.currentLink()) {
+        if (link.linkId() == m_initialTab.currentLink()) {
             index = i;
-            if (link.url() != m_tab.url()) {
+            if (link.url() != m_initialTab.url()) {
                 // The browser was started with an initial URL as a cmdline parameter -> reset tab history
-                urls << m_tab.url();
+                urls << m_initialTab.url();
                 index++;
-                DBManager::instance()->navigateTo(m_tab.tabId(), m_tab.url(), "", "");
+                DBManager::instance()->navigateTo(tabId(), m_initialTab.url(), "", "");
                 break;
             }
         }
@@ -331,7 +331,7 @@ QString DeclarativeWebPage::saveToFile(QImage image)
     }
 
     // 75% quality jpg produces small and good enough capture.
-    QString path = QString("%1/tab-%2-thumb.jpg").arg(QStandardPaths::writableLocation(QStandardPaths::CacheLocation)).arg(m_tab.tabId());
+    QString path = QString("%1/tab-%2-thumb.jpg").arg(QStandardPaths::writableLocation(QStandardPaths::CacheLocation)).arg(tabId());
     return !allBlack(image) && image.save(path, "jpg", 75) ? path : "";
 }
 

--- a/src/declarativewebpage.h
+++ b/src/declarativewebpage.h
@@ -45,7 +45,7 @@ public:
     void setContainer(DeclarativeWebContainer *container);
 
     int tabId() const;
-    void setTab(const Tab& tab);
+    void setInitialTab(const Tab& tab);
 
     QVariant resurrectedContentRect() const;
     void setResurrectedContentRect(QVariant resurrectedContentRect);
@@ -84,7 +84,7 @@ signals:
 private slots:
     void setFullscreen(const bool fullscreen);
     void onRecvAsyncMessage(const QString& message, const QVariant& data);
-    void onTabHistoryAvailable(const int& tabId, const QList<Link>& links);
+    void onTabHistoryAvailable(const int& historyTabId, const QList<Link>& links);
     void onUrlChanged();
     void grabResultReady();
     void grabWritten();
@@ -95,7 +95,8 @@ private:
     void restoreHistory();
 
     QPointer<DeclarativeWebContainer> m_container;
-    Tab m_tab;
+    // Tab data fetched upon web page initialization. It never changes afterwards.
+    Tab m_initialTab;
     bool m_userHasDraggedWhileLoading;
     bool m_fullscreen;
     bool m_forcedChrome;

--- a/src/tab.cpp
+++ b/src/tab.cpp
@@ -11,13 +11,13 @@
 
 #include "tab.h"
 
-Tab::Tab(int tabId, Link currentLink, int nextLinkId, int previousLinkId) :
-    m_tabId(tabId), m_currentLink(currentLink), m_nextLinkId(nextLinkId), m_previousLinkId(previousLinkId)
+Tab::Tab(int tabId, Link currentLink) :
+    m_tabId(tabId), m_currentLink(currentLink)
 {
 }
 
 Tab::Tab() :
-    m_tabId(0), m_nextLinkId(0), m_previousLinkId(0)
+    m_tabId(0)
 {
 }
 
@@ -39,16 +39,6 @@ int Tab::currentLink() const
 void Tab::setCurrentLink(int currentLinkId)
 {
     m_currentLink.setLinkId(currentLinkId);
-}
-
-int Tab::nextLink() const
-{
-    return m_nextLinkId;
-}
-
-void Tab::setNextLink(int nextLinkId)
-{
-    m_nextLinkId = nextLinkId;
 }
 
 QString Tab::url() const
@@ -86,21 +76,9 @@ bool Tab::isValid() const
     return m_tabId > 0;
 }
 
-int Tab::previousLink() const
-{
-    return m_previousLinkId;
-}
-
-void Tab::setPreviousLink(int previousLinkId)
-{
-    m_previousLinkId = previousLinkId;
-}
-
 bool Tab::operator==(const Tab &other) const
 {
     return (m_tabId == other.tabId() &&
-            m_previousLinkId == other.m_previousLinkId &&
-            m_nextLinkId == other.m_nextLinkId &&
             m_currentLink == other.m_currentLink);
 }
 
@@ -115,7 +93,6 @@ QDebug operator<<(QDebug dbg, const Tab *tab) {
     }
 
     dbg.nospace() << "Tab(tabId = " << tab->tabId() << ", isValid = " << tab->isValid() << ", linkId = " << tab->currentLink()
-                  << ", previousLink = " << tab->previousLink() << ", nextLink = " << tab->nextLink()
                   << ", url = " << tab->url() << ", title = " << tab->title() << ", thumbnailPath = " << tab->thumbnailPath() << ")";
     return dbg.space();
 }

--- a/src/tab.h
+++ b/src/tab.h
@@ -20,7 +20,7 @@
 class Tab
 {
 public:
-    explicit Tab(int tabId, Link currentLink, int nextLinkId, int previousLinkId);
+    explicit Tab(int tabId, Link currentLink);
     explicit Tab();
 
     int tabId() const;
@@ -28,12 +28,6 @@ public:
 
     int currentLink() const;
     void setCurrentLink(int currentLinkId);
-
-    int previousLink() const;
-    void setPreviousLink(int previousLinkId);
-
-    int nextLink() const;
-    void setNextLink(int nextLinkId);
 
     QString url() const;
     void setUrl(const QString &url);
@@ -53,7 +47,6 @@ private:
     int m_tabId;
     Link m_currentLink;
     int m_nextLinkId;
-    int m_previousLinkId;
 };
 
 QDebug operator<<(QDebug, const Tab *);

--- a/src/webpages.cpp
+++ b/src/webpages.cpp
@@ -156,7 +156,7 @@ WebPageActivationData WebPages::page(const Tab& tab, int parentId)
             if (webPage) {
                 webPage->setParentID(parentId);
                 webPage->setPrivateMode(m_webContainer->privateMode());
-                webPage->setTab(tab);
+                webPage->setInitialTab(tab);
                 webPage->setContainer(m_webContainer);
                 webPage->initialize();
                 m_webPageComponent->completeCreate();

--- a/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
+++ b/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
@@ -449,40 +449,30 @@ void tst_declarativetabmodel::reloadModel()
     QCOMPARE(tabModel->activeTab().url(), tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString());
     QCOMPARE(tabModel->activeTab().title(), tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString());
     QCOMPARE(tabModel->activeTab().currentLink(), tabModel->m_tabs.at(activeTabIndex).currentLink());
-    QCOMPARE(tabModel->activeTab().previousLink(), tabModel->m_tabs.at(activeTabIndex).previousLink());
-    QCOMPARE(tabModel->activeTab().nextLink(), tabModel->m_tabs.at(activeTabIndex).nextLink());
 
     modelIndex = tabModel->createIndex(0, 0);
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString(), QString("https://sailfishos.org/sailfish-silica/index.html"));
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), QString("Creating applications with Sailfish Silica | Sailfish Silica 1.0"));
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TabIdRole).toInt(), 3);
     QCOMPARE(tabModel->m_tabs.at(0).currentLink(), 3);
-    QCOMPARE(tabModel->m_tabs.at(0).previousLink(), 0);
-    QCOMPARE(tabModel->m_tabs.at(0).nextLink(), 0);
 
     modelIndex = tabModel->createIndex(1, 0);
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString(), QString("foo/bar/index.html"));
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), QString("A title something"));
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TabIdRole).toInt(), 4);
     QCOMPARE(tabModel->m_tabs.at(1).currentLink(), 12);
-    QCOMPARE(tabModel->m_tabs.at(1).previousLink(), 11);
-    QCOMPARE(tabModel->m_tabs.at(1).nextLink(), 0);
 
     modelIndex = tabModel->createIndex(2, 0);
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString(), QString("http://foobar"));
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), QString("FooBar non active tab"));
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TabIdRole).toInt(), 7);
     QCOMPARE(tabModel->m_tabs.at(2).currentLink(), 13);
-    QCOMPARE(tabModel->m_tabs.at(2).previousLink(), 0);
-    QCOMPARE(tabModel->m_tabs.at(2).nextLink(), 0);
 
     modelIndex = tabModel->createIndex(3, 0);
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString(), QString("http://foobar"));
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), QString("FooBar Two"));
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TabIdRole).toInt(), 8);
     QCOMPARE(tabModel->m_tabs.at(3).currentLink(), 14);
-    QCOMPARE(tabModel->m_tabs.at(3).previousLink(), 0);
-    QCOMPARE(tabModel->m_tabs.at(3).nextLink(), 0);
 }
 
 void tst_declarativetabmodel::changeTabAndLoad()
@@ -494,17 +484,13 @@ void tst_declarativetabmodel::changeTabAndLoad()
     tabModel->activateTab(1);
     QCOMPARE(currentTabId(), 4);
 
-    // Current link becomes previous after url update ("link clicked")
-    int previousLink = tabModel->activeTab().currentLink();
-    QCOMPARE(previousLink, 12);
+    QCOMPARE(tabModel->activeTab().currentLink(), 12);
     QString url = "http://www.foobar.com/something";
     tabModel->updateUrl(currentTabId(), true, url, false);
     QTest::qWait(1000);
 
     QCOMPARE(tabModel->activeTab().tabId(), 4);
     QCOMPARE(tabModel->activeTab().currentLink(), nextLinkId);
-    QCOMPARE(tabModel->activeTab().previousLink(), previousLink);
-    QCOMPARE(tabModel->activeTab().nextLink(), 0);
     QCOMPARE(tabModel->activeTab().url(), url);
     QCOMPARE(tabModel->activeTab().title(), QString(""));
 }


### PR DESCRIPTION
The first commit removes unused previousLink and nextLink properties from the `Tab` struct.

The second one simply renames DeclarativeWebPage::m_tab to DeclarativeWebPage::m_initialTab in order to stress the fact that this tab data is static and never changes after WebPage's initialization.