### PR TITLE
[sailfish-browser] Disable decoder limit workaround. Contributes to JB#30517

### DIFF
--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -49,6 +49,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 {
     setenv("USE_ASYNC", "1", 1);
     setenv("USE_NEMO_GSTREAMER", "1", 1);
+    setenv("NO_LIMIT_ONE_GST_DECODER", "1", 1);
 
     // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=929879
     setenv("LC_NUMERIC", "C", 1);


### PR DESCRIPTION
Since the workaround breaks loading of pages like jolla.com/tablet and
the original bug it was supposed to fix (JB#11038) is no longer
reproducible let's disable it.