### PR TITLE
[sailfish-browser] WIP: Improve tab thumbnailing logic. Fixes JB#23670

### DIFF
--- a/src/declarativetabmodel.h
+++ b/src/declarativetabmodel.h
@@ -49,6 +49,7 @@ public:
     Q_INVOKABLE void activateTab(int index, bool loadActiveTab = true);
     Q_INVOKABLE void closeActiveTab();
     Q_INVOKABLE void newTab(const QString &url, const QString &title, int parentId = 0);
+    Q_INVOKABLE QString url(int tabId) const;
 
     Q_INVOKABLE void dumpTabs() const;
 

--- a/src/declarativewebpage.cpp
+++ b/src/declarativewebpage.cpp
@@ -224,7 +224,6 @@ void DeclarativeWebPage::loadTab(QString newUrl, bool force)
 
 void DeclarativeWebPage::grabToFile(const QSize &size)
 {
-    emit clearGrabResult();
     // grabToImage handles invalid geometry.
     m_grabResult = grabToImage(size);
     if (m_grabResult) {

--- a/src/declarativewebpage.h
+++ b/src/declarativewebpage.h
@@ -74,7 +74,6 @@ signals:
     void domContentLoadedChanged();
     void faviconChanged();
     void resurrectedContentRectChanged();
-    void clearGrabResult();
     void grabResult(QString fileName);
     void thumbnailResult(QString data);
 

--- a/src/pages/components/TabItem.qml
+++ b/src/pages/components/TabItem.qml
@@ -38,14 +38,31 @@ BackgroundItem {
     // contentItem is hidden so this cannot be children of the contentItem.
     // So, making them as siblings of the contentItem.
     data: [
+        Rectangle {
+            color: "gray"
+            width: root.implicitWidth
+            height: root.implicitHeight
+            opacity: 0.2
+            // Intentional binding to an animator opacity.
+            visible: image.opacity < 1.0
+        },
         Image {
             id: image
 
             source: thumbnailPath
             width: root.implicitWidth
             height: root.implicitHeight
+
+            sourceSize {
+                width: root.implicitWidth
+                height: root.implicitHeight
+            }
+
             cache: false
             asynchronous: true
+            opacity: status !== Image.Ready && source !== "" ? 0.0 : 1.0
+
+            Behavior on opacity { FadeAnimator {} }
         },
 
         Rectangle {

--- a/tests/auto/common/declarativewebpage.h
+++ b/tests/auto/common/declarativewebpage.h
@@ -58,7 +58,6 @@ signals:
     void fullscreenChanged();
     void domContentLoadedChanged();
     void resurrectedContentRectChanged();
-    void clearGrabResult();
     void grabResult(QString fileName);
     void thumbnailResult(QString data);
 

--- a/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
+++ b/tests/auto/tst_declarativetabmodel/tst_declarativetabmodel.cpp
@@ -248,10 +248,7 @@ void tst_declarativetabmodel::multipleTabsWithSameUrls()
     tabModel->updateUrl(tab1, page2Tab1Url, false);
     QTest::qWait(1000);
     QCOMPARE(tabModel->activeTab().url(), page2Tab1Url);
-    // This is a bit problematic. From model point of view only url has changed.
-    // In real life between url change and title change there is a short moment
-    // when a wrong title / url can slip into the model. Title changes only
-    // after engine report the title.
+    // Title is cleared in the model when the url changes.
     QVERIFY(tabModel->activeTab().title().isEmpty());
 
     QTest::qWait(1000);


### PR DESCRIPTION
Do not drop the thumbnail when switching between tabs, only drop the thumbnail when the url has really changed. As we clear with white, we allow capturing from 4th frame onwards (number is out of my head) to increase likely hood that some sane content has been rendered.

This also adds grayish background for the tab item and the actual thumbnail is faded in. Light gray background for the tab item needs some design feedback but this looks imo better than e.g. highlight dimmer color ( @roppola ).