### PR TITLE
[sailfish-browser] Trigger compositing surface clear earlier. Fixes JB#30162

### DIFF
--- a/src/browser.qml
+++ b/src/browser.qml
@@ -28,6 +28,9 @@ ApplicationWindow {
         if (!model || model.count === 0) {
             cover = Qt.resolvedUrl("cover/NoTabsCover.qml")
         } else {
+            if (cover != null && window.webView) {
+              window.webView.clearSurface();
+            }
             cover = null
         }
     }

--- a/src/declarativewebcontainer.h
+++ b/src/declarativewebcontainer.h
@@ -121,6 +121,7 @@ public:
     Q_INVOKABLE void goBack();
 
     Q_INVOKABLE void updatePageFocus(bool focus);
+    Q_INVOKABLE void clearSurface() {  postClearWindowSurfaceTask(); }
 
     Q_INVOKABLE bool alive(int tabId);
 

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -35,6 +35,9 @@ Background {
         if (url == "about:config") {
             pageStack.push(Qt.resolvedUrl("ConfigWarning.qml"), {"browserPage": browserPage});
         } else {
+            if (webView && webView.tabModel.count === 0) {
+                webView.clearSurface();
+            }
             // let gecko figure out how to handle malformed URLs
             var pageUrl = url
             var pageTitle = title || ""


### PR DESCRIPTION
Currently the assumption is that when we switch to live cover page the
some content is already rendered in the web window. Unfortunately gecko
triggers first repaint after initial page reflow has been done.
Depending on content complexity this can take several seconds. To
alleviate this problem we manually fill compositing surface with white
color on several ocasions. This currently happens when gecko requests GL
context from the platform (it happens when initial EmbedLitePuppetWidget
is created) and when we get expose event and there is no active page
which can render its content. In case of bug 30162 the clear operation
triggered from EmbedLitePuppetWidget creation should ensure that no
garbage is seen when switching to a live cover. Unfortunately the actual
EmbedLitePuppetWidget creation happens on a different thread than cover
switching. This leaves a tiny possible window in which garbage can be
seen. To fix this the patch adds additional clear action triggered
directly from cover switching code.