### PR TITLE
Revoke geolocation permissions upon app restart. 

### DIFF
--- a/src/pages/components/LocationDialog.qml
+++ b/src/pages/components/LocationDialog.qml
@@ -16,6 +16,8 @@ import Sailfish.Silica 1.0
 UserPrompt {
     id: dialog
 
+    property string host
+
     //: Allow the server to use location
     //% "Allow"
     acceptText: qsTrId("sailfish_browser-he-accept_location")
@@ -24,8 +26,8 @@ UserPrompt {
         x: Theme.paddingLarge
         width: parent.width - Theme.paddingLarge * 2
         //: The site that wants know user location
-        //% "The site wants to use your current location."
-        text: qsTrId("sailfish_browser-la-location_requested")
+        //% "The site '%1' wants to use your current location."
+        text: qsTrId("sailfish_browser-la-location_requested").arg(host)
         wrapMode: Text.WordWrap
         color: Theme.highlightColor
     }

--- a/src/pages/components/WebPopupHandler.js
+++ b/src/pages/components/WebPopupHandler.js
@@ -25,9 +25,7 @@ var tabModel
 var WebUtils
 var pickerCreator
 
-// TODO: Handle these per QmlMozView (map of webviews + accepted/rejectedGeolocationUrl)
-var acceptedGeolocationUrl = ""
-var rejectedGeolocationUrl = ""
+var geolocationUrls = {}
 
 var _authenticationComponentUrl = Qt.resolvedUrl("AuthDialog.qml")
 var _passwordManagerComponentUrl = Qt.resolvedUrl("PasswordManagerDialog.qml")
@@ -52,16 +50,6 @@ function _hideVirtualKeyboard() {
     if (Qt.inputMethod.visible) {
         browserPage.focus = true
     }
-}
-
-function isAcceptedGeolocationUrl(url) {
-    var tmpUrl = WebUtils.displayableUrl(url)
-    return  acceptedGeolocationUrl === tmpUrl
-}
-
-function isRejectedGeolocationUrl(url) {
-    var tmpUrl = WebUtils.displayableUrl(url)
-    return  rejectedGeolocationUrl === tmpUrl
 }
 
 function openAuthDialog(input) {
@@ -179,34 +167,36 @@ function openContextMenu(data) {
 
 function openLocationDialog(data) {
     // Ask for location permission
-    var url = webView.contentItem.url
-    if (isAcceptedGeolocationUrl(url)) {
+    switch (geolocationUrls[data.host]) {
+    case "accepted": {
         webView.sendAsyncMessage("embedui:premissions", {
                              allow: true,
                              checkedDontAsk: false,
                              id: data.id })
-    } else if (isRejectedGeolocationUrl(url)) {
+        break;
+    }
+    case "rejected": {
         webView.sendAsyncMessage("embedui:premissions", {
                              allow: false,
                              checkedDontAsk: false,
                              id: data.id })
-    } else {
-        var dialog = pageStack.push(_locationComponentUrl, {})
+        break;
+    }
+    default:
+        var dialog = pageStack.push(_locationComponentUrl, {"host": data.host})
         dialog.accepted.connect(function() {
             webView.sendAsyncMessage("embedui:premissions", {
                                                allow: true,
                                                checkedDontAsk: false,
                                                id: data.id })
-            acceptedGeolocationUrl = WebUtils.displayableUrl(url)
-            rejectedGeolocationUrl = ""
+            geolocationUrls[data.host] = "accepted"
         })
         dialog.rejected.connect(function() {
             webView.sendAsyncMessage("embedui:premissions", {
                                                allow: false,
                                                checkedDontAsk: false,
                                                id: data.id })
-            rejectedGeolocationUrl = WebUtils.displayableUrl(url)
-            acceptedGeolocationUrl = ""
+            geolocationUrls[data.host] = "rejected"
         })
     }
 }

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -103,14 +103,6 @@ WebContainer {
                 if (url == "about:blank") return
 
                 webView.findInPageHasResult = false
-
-                if (!PopupHandler.isRejectedGeolocationUrl(url)) {
-                    PopupHandler.rejectedGeolocationUrl = ""
-                }
-
-                if (!PopupHandler.isAcceptedGeolocationUrl(url)) {
-                    PopupHandler.acceptedGeolocationUrl = ""
-                }
             }
 
             onBgcolorChanged: {
@@ -233,7 +225,17 @@ WebContainer {
                     break
                 }
                 case "embed:permissions": {
-                    PopupHandler.openLocationDialog(data)
+                    if (data.title === "geolocation") {
+                        PopupHandler.openLocationDialog(data)
+                    } else {
+                        // Currently we don't support other permission requests.
+                        sendAsyncMessage("embedui:premissions",
+                                         {
+                                             allow: false,
+                                             checkedDontAsk: false,
+                                             id: data.id
+                                         })
+                    }
                     break
                 }
                 case "embed:login": {


### PR DESCRIPTION
Keep accepted/reject hosts in a hash instead of single values for accepted and rejected urls.