### PR TITLE
[sailfish-browser] Insert new tab next to the parent tab. Fixes JB#30333

### DIFF
--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -18,6 +18,8 @@
 
 #include "tab.h"
 
+class DeclarativeWebContainer;
+
 class DeclarativeTabModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -30,7 +32,7 @@ protected:
     Q_PROPERTY(bool waitingForNewTab READ waitingForNewTab WRITE setWaitingForNewTab NOTIFY waitingForNewTabChanged FINAL)
 
 public:
-    DeclarativeTabModel(int nextTabId = 1, QObject *parent = 0);
+    DeclarativeTabModel(int nextTabId = 1, DeclarativeWebContainer *webContainer = 0);
     ~DeclarativeTabModel();
     
     enum TabRoles {
@@ -44,7 +46,7 @@ public:
     Q_INVOKABLE void remove(int index);
     Q_INVOKABLE void clear();
     Q_INVOKABLE bool activateTab(const QString &url);
-    Q_INVOKABLE bool activateTab(int index, bool loadActiveTab = true);
+    Q_INVOKABLE void activateTab(int index, bool loadActiveTab = true);
     Q_INVOKABLE void closeActiveTab();
     Q_INVOKABLE void newTab(const QString &url, const QString &title, int parentId = 0);
 
@@ -53,7 +55,6 @@ public:
     int activeTabIndex() const;
     int activeTabId() const;
     int count() const;
-    void addTab(const QString &url, const QString &title);
     bool activateTabById(int tabId);
     void removeTabById(int tabId, bool activeTab);
 
@@ -94,6 +95,7 @@ signals:
     void newTabRequested(QString url, QString title, int parentId = 0);
 
 protected:
+    void addTab(const QString &url, const QString &title, int index);
     void removeTab(int tabId, const QString &thumbnail, int index);
     int findTabIndex(int tabId) const;
     void updateActiveTab(const Tab &activeTab, bool loadActiveTab);
@@ -107,6 +109,11 @@ protected:
     virtual void navigateTo(int tabId, QString url, QString title, QString path) = 0;
     virtual void updateThumbPath(int tabId, QString path) = 0;
 
+    int nextActiveTabIndex(int index);
+
+    // Used from the tab model unit tests only.
+    void setWebContainer(DeclarativeWebContainer *webContainer);
+
     int m_activeTabId;
     QList<Tab> m_tabs;
 
@@ -114,6 +121,9 @@ protected:
     bool m_waitingForNewTab;
     int m_nextTabId;
 
+    QPointer<DeclarativeWebContainer> m_webContainer;
+
+    friend class tst_declarativehistorymodel;
     friend class tst_declarativetabmodel;
     friend class tst_webview;
 };

--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -411,6 +411,14 @@ bool DeclarativeWebContainer::activatePage(const Tab& tab, bool force, int paren
     return false;
 }
 
+int DeclarativeWebContainer::findParentTabId(int tabId) const
+{
+    if (m_webPages) {
+        return m_webPages->parentTabId(tabId);
+    }
+    return 0;
+}
+
 bool DeclarativeWebContainer::alive(int tabId)
 {
     return m_webPages->alive(tabId);
@@ -776,14 +784,6 @@ void DeclarativeWebContainer::onNewTabRequested(QString url, QString title, int 
     }
 }
 
-int DeclarativeWebContainer::parentTabId(int tabId) const
-{
-    if (m_webPages) {
-        return m_webPages->parentTabId(tabId);
-    }
-    return 0;
-}
-
 void DeclarativeWebContainer::releasePage(int tabId)
 {
     if (m_webPages) {
@@ -800,7 +800,7 @@ void DeclarativeWebContainer::closeWindow()
 {
     DeclarativeWebPage *webPage = qobject_cast<DeclarativeWebPage *>(sender());
     if (webPage && m_model) {
-        int parentPageTabId = parentTabId(webPage->tabId());
+        int parentPageTabId = findParentTabId(webPage->tabId());
         // Closing only allowed if window was created by script
         if (parentPageTabId > 0) {
             m_model->activateTabById(parentPageTabId);

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -114,6 +114,7 @@ public:
 
     bool isActiveTab(int tabId);
     bool activatePage(const Tab& tab, bool force = false, int parentId = 0);
+    int findParentTabId(int tabId) const;
 
     Q_INVOKABLE void load(QString url = "", QString title = "", bool force = false);
     Q_INVOKABLE void reload(bool force = true);
@@ -206,7 +207,6 @@ private slots:
 private:
     void setWebPage(DeclarativeWebPage *webPage);
     qreal contentHeight() const;
-    int parentTabId(int tabId) const;
     bool canInitialize() const;
     void loadTab(const Tab& tab, bool force);
     void updateMode();

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -40,7 +40,7 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
 
     Q_PROPERTY(QQuickItem *rotationHandler MEMBER m_rotationHandler NOTIFY rotationHandlerChanged FINAL)
     Q_PROPERTY(DeclarativeWebPage *contentItem READ webPage NOTIFY contentItemChanged FINAL)
-    Q_PROPERTY(DeclarativeTabModel *tabModel READ tabModel WRITE setTabModel NOTIFY tabModelChanged FINAL)
+    Q_PROPERTY(DeclarativeTabModel *tabModel READ tabModel NOTIFY tabModelChanged FINAL)
     Q_PROPERTY(bool completed READ completed NOTIFY completedChanged FINAL)
     Q_PROPERTY(bool enabled MEMBER m_enabled NOTIFY enabledChanged FINAL)
     Q_PROPERTY(bool foreground READ foreground WRITE setForeground NOTIFY foregroundChanged FINAL)
@@ -79,7 +79,6 @@ public:
     DeclarativeWebPage *webPage() const;
 
     DeclarativeTabModel *tabModel() const;
-    void setTabModel(DeclarativeTabModel *model);
 
     bool completed() const;
 
@@ -206,6 +205,7 @@ private slots:
 
 private:
     void setWebPage(DeclarativeWebPage *webPage);
+    void setTabModel(DeclarativeTabModel *model);
     qreal contentHeight() const;
     bool canInitialize() const;
     void loadTab(const Tab& tab, bool force);

--- a/src/persistenttabmodel.cpp
+++ b/src/persistenttabmodel.cpp
@@ -13,10 +13,11 @@
 
 #include "persistenttabmodel.h"
 #include "dbmanager.h"
+#include "declarativewebcontainer.h"
 #include "declarativewebutils.h"
 
-PersistentTabModel::PersistentTabModel(QObject *parent)
-    : DeclarativeTabModel(DBManager::instance()->getMaxTabId() + 1, parent)
+PersistentTabModel::PersistentTabModel(DeclarativeWebContainer *webContainer)
+    : DeclarativeTabModel(DBManager::instance()->getMaxTabId() + 1, webContainer)
 {
     connect(DBManager::instance(), SIGNAL(tabsAvailable(QList<Tab>)),
             this, SLOT(tabsAvailable(QList<Tab>)));

--- a/src/persistenttabmodel.h
+++ b/src/persistenttabmodel.h
@@ -14,6 +14,8 @@
 
 #include "declarativetabmodel.h"
 
+class DeclarativeWebContainer;
+
 class PersistentTabModel : public DeclarativeTabModel
 {
     Q_OBJECT
@@ -35,7 +37,7 @@ public slots:
     void tabsAvailable(QList<Tab> tabs);
 
 public:
-    PersistentTabModel(QObject *parent = 0);
+    PersistentTabModel(DeclarativeWebContainer *webContainer = 0);
     ~PersistentTabModel();
 };
 

--- a/src/privatetabmodel.cpp
+++ b/src/privatetabmodel.cpp
@@ -10,11 +10,12 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "privatetabmodel.h"
+#include "declarativewebcontainer.h"
 #include "declarativewebutils.h"
 #include "dbmanager.h"
 
-PrivateTabModel::PrivateTabModel(QObject *parent)
-    : DeclarativeTabModel(DBManager::instance()->getMaxTabId() + 10000, parent),
+PrivateTabModel::PrivateTabModel(DeclarativeWebContainer *webContainer)
+    : DeclarativeTabModel(DBManager::instance()->getMaxTabId() + 10000, webContainer),
       m_nextLinkId(1)
 {
     // Startup should be synced to this.

--- a/src/privatetabmodel.h
+++ b/src/privatetabmodel.h
@@ -14,6 +14,8 @@
 
 #include "declarativetabmodel.h"
 
+class DeclarativeWebContainer;
+
 class PrivateTabModel : public DeclarativeTabModel
 {
     Q_OBJECT
@@ -28,7 +30,7 @@ protected:
     virtual void updateThumbPath(int tabId, QString path);
 
 public:
-    PrivateTabModel(QObject *parent = 0);
+    PrivateTabModel(DeclarativeWebContainer *webContainer = 0);
     ~PrivateTabModel();
 
 private:

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -126,8 +126,8 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 
     qmlRegisterType<DeclarativeBookmarkModel>("Sailfish.Browser", 1, 0, "BookmarkModel");
     qmlRegisterUncreatableType<DeclarativeTabModel>("Sailfish.Browser", 1, 0, "TabModel", "TabModel is abstract!");
-    qmlRegisterType<PersistentTabModel>("Sailfish.Browser", 1, 0, "PersistentTabModel");
-    qmlRegisterType<PrivateTabModel>("Sailfish.Browser", 1, 0, "PrivateTabModel");
+    qmlRegisterUncreatableType<PersistentTabModel>("Sailfish.Browser", 1, 0, "PersistentTabModel", "");
+    qmlRegisterUncreatableType<PrivateTabModel>("Sailfish.Browser", 1, 0, "PrivateTabModel", "");
     qmlRegisterType<DeclarativeHistoryModel>("Sailfish.Browser", 1, 0, "HistoryModel");
     qmlRegisterType<DeclarativeWebContainer>("Sailfish.Browser", 1, 0, "WebContainer");
     qmlRegisterType<DeclarativeWebPage>("Sailfish.Browser", 1, 0, "WebPage");

--- a/src/webpagequeue.cpp
+++ b/src/webpagequeue.cpp
@@ -121,6 +121,8 @@ void WebPageQueue::prepend(int tabId, DeclarativeWebPage *webPage)
     } else {
         pageEntry->webPage = webPage;
         pageEntry->tabId = tabId;
+        pageEntry->parentId = webPage->parentId();
+        pageEntry->uniqueId = webPage->uniqueID();
         pageEntry->webPage->setResurrectedContentRect(*pageEntry->cssContentRect);
         if (pageEntry->cssContentRect) {
             delete pageEntry->cssContentRect;
@@ -153,12 +155,12 @@ int WebPageQueue::parentTabId(int tabId) const
     // Ported from webpages.cpp.
     int index = 0;
     WebPageEntry *childPageEntry = find(tabId, index);
-    if (childPageEntry && childPageEntry->webPage) {
-        int parentId = childPageEntry->webPage->parentId();
+    if (childPageEntry) {
+        int parentId = childPageEntry->parentId;
         for (int i = 0; i < m_queue.count(); ++i) {
             WebPageEntry *parentPageEntry = m_queue.at(i);
-            if (parentPageEntry->webPage && (int)parentPageEntry->webPage->uniqueID() == parentId) {
-                return parentPageEntry->webPage->tabId();
+            if (parentPageEntry && (int)parentPageEntry->uniqueId == parentId) {
+                return parentPageEntry->tabId;
             }
         }
     }
@@ -238,6 +240,8 @@ WebPageQueue::WebPageEntry *WebPageQueue::find(int tabId, int &index) const
 WebPageQueue::WebPageEntry::WebPageEntry(DeclarativeWebPage *webPage, QRectF *cssContentRect)
     : webPage(webPage)
     , tabId(webPage ? webPage->tabId() : 0)
+    , uniqueId(webPage ? webPage->uniqueID() : 0)
+    , parentId(webPage ? webPage->parentId() : 0)
     , cssContentRect(cssContentRect)
     , allowPageDelete(false)
 {

--- a/src/webpagequeue.h
+++ b/src/webpagequeue.h
@@ -46,6 +46,8 @@ private:
 
         DeclarativeWebPage *webPage;
         int tabId;
+        int uniqueId;
+        int parentId;
         QRectF *cssContentRect;
         bool allowPageDelete;
     };

--- a/tests/auto/common/declarativewebcontainer.cpp
+++ b/tests/auto/common/declarativewebcontainer.cpp
@@ -1,0 +1,27 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "declarativewebcontainer.h"
+
+DeclarativeWebContainer::DeclarativeWebContainer(QObject *parent)
+    : QObject(parent)
+{
+}
+
+int DeclarativeWebContainer::findParentTabId(int) const
+{
+    return 0;
+}
+
+DeclarativeWebPage *DeclarativeWebContainer::webPage() const
+{
+    return 0;
+}

--- a/tests/auto/common/declarativewebcontainer.h
+++ b/tests/auto/common/declarativewebcontainer.h
@@ -1,0 +1,31 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef DECLARATIVEWEBCONTAINER_H
+#define DECLARATIVEWEBCONTAINER_H
+
+#include <QObject>
+
+class DeclarativeWebPage;
+
+class DeclarativeWebContainer : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit DeclarativeWebContainer(QObject *parent = 0);
+
+    int findParentTabId(int) const;
+    DeclarativeWebPage *webPage() const;
+};
+
+
+#endif

--- a/tests/auto/common/declarativewebcontainer_mock.pri
+++ b/tests/auto/common/declarativewebcontainer_mock.pri
@@ -1,0 +1,8 @@
+# Mock interface for DeclarativeWebContainer. Interface is not complete.
+# Currently it includes only methods needed at runtime.
+# This pri is included indirectly from unit tests cases that
+# are at the same level in the file hierarchy.
+SOURCES += ../common/declarativewebcontainer.cpp
+HEADERS += ../common/declarativewebcontainer.h
+
+INCLUDEPATH += ../common

--- a/tests/auto/common/declarativewebpage.cpp
+++ b/tests/auto/common/declarativewebpage.cpp
@@ -16,6 +16,28 @@ DeclarativeWebPage::DeclarativeWebPage()
 {
 }
 
+void DeclarativeWebPage::setContainer(DeclarativeWebContainer *)
+{
+}
+
+
+void DeclarativeWebPage::setResurrectedContentRect(QVariant)
+{
+
+}
+
+void DeclarativeWebPage::setInitialTab(const Tab&)
+{
+}
+
+void DeclarativeWebPage::resetHeight(bool)
+{
+}
+
+void DeclarativeWebPage::forceChrome(bool)
+{
+}
+
 int DeclarativeWebPage::tabId() const
 {
     return 0;
@@ -28,4 +50,17 @@ bool DeclarativeWebPage::initialLoadHasHappened() const
 
 void DeclarativeWebPage::setInitialLoadHasHappened()
 {
+}
+
+void DeclarativeWebPage::loadTab(QString newUrl, bool force)
+{
+    Q_UNUSED(newUrl)
+    Q_UNUSED(force);
+}
+
+QDebug operator<<(QDebug dbg, const DeclarativeWebPage *page)
+{
+    Q_UNUSED(page);
+
+    return dbg;
 }

--- a/tests/auto/common/declarativewebpage.h
+++ b/tests/auto/common/declarativewebpage.h
@@ -13,6 +13,10 @@
 #define DECLARATIVEWEBPAGE_H
 
 #include <QObject>
+#include <QDebug>
+
+class Tab;
+class DeclarativeWebContainer;
 
 class DeclarativeWebPage : public QObject
 {
@@ -21,9 +25,31 @@ class DeclarativeWebPage : public QObject
 public:
     explicit DeclarativeWebPage();
 
+    void setContainer(DeclarativeWebContainer *);
+
+    void setResurrectedContentRect(QVariant);
+    void setInitialTab(const Tab&);
+
+    void resetHeight(bool);
+    void forceChrome(bool);
+
     int tabId() const;
     bool initialLoadHasHappened() const;
     void setInitialLoadHasHappened();
+
+    Q_INVOKABLE void loadTab(QString newUrl, bool force);
+signals:
+    void containerChanged();
+    void tabIdChanged();
+    void forcedChromeChanged();
+    void fullscreenChanged();
+    void domContentLoadedChanged();
+    void resurrectedContentRectChanged();
+    void clearGrabResult();
+    void grabResult(QString fileName);
+    void thumbnailResult(QString data);
 };
+
+QDebug operator<<(QDebug, const DeclarativeWebPage *);
 
 #endif

--- a/tests/auto/common/webview.pri
+++ b/tests/auto/common/webview.pri
@@ -1,0 +1,29 @@
+CONFIG += link_pkgconfig
+
+PKGCONFIG += mlite5
+
+# WebContainer need this
+isEmpty(QTEMBED_LIB) {
+  PKGCONFIG += qt5embedwidget
+} else {
+  LIBS+=$$QTEMBED_LIB
+}
+
+QT += gui-private
+
+SOURCES += ../../../src/declarativewebcontainer.cpp \
+    ../../../src/declarativewebpagecreator.cpp \
+    ../../../src/settingmanager.cpp \
+    ../../../src/webpagequeue.cpp \
+    ../../../src/webpages.cpp
+
+HEADERS += ../../../src/declarativewebcontainer.h \
+    ../../../src/declarativewebpagecreator.h \
+    ../../../src/settingmanager.h \
+    ../../../src/webpagequeue.h \
+    ../../../src/webpages.h
+
+isEmpty(MOCK_WEBPAGE) {
+    SOURCES += ../../../src/declarativewebpage.cpp
+    HEADERS += ../../../src/declarativewebpage.h
+}

--- a/tests/auto/tst_dbmanager/tst_dbmanager.pro
+++ b/tests/auto/tst_dbmanager/tst_dbmanager.pro
@@ -1,6 +1,17 @@
 TARGET = tst_dbmanager
+NO_COMMON_INCLUDES=1
 include(../test_common.pri)
-include(../common/declarativewebpage_mock.pri)
 include(../common/testobject.pri)
 
-SOURCES += tst_dbmanager.cpp
+DEFINES += DB_NAME=\\\"sailfish-browser.sqlite\\\"
+
+SOURCES += tst_dbmanager.cpp \
+    ../../../src/dbmanager.cpp \
+    ../../../src/dbworker.cpp \
+    ../../../src/link.cpp \
+    ../../../src/tab.cpp
+
+HEADERS += ../../../src/dbmanager.h \
+    ../../../src/dbworker.h \
+    ../../../src/link.h \
+    ../../../src/tab.h

--- a/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.cpp
+++ b/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.cpp
@@ -100,7 +100,7 @@ void tst_declarativehistorymodel::addNonSameHistoryEntries()
     QFETCH(QString, searchTerm);
     QFETCH(int, expectedCount);
 
-    tabModel->addTab(url, title);
+    tabModel->addTab(url, title, tabModel->count());
 
     historyModel->search("");
     QTest::qWait(1000);
@@ -131,7 +131,7 @@ void tst_declarativehistorymodel::addDuplicateHistoryEntries()
 
     QSignalSpy countChangeSpy(historyModel, SIGNAL(countChanged()));
 
-    tabModel->addTab(url, title);
+    tabModel->addTab(url, title, tabModel->count());
 
     historyModel->search("");
     waitSignals(countChangeSpy, 1);
@@ -174,7 +174,7 @@ void tst_declarativehistorymodel::sortedHistoryEntries()
     QFETCH(QStringList, order);
     QFETCH(int, expectedCount);
 
-    tabModel->addTab(url, title);
+    tabModel->addTab(url, title, tabModel->count());
 
     historyModel->search(searchTerm);
     waitSignals(countChangeSpy, 2);
@@ -207,7 +207,7 @@ void tst_declarativehistorymodel::emptyTitles()
     QFETCH(QString, url);
     QFETCH(QString, searchTerm);
     QFETCH(int, expectedCount);
-    tabModel->addTab(url, "");
+    tabModel->addTab(url, "", tabModel->count());
 
     historyModel->search(searchTerm);
     waitSignals(countChangeSpy, 2);
@@ -245,7 +245,7 @@ void tst_declarativehistorymodel::searchWithSpecialChars()
     QFETCH(QString, searchTerm);
     QFETCH(int, expectedCount);
 
-    tabModel->addTab(url, title);
+    tabModel->addTab(url, title, tabModel->count());
     historyModel->search(searchTerm);
     waitSignals(countChangeSpy, 2);
 

--- a/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.pro
+++ b/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.pro
@@ -1,6 +1,9 @@
 TARGET = tst_declarativehistorymodel
+MOCK_WEBPAGE=1
 include(../test_common.pri)
 include(../common/testobject.pri)
 include(../common/declarativewebpage_mock.pri)
+include(../common/webview.pri)
+include(../../../src/bookmarks.pri)
 
 SOURCES += tst_declarativehistorymodel.cpp

--- a/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.pro
+++ b/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.pro
@@ -1,6 +1,7 @@
 TARGET = tst_declarativetabmodel
+include(../common/declarativewebpage_mock.pri)
+include(../common/declarativewebcontainer_mock.pri)
 include(../test_common.pri)
 include(../common/testobject.pri)
-include(../common/declarativewebpage_mock.pri)
 
 SOURCES += tst_declarativetabmodel.cpp

--- a/tests/auto/tst_linkvalidator/tst_linkvalidator.pro
+++ b/tests/auto/tst_linkvalidator/tst_linkvalidator.pro
@@ -1,5 +1,11 @@
 TARGET = tst_linkvalidator
+NO_COMMON_INCLUDES=1
 include(../test_common.pri)
 include(../common/declarativewebpage_mock.pri)
 
-SOURCES += tst_linkvalidator.cpp
+SOURCES += tst_linkvalidator.cpp \
+    ../../../src/link.cpp \
+    ../../../src/linkvalidator.cpp
+
+HEADERS += ../../../src/link.h \
+    ../../../src/linkvalidator.h

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -795,7 +795,7 @@ int main(int argc, char *argv[])
 
     qmlRegisterType<DeclarativeHistoryModel>("Sailfish.Browser", 1, 0, "HistoryModel");
     qmlRegisterUncreatableType<DeclarativeTabModel>("Sailfish.Browser", 1, 0, "TabModel", "TabModel is abstract!");
-    qmlRegisterType<PersistentTabModel>("Sailfish.Browser", 1, 0, "PersistentTabModel");
+    qmlRegisterUncreatableType<PersistentTabModel>("Sailfish.Browser", 1, 0, "PersistentTabModel", "");
     qmlRegisterType<DeclarativeWebContainer>("Sailfish.Browser", 1, 0, "WebContainer");
     qmlRegisterType<DeclarativeWebPage>("Sailfish.Browser", 1, 0, "WebPage");
     qmlRegisterType<DeclarativeWebPageCreator>("Sailfish.Browser", 1, 0, "WebPageCreator");

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -1,35 +1,10 @@
 TARGET = tst_webview
 include(../test_common.pri)
 include(../common/testobject.pri)
+include(../common/webview.pri)
 include(../../../src/bookmarks.pri)
 
-CONFIG += link_pkgconfig
-
-PKGCONFIG += mlite5
-
-# WebContainer need this
-isEmpty(QTEMBED_LIB) {
-  PKGCONFIG += qt5embedwidget
-} else {
-  LIBS+=$$QTEMBED_LIB
-}
-
-QT += gui-private
-
-SOURCES += tst_webview.cpp \
-    ../../../src/declarativewebcontainer.cpp \
-    ../../../src/declarativewebpage.cpp \
-    ../../../src/declarativewebpagecreator.cpp \
-    ../../../src/settingmanager.cpp \
-    ../../../src/webpagequeue.cpp \
-    ../../../src/webpages.cpp
-
-HEADERS += ../../../src/declarativewebcontainer.h \
-    ../../../src/declarativewebpage.h \
-    ../../../src/declarativewebpagecreator.h \
-    ../../../src/settingmanager.h \
-    ../../../src/webpagequeue.h \
-    ../../../src/webpages.h
+SOURCES += tst_webview.cpp
 
 OTHER_FILES = *.qml
 

--- a/tests/manual/testwindowopen.html
+++ b/tests/manual/testwindowopen.html
@@ -27,5 +27,9 @@
     <div id="div" style="width:400px;height:150px">
       <a href="javascript:void(0)" onclick="window.close()"><h1>Try to close this window, root window cannot close itself</h1></a>
     </div>
+
+    <div id="div" style="width:400px;height:150px">
+      <a href="testfilepicker.html" target="_blank"><h1>Open file picker page into a new tab</h1></a>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
When a tab is closed and it had a parent tab, the parent tab activated
otherwise the index next to the previous active tab is activated.