### PR TITLE
Set of small fixes for the overlay

### DIFF
--- a/src/pages/components/FavoriteGrid.qml
+++ b/src/pages/components/FavoriteGrid.qml
@@ -62,6 +62,7 @@ SilicaGridView {
     cellHeight: Math.round(pageHeight / rows)
 
     displaced: Transition { NumberAnimation { properties: "x,y"; easing.type: Easing.InOutQuad; duration: 200 } }
+    cacheBuffer: cellHeight * 2
 
     onVisibleChanged: {
         if (!visible && contextMenuActive) {

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -298,7 +298,8 @@ Background {
 
                 background: null
                 opacity: toolBar.opacity * -1.0
-                visible: opacity > 0.0
+                visible: opacity > 0.0 && y >= -searchField.height
+
                 onRequestingFocusChanged: {
                     if (requestingFocus) {
                         forceActiveFocus()

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -192,7 +192,7 @@ Background {
         Item {
             id: historyContainer
 
-            readonly property bool showFavorites: (!searchField.edited && searchField.text === webView.url || !searchField.text)
+            readonly property bool showFavorites: !overlayAnimator.atBottom && (!searchField.edited && searchField.text === webView.url || !searchField.text)
 
             width: parent.width
             height: toolBar.toolsHeight + historyList.height
@@ -361,24 +361,24 @@ Background {
                 }
 
                 search: searchField.text
-                opacity: historyContainer.showFavorites ? 0.0 : 1.0
+                opacity: historyContainer.showFavorites || toolBar.opacity > 0.9 ? 0.0 : 1.0
                 enabled: overlayAnimator.atTop
-                visible: !overlayAnimator.atBottom && !toolBar.findInPageActive && opacity > 0.0
+                visible: !overlayAnimator.atBottom && !toolBar.findInPageActive && !historyContainer.showFavorites
 
                 onMovingChanged: if (moving) historyList.focus = true
                 onSearchChanged: if (search !== webView.url) historyModel.search(search)
                 onLoad: overlay.loadPage(url, title)
 
-                Behavior on opacity { FadeAnimation {} }
+                Behavior on opacity { FadeAnimator {} }
             }
 
             Browser.FavoriteGrid {
                 id: favoriteGrid
 
                 height: historyList.height
-                opacity: historyContainer.showFavorites ? 1.0 : 0.0
+                opacity: historyContainer.showFavorites && toolBar.opacity < 0.9 ? 1.0 : 0.0
                 enabled: overlayAnimator.atTop
-                visible: !overlayAnimator.atBottom && !toolBar.findInPageActive && opacity > 0.0
+                visible: !overlayAnimator.atBottom && !toolBar.findInPageActive && historyContainer.showFavorites
 
                 header: Item {
                     width: parent.width
@@ -402,7 +402,7 @@ Background {
 
                 onShare: pageStack.push(Qt.resolvedUrl("../ShareLinkPage.qml"), {"link" : url, "linkTitle": title})
 
-                Behavior on opacity { FadeAnimation {} }
+                Behavior on opacity { FadeAnimator {} }
             }
         }
     }

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -124,6 +124,14 @@ Background {
                 if (!WebUtils.firstUseDone) {
                     WebUtils.firstUseDone = true
                 }
+
+                dragArea.moved = false
+            }
+        }
+
+        onAtTopChanged: {
+            if (!atTop) {
+                dragArea.moved = true
             }
         }
     }
@@ -147,6 +155,7 @@ Background {
     MouseArea {
         id: dragArea
 
+        property bool moved
         property int dragThreshold: state === "fullscreenOverlay" ? toolBar.toolsHeight * 1.5 :
                                                                     state === "doubleToolBar" ?
                                                                         (webView.fullscreenHeight - toolBar.toolsHeight * 4) :
@@ -257,7 +266,7 @@ Background {
             SearchField {
                 id: searchField
 
-                readonly property bool requestingFocus: overlayAnimator.atTop && browserPage.active
+                readonly property bool requestingFocus: overlayAnimator.atTop && browserPage.active && !dragArea.moved
                 property bool edited
                 property bool enteringNewTabUrl
 
@@ -299,6 +308,12 @@ Background {
                 background: null
                 opacity: toolBar.opacity * -1.0
                 visible: opacity > 0.0 && y >= -searchField.height
+
+                onYChanged: {
+                    if (y < 0) {
+                        dragArea.moved = true
+                    }
+                }
 
                 onRequestingFocusChanged: {
                     if (requestingFocus) {

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -196,7 +196,12 @@ Background {
 
             width: parent.width
             height: toolBar.toolsHeight + historyList.height
-            clip: true
+            // Clip only when content has been moved and we're at top or animating downwards.
+            clip: (overlayAnimator.atTop ||
+                   overlayAnimator.direction === "downwards" ||
+                   overlayAnimator.direction === "upwards" ||
+                   favoriteGrid.opacity != 0.0 ||
+                   historyList.opacity != 0.0) && searchField.y < 0
 
             PrivateModeTexture {
                 opacity: toolBar.visible && webView.privateMode ? toolBar.opacity : 0.0

--- a/src/pages/components/OverlayAnimator.qml
+++ b/src/pages/components/OverlayAnimator.qml
@@ -16,6 +16,7 @@ Item {
 
     property Item overlay
     property QtObject webView
+    property string direction
     property bool portrait
     property bool atTop
     property bool atBottom: true
@@ -23,71 +24,84 @@ Item {
     property real openYPosition: portrait ? overlay.toolBar.toolsHeight : 0
 
     property bool active
-    readonly property bool allowContentUse: state === "chromeVisible" || state === "fullscreenWebPage" || state === "doubleToolBar"
-    readonly property bool dragging: state === "draggingOverlay"
-    readonly property bool secondaryTools: state === "doubleToolBar"
+    readonly property bool allowContentUse: state === _chromeVisible || state === _fullscreenWebPage || state === _doubleToolBar
+    readonly property bool dragging: state === _draggingOverlay
+    readonly property bool secondaryTools: state === _doubleToolBar
 
     property bool _immediate
 
+    readonly property string _fullscreenOverlay: "fullscreenOverlay"
+    readonly property string _doubleToolBar: "doubleToolBar"
+    readonly property string _chromeVisible: "chromeVisible"
+    readonly property string _fullscreenWebPage: "fullscreenWebPage"
+    readonly property string _draggingOverlay: "draggingOverlay"
+    readonly property string _noOverlay: "noOverlay"
+
     function showSecondaryTools() {
-        updateState("doubleToolBar")
+        updateState(_doubleToolBar)
     }
 
     function showChrome(immediate) {
-        updateState("chromeVisible", immediate || false)
+        updateState(_chromeVisible, immediate || false)
     }
 
     function showOverlay(immediate) {
-        updateState("fullscreenOverlay", immediate || false)
+        updateState(_fullscreenOverlay, immediate || false)
     }
 
     function drag() {
-        updateState("draggingOverlay")
+        updateState(_draggingOverlay)
     }
 
     function hide() {
-        updateState("noOverlay")
+        updateState(_noOverlay)
     }
 
     // Wrapper from updating the state. Handy for debugging.
     function updateState(newState, immediate) {
         _immediate = immediate || false
-        if (newState !== "fullscreenWebPage") {
+        if (newState !== _fullscreenWebPage) {
             overlay.visible = true
         }
 
         state = newState
     }
 
-    state: "chromeVisible"
+    state: _chromeVisible
 
     // TODO: Fix real cover. Once that is fixed, we should remove this block.
     onActiveChanged: {
         // When activating and state already changed to something else than
-        // "fullscreenWebPage" we should not alter the state.
+        // _fullscreenWebPage we should not alter the state.
         // For instance "new-tab" cover action triggers this state change.
-        if (active && (state !== "fullscreenWebPage" || webView.contentItem && webView.contentItem.fullscreen)) {
+        if (active && (state !== _fullscreenWebPage || webView.contentItem && webView.contentItem.fullscreen)) {
             return
         }
 
         if (active) {
             if (webView.completed && !webView.tabModel.waitingForNewTab && webView.tabModel.count === 0) {
-                updateState("fullscreenOverlay", true)
+                updateState(_fullscreenOverlay, true)
             } else {
-                updateState("chromeVisible", true)
+                updateState(_chromeVisible, true)
             }
         } else if (webView.tabModel.count > 0) {
-            updateState("fullscreenWebPage", true)
+            updateState(_fullscreenWebPage, true)
         }
     }
 
     onStateChanged: {
-        // Animation end changes to true state. Hence not like atTop = state !== "fullscreenOverlay"
-        if (state !== "fullscreenOverlay") {
+        // Animation end changes to true state. Hence not like atTop = state !== _fullscreenOverlay
+        var wasAtMiddle = !atBottom && !atTop
+        var goingUp = (atBottom || wasAtMiddle) && state === _fullscreenOverlay
+        var goingDown = (atTop || wasAtMiddle) && (state === _chromeVisible || state === _fullscreenWebPage || state === _doubleToolBar || state === _noOverlay || state == _draggingOverlay)
+
+        if (state !== _fullscreenOverlay) {
             atTop = false
-        } if (state !== "chromeVisible" && state !== "fullscreenWebPage" && state !== "doubleToolBar") {
+        } if (state !== _chromeVisible && state !== _fullscreenWebPage && state !== _doubleToolBar) {
             atBottom = false
         }
+
+        direction = goingUp ? "upwards" : (goingDown ? "downwards" : "")
     }
 
     Connections {
@@ -100,16 +114,16 @@ Item {
             }
 
             if (webView.fullscreenMode) {
-                updateState("fullscreenWebPage")
+                updateState(_fullscreenWebPage)
             } else {
-                updateState("chromeVisible")
+                updateState(_chromeVisible)
             }
         }
     }
 
     states: [
         State {
-            name: "fullscreenWebPage"
+            name: _fullscreenWebPage
             changes: [
                 PropertyChanges {
                     target: overlay
@@ -118,11 +132,11 @@ Item {
             ]
         },
         State {
-            name: "noOverlay"
-            extend: "fullscreenWebPage"
+            name: _noOverlay
+            extend: _fullscreenWebPage
         },
         State {
-            name: "chromeVisible"
+            name: _chromeVisible
             changes: [
                 PropertyChanges {
                     target: overlay
@@ -131,7 +145,7 @@ Item {
             ]
         },
         State {
-            name: "draggingOverlay"
+            name: _draggingOverlay
             changes: [
                 PropertyChanges {
                     target: overlay
@@ -145,7 +159,7 @@ Item {
         },
 
         State {
-            name: "fullscreenOverlay"
+            name: _fullscreenOverlay
             changes: [
                 PropertyChanges {
                     target: overlay
@@ -155,7 +169,7 @@ Item {
         },
 
         State {
-            name: "doubleToolBar"
+            name: _doubleToolBar
             changes: [
                 PropertyChanges {
                     target: overlay
@@ -178,17 +192,22 @@ Item {
                 NumberAnimation { target: webView; property: "height"; duration: transitionDuration; easing.type: Easing.InOutQuad }
                 ScriptAction {
                     script: {
-                        if (animator.state === "chromeVisible" || animator.state === "fullscreenWebPage" || animator.state === "doubleToolBar") {
+                        if (animator.state === _chromeVisible || animator.state === _fullscreenWebPage || animator.state === _doubleToolBar) {
                             atBottom = true
-                        } else if (animator.state === "fullscreenOverlay") {
+                        } else if (animator.state === _fullscreenOverlay) {
                             atTop = true
                         }
 
                         if (webView.contentItem && !webView.contentItem.fullscreen) {
-                            webView.contentItem.chrome = animator.state !== "fullscreenWebPage"
+                            webView.contentItem.chrome = animator.state !== _fullscreenWebPage
                         }
                         _immediate = false
-                        overlay.visible = animator.state !== "fullscreenWebPage" && animator.state !== "noOverlay"
+                        overlay.visible = animator.state !== _fullscreenWebPage && animator.state !== _noOverlay
+
+                        // Target reached, clear it.
+                        if (atBottom || atTop) {
+                            direction = ""
+                        }
                     }
                 }
             }
@@ -197,7 +216,7 @@ Item {
         }
         ,
         Transition {
-            to: "draggingOverlay"
+            to: _draggingOverlay
             NumberAnimation { target: overlay.toolBar; property: "secondaryToolsHeight"; duration: transitionDuration; easing.type: Easing.InOutQuad }
         }
     ]

--- a/src/pages/components/OverlayAnimator.qml
+++ b/src/pages/components/OverlayAnimator.qml
@@ -18,7 +18,6 @@ Item {
     property QtObject webView
     property bool portrait
     property bool atTop
-    property bool atMiddle
     property bool atBottom: true
     property int transitionDuration: !_immediate ? 400 : 0
     property real openYPosition: portrait ? overlay.toolBar.toolsHeight : 0
@@ -88,8 +87,6 @@ Item {
             atTop = false
         } if (state !== "chromeVisible" && state !== "fullscreenWebPage" && state !== "doubleToolBar") {
             atBottom = false
-        } if (state !== "loadProgressOverlay") {
-            atMiddle = false
         }
     }
 


### PR DESCRIPTION
- Use animator for animating favorite grid and history list
- Don't unnecessary open virtual keyboard
- Enable clipping for the overlay only when absolutely mandatory