### PR TITLE
[sailfish-browser] Send "low-memory" notification to gecko on warning/critical memory level. Contributes to JB#30573

### DIFF
--- a/src/core/webpages.cpp
+++ b/src/core/webpages.cpp
@@ -255,6 +255,7 @@ void WebPages::handleMemNotify(const QString &memoryLevel)
             connect(m_activePages.activeWebPage(), SIGNAL(completedChanged()), this, SLOT(delayVirtualization()), Qt::UniqueConnection);
         }
 
+        QMozContext::GetInstance()->sendObserve(QString("memory-pressure"), QString("low-memory"));
         if (!m_webContainer->foreground() &&
                 (QDateTime::currentMSecsSinceEpoch() - m_backgroundTimestamp) > gMemoryPressureTimeout) {
             m_backgroundTimestamp = QDateTime::currentMSecsSinceEpoch();

--- a/src/declarativewebutils.cpp
+++ b/src/declarativewebutils.cpp
@@ -186,11 +186,6 @@ void DeclarativeWebUtils::updateWebEngineSettings()
     mozContext->setPref(QStringLiteral("embedlite.inputItemSize"), QVariant(m_inputItemSize));
     mozContext->setPref(QStringLiteral("embedlite.zoomMargin"), QVariant(m_zoomMargin));
 
-    // Memory management related preferences.
-    // We're sending "memory-pressure" when browser is on background (cover by another application)
-    // and when the browser page is inactivated.
-    mozContext->setPref(QString("javascript.options.gc_on_memory_pressure"), QVariant(true));
-
     // Disable SSLv3
     mozContext->setPref(QString("security.tls.version.min"), QVariant(1));
 


### PR DESCRIPTION
Due to "low-memory" memory notification we cannot run gc upon
memory pressure. So, let the engine to run to gc when needed.

I feel that this approach works nicely with the https://github.com/nemomobile-packages/gecko-dev/pull/43