### PR TITLE
[sailfish-browser] Fix virtual keyboard first time opening. Fixes JB#30972

### DIFF
--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -127,9 +127,8 @@ Background {
                 if (!WebUtils.firstUseDone) {
                     WebUtils.firstUseDone = true
                 }
-
-                dragArea.moved = false
             }
+            dragArea.moved = false
         }
 
         onAtTopChanged: {
@@ -270,6 +269,11 @@ Background {
                 id: searchField
 
                 readonly property bool requestingFocus: overlayAnimator.atTop && browserPage.active && !dragArea.moved
+
+                // Release focus when ever history list or favorite grid is moved and overlay itself starts moving
+                // from the top. After moving the overlay or the content, search field can be focused by tapping.
+                readonly property bool focusOut: dragArea.moved
+
                 property bool edited
                 property bool enteringNewTabUrl
 
@@ -321,8 +325,12 @@ Background {
                 onRequestingFocusChanged: {
                     if (requestingFocus) {
                         forceActiveFocus()
-                    } else {
-                        focus = false
+                    }
+                }
+
+                onFocusOutChanged: {
+                    if (focusOut) {
+                        overlay.focus = true
                     }
                 }
 
@@ -335,6 +343,7 @@ Background {
                         } else {
                             searchField.selectAll()
                         }
+                        dragArea.moved = false
                     }
                 }
 


### PR DESCRIPTION
There were to cases:
1) After browser start the virtual keyboard didn't appear when url was
clicked from the toolbar

2) When to overlay content was moved and the search field was focused
afterwards the virtual keyboard didn't close propertly