### PR TITLE
[sailfish-browser] Reset glScissor state before clering the surface. Fixes JB#30882

### DIFF
--- a/src/declarativewebcontainer.cpp
+++ b/src/declarativewebcontainer.cpp
@@ -473,6 +473,8 @@ void DeclarativeWebContainer::clearWindowSurface()
     m_context->makeCurrent(this);
     QOpenGLFunctions_ES2* funcs = m_context->versionFunctions<QOpenGLFunctions_ES2>();
     Q_ASSERT(funcs);
+    QSize s = m_context->surface()->size();
+    funcs->glScissor(0, 0, s.width(), s.height());
     funcs->glClearColor(1.0, 1.0, 1.0, 0.0);
     funcs->glClear(GL_COLOR_BUFFER_BIT);
     m_context->swapBuffers(this);


### PR DESCRIPTION
Gecko's CompositorOGL can use glScissor to limit the rendering area when
compositing pages containing inline surfaces (example: iframes). In case
we've closed a view which has set some scissor box the clear operation
will not actually clear the whole surface, but only part of it. The
remaining area will have undefined content. This patch ensures that we
always reset the scissor box before clearing the surface. We currently
clear the surface manually only when no webview is opened so there is no
risk we'll affect operation of some existing CompositorOGL instance.
There shouldn't be any when the reset occurs.