### PR TITLE
[sailfish-browser] Add "like Andoird" token to user agent string. Contributes to JB#30687

### DIFF
--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -74,7 +74,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     // TODO : Remove this and set custom user agent always
     // Don't set custom user agent string when arguments contains -developerMode, give url as last argument
     if (!app->arguments().contains("-developerMode")) {
-        setenv("CUSTOM_UA", "Mozilla/5.0 (Maemo; Linux; U; Jolla; Sailfish; Mobile; rv:31.0) Gecko/31.0 Firefox/31.0 SailfishBrowser/1.0", 1);
+        setenv("CUSTOM_UA", "Mozilla/5.0 (Maemo; Linux; U; Jolla; Sailfish; Mobile; like Android; rv:31.0) Gecko/31.0 Firefox/31.0 SailfishBrowser/1.0", 1);
     }
 
     BrowserService *service = new BrowserService(app.data());


### PR DESCRIPTION
The "like Android" keyword goal is to tell the servers that we're not
really Android, but would like to get the same content. Such token is
for example used in Windows mobile 8.1 browser.