### PR TITLE
[history] Use actual current URL when modifying session history.

### DIFF
--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -160,11 +160,12 @@ void DeclarativeWebPage::restoreHistory() {
         urls << link.url();
         if (link.linkId() == m_initialTab.currentLink()) {
             index = i;
-            if (link.url() != m_initialTab.url()) {
+            QString currentUrl(url().toString());
+            if (link.url() != currentUrl) {
                 // The browser was started with an initial URL as a cmdline parameter -> reset tab history
-                urls << m_initialTab.url();
+                urls << currentUrl;
                 index++;
-                DBManager::instance()->navigateTo(tabId(), m_initialTab.url(), "", "");
+                DBManager::instance()->navigateTo(tabId(), currentUrl, "", "");
                 break;
             }
         }


### PR DESCRIPTION
By the time session history is restored WebPage already knows
its actual URL since this is one of two conditions required to
be met when DeclarativeWebPage::restoreHistory() is called.
This actual URL needs to be provided to Gecko's DocShell
when loading session history instead of the tab's initialURL,
because Gecko may alter the URL when loading a page.

For example initialURL instead of a valid URI may contain a text
input which will be recognized as a request to search engine.
Another example would be initialURL containing just a file path
without proto. This input will be recognized as an URL of
file:// protocol. And so on...