### PR TITLE
[sailfish-browser] Focus search field after browser page gets activated. Fixes JB#30418

### DIFF
--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -254,7 +254,7 @@ Background {
             SearchField {
                 id: searchField
 
-                readonly property bool overlayAtTop: overlayAnimator.atTop
+                readonly property bool requestingFocus: overlayAnimator.atTop && browserPage.active
                 property bool edited
                 property bool enteringNewTabUrl
 
@@ -294,8 +294,8 @@ Background {
                 background: null
                 opacity: toolBar.opacity * -1.0
                 visible: opacity > 0.0
-                onOverlayAtTopChanged: {
-                    if (overlayAtTop) {
+                onRequestingFocusChanged: {
+                    if (requestingFocus) {
                         forceActiveFocus()
                     } else {
                         focus = false


### PR DESCRIPTION
Silica Page is a focus scope so we should not focus the search field
until the browser page is active.

Before this fix virtual keyboard opened already on the tab page when
all tabs were closed and you started pop gesture from the tab page. Due
to this and virtual keyboard observer there was a white stripe blinking
at the bottom of the screen.