### PR TITLE
[sailfish-browser] Add new tab cover action back to the tab view. Fixes JB#30443

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -22,6 +22,7 @@ Page {
 
     readonly property rect inputMask: inputMaskForOrientation(orientation)
     readonly property bool active: status == PageStatus.Active
+    property bool tabPageActive
     readonly property bool largeScreen: Screen.sizeCategory > Screen.Medium
     readonly property size thumbnailSize: Qt.size((Screen.width - (largeScreen ? (2 * Theme.horizontalPageMargin) : 0)), (largeScreen ? Theme.itemSizeExtraLarge + (2 * Theme.paddingLarge) : Screen.height / 5))
     property Item debug
@@ -294,7 +295,7 @@ Page {
     }
 
     CoverActionList {
-        enabled: (browserPage.status === PageStatus.Active || !webView.tabModel || webView.tabModel.count === 0)
+        enabled: (browserPage.status === PageStatus.Active || browserPage.tabPageActive || !webView.tabModel || webView.tabModel.count === 0)
         iconBackground: true
         window: webView
 

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -412,6 +412,8 @@ Background {
             id: tabPage
             property int activeTabIndex
 
+            onStatusChanged: browserPage.tabPageActive = (status == PageStatus.Active)
+
             Browser.TabView {
                 id: tabViewItem
 


### PR DESCRIPTION
This workaround adds the new tab cover action back to the cover in case
tab page is active when browser pushed to switcher. Other sub pages are not
handled (sharing and web prompts). For web prompts we should not have
new tab cover action as triggering the action would reject the prompt.

Remove this when the tab view cover is done.