### PR TITLE
Refactor storage subsystem

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -79,8 +79,9 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     QMozContext::GetInstance()->setPixelRatio(2.0);
 
     m_webPages = new WebPages(this);
-    m_persistentTabModel = new PersistentTabModel(this);
-    m_privateTabModel = new PrivateTabModel(this);
+    int maxTabid = DBManager::instance()->getMaxTabId();
+    m_persistentTabModel = new PersistentTabModel(maxTabid + 1, this);
+    m_privateTabModel = new PrivateTabModel(maxTabid + 1001, this);
 
     setTabModel(privateMode() ? m_privateTabModel.data() : m_persistentTabModel.data());
 

--- a/src/history/declarativehistorymodel.cpp
+++ b/src/history/declarativehistorymodel.cpp
@@ -18,8 +18,8 @@ DeclarativeHistoryModel::DeclarativeHistoryModel(QObject *parent)
 {
     connect(DBManager::instance(), SIGNAL(historyAvailable(QList<Link>)),
             this, SLOT(historyAvailable(QList<Link>)));
-    connect(DBManager::instance(), SIGNAL(titleChanged(int,int,QString,QString)),
-            this, SLOT(updateTitle(int,int,QString,QString)));
+    connect(DBManager::instance(), SIGNAL(titleChanged(QString,QString)),
+            this, SLOT(updateTitle(QString,QString)));
 }
 
 QHash<int, QByteArray> DeclarativeHistoryModel::roleNames() const
@@ -114,10 +114,8 @@ void DeclarativeHistoryModel::updateModel(QList<Link> linkList)
     }
 }
 
-void DeclarativeHistoryModel::updateTitle(int tabId, int linkId, QString url, QString title)
+void DeclarativeHistoryModel::updateTitle(QString url, QString title)
 {
-    Q_UNUSED(tabId);
-    Q_UNUSED(linkId);
     QVector<int> roles;
     roles << TitleRole;
     for (int i = 0; i < m_links.count(); i++) {

--- a/src/history/declarativehistorymodel.h
+++ b/src/history/declarativehistorymodel.h
@@ -49,7 +49,7 @@ signals:
 
 private slots:
     void historyAvailable(QList<Link> linkList);
-    void updateTitle(int tabId, int linkId, QString url, QString title);
+    void updateTitle(QString url, QString title);
 
 private:
     void updateModel(QList<Link> linkList);

--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -282,7 +282,6 @@ void DeclarativeTabModel::updateUrl(int tabId, const QString &url, bool initialL
         m_tabs[tabIndex].setUrl(url);
 
         if (!initialLoad) {
-            m_tabs[tabIndex].setCurrentLink(nextLinkId());
             updateDb = true;
         }
         m_tabs[tabIndex].setThumbnailPath("");
@@ -443,7 +442,7 @@ void DeclarativeTabModel::onTitleChanged()
             roles << TitleRole;
             m_tabs[tabIndex].setTitle(title);
             emit dataChanged(index(tabIndex, 0), index(tabIndex, 0), roles);
-            updateTitle(tabId, m_tabs.at(tabIndex).currentLink(), webPage->url().toString(), title);
+            updateTitle(tabId, webPage->url().toString(), title);
         }
     }
 }

--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -56,10 +56,8 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title, int i
 
     Q_ASSERT(index >= 0 && index <= m_tabs.count());
 
-    int tabId = createTab();
-    int linkId = createLink(tabId, url, title);
+    Tab tab = createTab(url, title);
 
-    Tab tab(tabId, Link(linkId, url, "", title));
 #if DEBUG_LOGS
     qDebug() << "new tab data:" << &tab;
 #endif
@@ -72,9 +70,9 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title, int i
     updateActiveTab(tab, true);
 
     emit countChanged();
-    emit tabAdded(tabId);
+    emit tabAdded(tab.tabId());
 
-    m_nextTabId = ++tabId;
+    m_nextTabId = tab.tabId() + 1;
     emit nextTabIdChanged();
 }
 

--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -73,7 +73,6 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title, int i
     emit tabAdded(tab.tabId());
 
     m_nextTabId = tab.tabId() + 1;
-    emit nextTabIdChanged();
 }
 
 int DeclarativeTabModel::nextTabId() const

--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -56,7 +56,7 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title, int i
 
     Q_ASSERT(index >= 0 && index <= m_tabs.count());
 
-    Tab tab = createTab(url, title);
+    Tab tab = createTab(m_nextTabId, url, title);
 
 #if DEBUG_LOGS
     qDebug() << "new tab data:" << &tab;

--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -56,7 +56,8 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title, int i
 
     Q_ASSERT(index >= 0 && index <= m_tabs.count());
 
-    Tab tab = createTab(m_nextTabId, url, title);
+    const Tab tab(m_nextTabId, url, title, "");
+    createTab(tab);
 
 #if DEBUG_LOGS
     qDebug() << "new tab data:" << &tab;

--- a/src/history/declarativetabmodel.h
+++ b/src/history/declarativetabmodel.h
@@ -27,7 +27,6 @@ class DeclarativeTabModel : public QAbstractListModel
 protected:
     Q_PROPERTY(int activeTabIndex READ activeTabIndex NOTIFY activeTabIndexChanged FINAL)
     Q_PROPERTY(int count READ count NOTIFY countChanged FINAL)
-    Q_PROPERTY(int nextTabId READ nextTabId NOTIFY nextTabIdChanged FINAL)
     Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged FINAL)
     Q_PROPERTY(bool waitingForNewTab READ waitingForNewTab WRITE setWaitingForNewTab NOTIFY waitingForNewTabChanged FINAL)
 
@@ -89,7 +88,6 @@ signals:
     // only for testing purposes.
     void tabAdded(int tabId);
     void tabClosed(int tabId);
-    void nextTabIdChanged();
     void loadedChanged();
     void waitingForNewTabChanged();
     void newTabRequested(QString url, QString title, int parentId = 0);

--- a/src/history/declarativetabmodel.h
+++ b/src/history/declarativetabmodel.h
@@ -101,8 +101,7 @@ protected:
     void updateActiveTab(const Tab &activeTab, bool loadActiveTab);
     void updateUrl(int tabId, const QString &url, bool initialLoad);
 
-    virtual int createTab() = 0;
-    virtual int createLink(int tabId, QString url, QString title) = 0;
+    virtual Tab createTab(QString url, QString title) = 0;
     virtual void updateTitle(int tabId, int linkId, QString url, QString title) = 0;
     virtual void removeTab(int tabId) = 0;
     virtual int nextLinkId() = 0;

--- a/src/history/declarativetabmodel.h
+++ b/src/history/declarativetabmodel.h
@@ -100,9 +100,8 @@ protected:
     void updateUrl(int tabId, const QString &url, bool initialLoad);
 
     virtual Tab createTab(int tabId, QString url, QString title) = 0;
-    virtual void updateTitle(int tabId, int linkId, QString url, QString title) = 0;
+    virtual void updateTitle(int tabId, QString url, QString title) = 0;
     virtual void removeTab(int tabId) = 0;
-    virtual int nextLinkId() = 0;
     virtual void navigateTo(int tabId, QString url, QString title, QString path) = 0;
     virtual void updateThumbPath(int tabId, QString path) = 0;
 

--- a/src/history/declarativetabmodel.h
+++ b/src/history/declarativetabmodel.h
@@ -99,7 +99,7 @@ protected:
     void updateActiveTab(const Tab &activeTab, bool loadActiveTab);
     void updateUrl(int tabId, const QString &url, bool initialLoad);
 
-    virtual Tab createTab(int tabId, QString url, QString title) = 0;
+    virtual void createTab(const Tab &tab) = 0;
     virtual void updateTitle(int tabId, QString url, QString title) = 0;
     virtual void removeTab(int tabId) = 0;
     virtual void navigateTo(int tabId, QString url, QString title, QString path) = 0;

--- a/src/history/declarativetabmodel.h
+++ b/src/history/declarativetabmodel.h
@@ -32,7 +32,7 @@ protected:
     Q_PROPERTY(bool waitingForNewTab READ waitingForNewTab WRITE setWaitingForNewTab NOTIFY waitingForNewTabChanged FINAL)
 
 public:
-    DeclarativeTabModel(int nextTabId = 1, DeclarativeWebContainer *webContainer = 0);
+    DeclarativeTabModel(int nextTabId, DeclarativeWebContainer *webContainer = 0);
     ~DeclarativeTabModel();
 
     enum TabRoles {
@@ -101,7 +101,7 @@ protected:
     void updateActiveTab(const Tab &activeTab, bool loadActiveTab);
     void updateUrl(int tabId, const QString &url, bool initialLoad);
 
-    virtual Tab createTab(QString url, QString title) = 0;
+    virtual Tab createTab(int tabId, QString url, QString title) = 0;
     virtual void updateTitle(int tabId, int linkId, QString url, QString title) = 0;
     virtual void removeTab(int tabId) = 0;
     virtual int nextLinkId() = 0;

--- a/src/history/persistenttabmodel.cpp
+++ b/src/history/persistenttabmodel.cpp
@@ -82,18 +82,14 @@ Tab PersistentTabModel::createTab(int tabId, QString url, QString title) {
     return DBManager::instance()->createTab(tabId, url, title);
 }
 
-void PersistentTabModel::updateTitle(int tabId, int linkId, QString url, QString title)
+void PersistentTabModel::updateTitle(int tabId, QString url, QString title)
 {
-    DBManager::instance()->updateTitle(tabId, linkId, url, title);
+    DBManager::instance()->updateTitle(tabId, url, title);
 }
 
 void PersistentTabModel::removeTab(int tabId)
 {
     DBManager::instance()->removeTab(tabId);
-}
-
-int PersistentTabModel::nextLinkId() {
-    return DBManager::instance()->nextLinkId();
 }
 
 void PersistentTabModel::navigateTo(int tabId, QString url, QString title, QString path) {

--- a/src/history/persistenttabmodel.cpp
+++ b/src/history/persistenttabmodel.cpp
@@ -78,8 +78,8 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
             this, SLOT(saveActiveTab()), Qt::UniqueConnection);
 }
 
-Tab PersistentTabModel::createTab(int tabId, QString url, QString title) {
-    return DBManager::instance()->createTab(tabId, url, title);
+void PersistentTabModel::createTab(const Tab &tab) {
+    DBManager::instance()->createTab(tab);
 }
 
 void PersistentTabModel::updateTitle(int tabId, QString url, QString title)

--- a/src/history/persistenttabmodel.cpp
+++ b/src/history/persistenttabmodel.cpp
@@ -73,12 +73,8 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
             this, SLOT(saveActiveTab()), Qt::UniqueConnection);
 }
 
-int PersistentTabModel::createTab() {
-    return DBManager::instance()->createTab();
-}
-
-int PersistentTabModel::createLink(int tabId, QString url, QString title) {
-    return DBManager::instance()->createLink(tabId, url, title);
+Tab PersistentTabModel::createTab(QString url, QString title) {
+    return DBManager::instance()->createTab(url, title);
 }
 
 void PersistentTabModel::updateTitle(int tabId, int linkId, QString url, QString title)

--- a/src/history/persistenttabmodel.cpp
+++ b/src/history/persistenttabmodel.cpp
@@ -28,7 +28,7 @@ PersistentTabModel::~PersistentTabModel()
 {
 }
 
-void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
+void PersistentTabModel::tabsAvailable(const QList<Tab> &tabs)
 {
     beginResetModel();
     int oldCount = count();
@@ -58,7 +58,7 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
     }
 
     int maxTabId(0);
-    foreach (Tab tab, tabs) {
+    foreach (const Tab &tab, tabs) {
         if (maxTabId < tab.tabId()) {
             maxTabId = tab.tabId();
         }

--- a/src/history/persistenttabmodel.cpp
+++ b/src/history/persistenttabmodel.cpp
@@ -15,8 +15,8 @@
 #include "persistenttabmodel.h"
 #include "dbmanager.h"
 
-PersistentTabModel::PersistentTabModel(DeclarativeWebContainer *webContainer)
-    : DeclarativeTabModel(DBManager::instance()->getMaxTabId() + 1, webContainer)
+PersistentTabModel::PersistentTabModel(int nextTabId, DeclarativeWebContainer *webContainer)
+    : DeclarativeTabModel(nextTabId, webContainer)
 {
     connect(DBManager::instance(), SIGNAL(tabsAvailable(QList<Tab>)),
             this, SLOT(tabsAvailable(QList<Tab>)));
@@ -57,7 +57,13 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
         emit countChanged();
     }
 
-    int maxTabId = DBManager::instance()->getMaxTabId();
+    int maxTabId(0);
+    foreach (Tab tab, tabs) {
+        if (maxTabId < tab.tabId()) {
+            maxTabId = tab.tabId();
+        }
+    }
+
     if (m_nextTabId != maxTabId + 1) {
         m_nextTabId = maxTabId + 1;
         emit nextTabIdChanged();
@@ -73,8 +79,8 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
             this, SLOT(saveActiveTab()), Qt::UniqueConnection);
 }
 
-Tab PersistentTabModel::createTab(QString url, QString title) {
-    return DBManager::instance()->createTab(url, title);
+Tab PersistentTabModel::createTab(int tabId, QString url, QString title) {
+    return DBManager::instance()->createTab(tabId, url, title);
 }
 
 void PersistentTabModel::updateTitle(int tabId, int linkId, QString url, QString title)

--- a/src/history/persistenttabmodel.cpp
+++ b/src/history/persistenttabmodel.cpp
@@ -66,7 +66,6 @@ void PersistentTabModel::tabsAvailable(QList<Tab> tabs)
 
     if (m_nextTabId != maxTabId + 1) {
         m_nextTabId = maxTabId + 1;
-        emit nextTabIdChanged();
     }
 
     // Startup should be synced to this.

--- a/src/history/persistenttabmodel.h
+++ b/src/history/persistenttabmodel.h
@@ -22,9 +22,8 @@ class PersistentTabModel : public DeclarativeTabModel
 
 protected:
     virtual Tab createTab(int tabId, QString url, QString title);
-    virtual void updateTitle(int tabId, int linkId, QString url, QString title);
+    virtual void updateTitle(int tabId, QString url, QString title);
     virtual void removeTab(int tabId);
-    virtual int nextLinkId();
     virtual void navigateTo(int tabId, QString url, QString title, QString path);
     virtual void updateThumbPath(int tabId, QString path);
 

--- a/src/history/persistenttabmodel.h
+++ b/src/history/persistenttabmodel.h
@@ -21,7 +21,7 @@ class PersistentTabModel : public DeclarativeTabModel
     Q_OBJECT
 
 protected:
-    virtual Tab createTab(int tabId, QString url, QString title);
+    virtual void createTab(const Tab &tab);
     virtual void updateTitle(int tabId, QString url, QString title);
     virtual void removeTab(int tabId);
     virtual void navigateTo(int tabId, QString url, QString title, QString path);

--- a/src/history/persistenttabmodel.h
+++ b/src/history/persistenttabmodel.h
@@ -21,8 +21,7 @@ class PersistentTabModel : public DeclarativeTabModel
     Q_OBJECT
 
 protected:
-    virtual int createTab();
-    virtual int createLink(int tabId, QString url, QString title);
+    virtual Tab createTab(QString url, QString title);
     virtual void updateTitle(int tabId, int linkId, QString url, QString title);
     virtual void removeTab(int tabId);
     virtual int nextLinkId();

--- a/src/history/persistenttabmodel.h
+++ b/src/history/persistenttabmodel.h
@@ -21,7 +21,7 @@ class PersistentTabModel : public DeclarativeTabModel
     Q_OBJECT
 
 protected:
-    virtual Tab createTab(QString url, QString title);
+    virtual Tab createTab(int tabId, QString url, QString title);
     virtual void updateTitle(int tabId, int linkId, QString url, QString title);
     virtual void removeTab(int tabId);
     virtual int nextLinkId();
@@ -36,7 +36,7 @@ public slots:
     void tabsAvailable(QList<Tab> tabs);
 
 public:
-    PersistentTabModel(DeclarativeWebContainer *webContainer = 0);
+    PersistentTabModel(int nextTabId, DeclarativeWebContainer *webContainer = 0);
     ~PersistentTabModel();
 };
 

--- a/src/history/persistenttabmodel.h
+++ b/src/history/persistenttabmodel.h
@@ -29,10 +29,7 @@ protected:
 
 private slots:
     void saveActiveTab() const;
-
-public slots:
-    // TODO: Move to be private
-    void tabsAvailable(QList<Tab> tabs);
+    void tabsAvailable(const QList<Tab> &tabs);
 
 public:
     PersistentTabModel(int nextTabId, DeclarativeWebContainer *webContainer = 0);

--- a/src/history/privatetabmodel.cpp
+++ b/src/history/privatetabmodel.cpp
@@ -13,8 +13,8 @@
 #include "privatetabmodel.h"
 #include "dbmanager.h"
 
-PrivateTabModel::PrivateTabModel(DeclarativeWebContainer *webContainer)
-    : DeclarativeTabModel(DBManager::instance()->getMaxTabId() + 10000, webContainer),
+PrivateTabModel::PrivateTabModel(int nextTabId, DeclarativeWebContainer *webContainer)
+    : DeclarativeTabModel(nextTabId, webContainer),
       m_nextLinkId(1)
 {
     // Startup should be synced to this.
@@ -28,8 +28,8 @@ PrivateTabModel::~PrivateTabModel()
 {
 }
 
-Tab PrivateTabModel::createTab(QString url, QString title) {
-    return Tab(nextTabId(), Link(m_nextLinkId++, url, "", title));
+Tab PrivateTabModel::createTab(int tabId, QString url, QString title) {
+    return Tab(tabId, Link(m_nextLinkId++, url, "", title));
 }
 
 void PrivateTabModel::updateTitle(int tabId, int linkId, QString url, QString title)

--- a/src/history/privatetabmodel.cpp
+++ b/src/history/privatetabmodel.cpp
@@ -28,16 +28,8 @@ PrivateTabModel::~PrivateTabModel()
 {
 }
 
-int PrivateTabModel::createTab() {
-    return nextTabId();
-}
-
-int PrivateTabModel::createLink(int tabId, QString url, QString title) {
-    Q_UNUSED(tabId)
-    Q_UNUSED(url)
-    Q_UNUSED(title)
-
-    return m_nextLinkId++;
+Tab PrivateTabModel::createTab(QString url, QString title) {
+    return Tab(nextTabId(), Link(m_nextLinkId++, url, "", title));
 }
 
 void PrivateTabModel::updateTitle(int tabId, int linkId, QString url, QString title)

--- a/src/history/privatetabmodel.cpp
+++ b/src/history/privatetabmodel.cpp
@@ -13,8 +13,6 @@
 #include "privatetabmodel.h"
 #include "dbmanager.h"
 
-#define LINK_ID 1000
-
 PrivateTabModel::PrivateTabModel(int nextTabId, DeclarativeWebContainer *webContainer)
     : DeclarativeTabModel(nextTabId, webContainer)
 {
@@ -30,7 +28,7 @@ PrivateTabModel::~PrivateTabModel()
 }
 
 Tab PrivateTabModel::createTab(int tabId, QString url, QString title) {
-    return Tab(tabId, Link(LINK_ID, url, "", title));
+    return Tab(tabId, url, title, "");
 }
 
 void PrivateTabModel::updateTitle(int tabId, QString url, QString title)

--- a/src/history/privatetabmodel.cpp
+++ b/src/history/privatetabmodel.cpp
@@ -13,9 +13,10 @@
 #include "privatetabmodel.h"
 #include "dbmanager.h"
 
+#define LINK_ID 1000
+
 PrivateTabModel::PrivateTabModel(int nextTabId, DeclarativeWebContainer *webContainer)
-    : DeclarativeTabModel(nextTabId, webContainer),
-      m_nextLinkId(1)
+    : DeclarativeTabModel(nextTabId, webContainer)
 {
     // Startup should be synced to this.
     if (!m_loaded) {
@@ -29,13 +30,12 @@ PrivateTabModel::~PrivateTabModel()
 }
 
 Tab PrivateTabModel::createTab(int tabId, QString url, QString title) {
-    return Tab(tabId, Link(m_nextLinkId++, url, "", title));
+    return Tab(tabId, Link(LINK_ID, url, "", title));
 }
 
-void PrivateTabModel::updateTitle(int tabId, int linkId, QString url, QString title)
+void PrivateTabModel::updateTitle(int tabId, QString url, QString title)
 {
     Q_UNUSED(tabId)
-    Q_UNUSED(linkId)
     Q_UNUSED(url)
     Q_UNUSED(title)
 }
@@ -43,10 +43,6 @@ void PrivateTabModel::updateTitle(int tabId, int linkId, QString url, QString ti
 void PrivateTabModel::removeTab(int tabId)
 {
     Q_UNUSED(tabId)
-}
-
-int PrivateTabModel::nextLinkId() {
-    return m_nextLinkId;
 }
 
 void PrivateTabModel::navigateTo(int tabId, QString url, QString title, QString path) {

--- a/src/history/privatetabmodel.cpp
+++ b/src/history/privatetabmodel.cpp
@@ -27,8 +27,8 @@ PrivateTabModel::~PrivateTabModel()
 {
 }
 
-Tab PrivateTabModel::createTab(int tabId, QString url, QString title) {
-    return Tab(tabId, url, title, "");
+void PrivateTabModel::createTab(const Tab &tab) {
+    Q_UNUSED(tab);
 }
 
 void PrivateTabModel::updateTitle(int tabId, QString url, QString title)

--- a/src/history/privatetabmodel.h
+++ b/src/history/privatetabmodel.h
@@ -21,7 +21,7 @@ class PrivateTabModel : public DeclarativeTabModel
     Q_OBJECT
 
 protected:
-    virtual Tab createTab(QString url, QString title);
+    virtual Tab createTab(int tabId, QString url, QString title);
     virtual void updateTitle(int tabId, int linkId, QString url, QString title);
     virtual void removeTab(int tabId);
     virtual int nextLinkId();
@@ -29,7 +29,7 @@ protected:
     virtual void updateThumbPath(int tabId, QString path);
 
 public:
-    PrivateTabModel(DeclarativeWebContainer *webContainer = 0);
+    PrivateTabModel(int nextTabId, DeclarativeWebContainer *webContainer = 0);
     ~PrivateTabModel();
 
 private:

--- a/src/history/privatetabmodel.h
+++ b/src/history/privatetabmodel.h
@@ -21,8 +21,7 @@ class PrivateTabModel : public DeclarativeTabModel
     Q_OBJECT
 
 protected:
-    virtual int createTab();
-    virtual int createLink(int tabId, QString url, QString title);
+    virtual Tab createTab(QString url, QString title);
     virtual void updateTitle(int tabId, int linkId, QString url, QString title);
     virtual void removeTab(int tabId);
     virtual int nextLinkId();

--- a/src/history/privatetabmodel.h
+++ b/src/history/privatetabmodel.h
@@ -21,7 +21,7 @@ class PrivateTabModel : public DeclarativeTabModel
     Q_OBJECT
 
 protected:
-    virtual Tab createTab(int tabId, QString url, QString title);
+    virtual void createTab(const Tab &tab);
     virtual void updateTitle(int tabId, QString url, QString title);
     virtual void removeTab(int tabId);
     virtual void navigateTo(int tabId, QString url, QString title, QString path);

--- a/src/history/privatetabmodel.h
+++ b/src/history/privatetabmodel.h
@@ -22,18 +22,14 @@ class PrivateTabModel : public DeclarativeTabModel
 
 protected:
     virtual Tab createTab(int tabId, QString url, QString title);
-    virtual void updateTitle(int tabId, int linkId, QString url, QString title);
+    virtual void updateTitle(int tabId, QString url, QString title);
     virtual void removeTab(int tabId);
-    virtual int nextLinkId();
     virtual void navigateTo(int tabId, QString url, QString title, QString path);
     virtual void updateThumbPath(int tabId, QString path);
 
 public:
     PrivateTabModel(int nextTabId, DeclarativeWebContainer *webContainer = 0);
     ~PrivateTabModel();
-
-private:
-    int m_nextLinkId;
 };
 
 #endif // PRIVATETABMODEL_H

--- a/src/qtmozembed/declarativewebpage.h
+++ b/src/qtmozembed/declarativewebpage.h
@@ -84,7 +84,7 @@ signals:
 private slots:
     void setFullscreen(const bool fullscreen);
     void onRecvAsyncMessage(const QString& message, const QVariant& data);
-    void onTabHistoryAvailable(const int& historyTabId, const QList<Link>& links);
+    void onTabHistoryAvailable(const int& historyTabId, const QList<Link>& links, int currentLinkId);
     void onUrlChanged();
     void grabResultReady();
     void grabWritten();
@@ -110,6 +110,7 @@ private:
     QSharedPointer<QMozGrabResult> m_thumbnailResult;
     QFutureWatcher<QString> m_grabWritter;
     QList<Link> m_restoredTabHistory;
+    int m_restoredCurrentLinkId;
 
     qreal m_fullScreenHeight;
     qreal m_toolbarHeight;

--- a/src/storage/dbmanager.cpp
+++ b/src/storage/dbmanager.cpp
@@ -38,7 +38,7 @@ DBManager::DBManager(QObject *parent)
     connect(&workerThread, SIGNAL(finished()), worker, SLOT(deleteLater()));
     connect(worker, SIGNAL(tabsAvailable(QList<Tab>)), this, SLOT(tabListAvailable(QList<Tab>)));
     connect(worker, SIGNAL(historyAvailable(QList<Link>)), this, SIGNAL(historyAvailable(QList<Link>)));
-    connect(worker, SIGNAL(tabHistoryAvailable(int,QList<Link>)), this, SIGNAL(tabHistoryAvailable(int,QList<Link>)));
+    connect(worker, SIGNAL(tabHistoryAvailable(int,QList<Link>,int)), this, SIGNAL(tabHistoryAvailable(int,QList<Link>,int)));
     connect(worker, SIGNAL(titleChanged(QString,QString)), this, SIGNAL(titleChanged(QString,QString)));
     connect(worker, SIGNAL(thumbPathChanged(int,QString)), this, SIGNAL(thumbPathChanged(int,QString)));
     workerThread.start();

--- a/src/storage/dbmanager.cpp
+++ b/src/storage/dbmanager.cpp
@@ -67,13 +67,10 @@ int DBManager::getMaxTabId()
     return maxTabId;
 }
 
-Tab DBManager::createTab(int tabId, QString url, QString title)
+void DBManager::createTab(const Tab &tab)
 {
-    Tab newTab;
-    QMetaObject::invokeMethod(worker, "createTab", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(Tab, newTab),
-                              Q_ARG(int, tabId), Q_ARG(QString, url), Q_ARG(QString, title));
-    return newTab;
+    QMetaObject::invokeMethod(worker, "createTab", Qt::QueuedConnection,
+                              Q_ARG(Tab, tab));
 }
 
 void DBManager::navigateTo(int tabId, QString url, QString title, QString path)

--- a/src/storage/dbmanager.cpp
+++ b/src/storage/dbmanager.cpp
@@ -36,7 +36,7 @@ DBManager::DBManager(QObject *parent)
     worker->moveToThread(&workerThread);
 
     connect(&workerThread, SIGNAL(finished()), worker, SLOT(deleteLater()));
-    connect(worker, SIGNAL(tabsAvailable(QList<Tab>)), this, SLOT(tabListAvailable(QList<Tab>)));
+    connect(worker, SIGNAL(tabsAvailable(QList<Tab>)), this, SIGNAL(tabsAvailable(QList<Tab>)));
     connect(worker, SIGNAL(historyAvailable(QList<Link>)), this, SIGNAL(historyAvailable(QList<Link>)));
     connect(worker, SIGNAL(tabHistoryAvailable(int,QList<Link>,int)), this, SIGNAL(tabHistoryAvailable(int,QList<Link>,int)));
     connect(worker, SIGNAL(titleChanged(QString,QString)), this, SIGNAL(titleChanged(QString,QString)));
@@ -155,9 +155,4 @@ void DBManager::deleteSetting(QString name)
         QMetaObject::invokeMethod(worker, "deleteSetting", Qt::BlockingQueuedConnection,
                                   Q_ARG(QString, name));
     }
-}
-
-void DBManager::tabListAvailable(QList<Tab> tabs)
-{
-    emit tabsAvailable(tabs);
 }

--- a/src/storage/dbmanager.cpp
+++ b/src/storage/dbmanager.cpp
@@ -77,24 +77,16 @@ int DBManager::nextLinkId()
     return m_nextLinkId;
 }
 
-int DBManager::createTab()
+Tab DBManager::createTab(QString url, QString title)
 {
-    QMetaObject::invokeMethod(worker, "createTab", Qt::QueuedConnection, Q_ARG(int, ++m_maxTabId));
-    return m_maxTabId;
-}
-
-int DBManager::createLink(int tabId, QString url, QString title)
-{
-    int linkId;
-    QMetaObject::invokeMethod(worker, "createLink", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(int, linkId), Q_ARG(int, tabId),
-                              Q_ARG(QString, url), Q_ARG(QString, title));
-
-    if (linkId == m_nextLinkId) {
+    Tab newTab;
+    QMetaObject::invokeMethod(worker, "createTab", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(Tab, newTab),
+                              Q_ARG(int, ++m_maxTabId), Q_ARG(QString, url), Q_ARG(QString, title));
+    if (newTab.currentLink() == m_nextLinkId) {
         ++m_nextLinkId;
     }
-
-    return linkId;
+    return newTab;
 }
 
 void DBManager::navigateTo(int tabId, QString url, QString title, QString path)

--- a/src/storage/dbmanager.h
+++ b/src/storage/dbmanager.h
@@ -48,9 +48,6 @@ public:
 
     int getMaxTabId();
 
-public slots:
-    void tabListAvailable(QList<Tab> tabs);
-
 signals:
     void tabsAvailable(QList<Tab> tab);
     void historyAvailable(QList<Link> links);

--- a/src/storage/dbmanager.h
+++ b/src/storage/dbmanager.h
@@ -36,7 +36,7 @@ public:
     void goBack(int tabId);
 
     void updateThumbPath(int tabId, QString path);
-    void updateTitle(int tabId, int linkId, QString url, QString title);
+    void updateTitle(int tabId, QString url, QString title);
 
     void clearHistory();
     void getHistory(const QString &filter = "");
@@ -47,7 +47,6 @@ public:
     void deleteSetting(QString name);
 
     int getMaxTabId();
-    int nextLinkId();
 
 public slots:
     void tabListAvailable(QList<Tab> tabs);
@@ -57,16 +56,12 @@ signals:
     void historyAvailable(QList<Link> links);
     void tabHistoryAvailable(int tabId, QList<Link> links);
     void thumbPathChanged(int tabId, QString path);
-    void titleChanged(int tabId, int linkId, QString url, QString title);
+    void titleChanged(QString url, QString title);
     void settingsChanged();
-
-private slots:
-    void updateNextLinkId(int linkId);
 
 private:
     DBManager(QObject *parent = 0);
 
-    int m_nextLinkId;
     QMap<QString, QString> m_settings;
 
     QThread workerThread;

--- a/src/storage/dbmanager.h
+++ b/src/storage/dbmanager.h
@@ -54,7 +54,7 @@ public slots:
 signals:
     void tabsAvailable(QList<Tab> tab);
     void historyAvailable(QList<Link> links);
-    void tabHistoryAvailable(int tabId, QList<Link> links);
+    void tabHistoryAvailable(int tabId, QList<Link> links, int currentLinkId);
     void thumbPathChanged(int tabId, QString path);
     void titleChanged(QString url, QString title);
     void settingsChanged();

--- a/src/storage/dbmanager.h
+++ b/src/storage/dbmanager.h
@@ -28,7 +28,7 @@ public:
     static DBManager *instance();
     virtual ~DBManager();
 
-    Tab createTab(QString url, QString title);
+    Tab createTab(int tabId, QString url, QString title);
     void getAllTabs();
     void removeTab(int tabId);
     void navigateTo(int tabId, QString url, QString title = "", QString path = "");
@@ -66,7 +66,6 @@ private slots:
 private:
     DBManager(QObject *parent = 0);
 
-    int m_maxTabId;
     int m_nextLinkId;
     QMap<QString, QString> m_settings;
 

--- a/src/storage/dbmanager.h
+++ b/src/storage/dbmanager.h
@@ -28,8 +28,7 @@ public:
     static DBManager *instance();
     virtual ~DBManager();
 
-    int createTab();
-    int createLink(int tabId, QString url, QString title);
+    Tab createTab(QString url, QString title);
     void getAllTabs();
     void removeTab(int tabId);
     void navigateTo(int tabId, QString url, QString title = "", QString path = "");

--- a/src/storage/dbmanager.h
+++ b/src/storage/dbmanager.h
@@ -28,7 +28,7 @@ public:
     static DBManager *instance();
     virtual ~DBManager();
 
-    Tab createTab(int tabId, QString url, QString title);
+    void createTab(const Tab &tab);
     void getAllTabs();
     void removeTab(int tabId);
     void navigateTo(int tabId, QString url, QString title = "", QString path = "");

--- a/src/storage/dbworker.cpp
+++ b/src/storage/dbworker.cpp
@@ -211,38 +211,36 @@ bool DBWorker::execute(QSqlQuery &query)
     return true;
 }
 
-Tab DBWorker::createTab(int tabId, QString url, QString title)
+void DBWorker::createTab(const Tab &tab)
 {
 #if DEBUG_LOGS
-    qDebug() << "new tab id: " << tabId;
+    qDebug() << "new tab id: " << tab.tabId();
 #endif
     QSqlQuery query = prepare("INSERT INTO tab (tab_id, tab_history_id) VALUES (?,?);");
-    query.bindValue(0, tabId);
+    query.bindValue(0, tab.tabId());
     query.bindValue(1, 0);
     execute(query);
 
-    if (url.isEmpty()) {
-        return Tab();
+    if (tab.url().isEmpty()) {
+        return;
     }
 
-    int linkId = createLink(url, title, "");
+    int linkId = createLink(tab.url(), tab.title(), tab.thumbnailPath());
 
-    if (addToBrowserHistory(url, title) == Error) {
-        qWarning() << Q_FUNC_INFO << "failed to add url to history" << url;
+    if (addToBrowserHistory(tab.url(), tab.title()) == Error) {
+        qWarning() << Q_FUNC_INFO << "failed to add url to history" << tab.url();
     }
 
-    int historyId = addToTabHistory(tabId, linkId);
+    int historyId = addToTabHistory(tab.tabId(), linkId);
     if (historyId > 0) {
-        updateTab(tabId, historyId);
+        updateTab(tab.tabId(), historyId);
     } else {
-        qWarning() << Q_FUNC_INFO << "failed to add url to tab history" << url;
+        qWarning() << Q_FUNC_INFO << "failed to add url to tab history" << tab.url();
     }
 
 #if DEBUG_LOGS
-    qDebug() << "created link:" << linkId << "with history id:" << historyId << "for tab:" << tabId << url;
+    qDebug() << "created link:" << linkId << "with history id:" << historyId << "for tab:" << tab.tabId() << tab.url();
 #endif
-
-    return Tab(tabId, url, title, "");
 }
 
 void DBWorker::updateTab(int tabId, int tabHistoryId)

--- a/src/storage/dbworker.cpp
+++ b/src/storage/dbworker.cpp
@@ -211,7 +211,7 @@ bool DBWorker::execute(QSqlQuery &query)
     return true;
 }
 
-void DBWorker::createTab(int tabId)
+Tab DBWorker::createTab(int tabId, QString url, QString title)
 {
 #if DEBUG_LOGS
     qDebug() << "new tab id: " << tabId;
@@ -220,12 +220,9 @@ void DBWorker::createTab(int tabId)
     query.bindValue(0, tabId);
     query.bindValue(1, 0);
     execute(query);
-}
 
-int DBWorker::createLink(int tabId, QString url, QString title)
-{
     if (url.isEmpty()) {
-        return 0;
+        return Tab();
     }
 
     int linkId = createLink(url, title, "");
@@ -244,7 +241,8 @@ int DBWorker::createLink(int tabId, QString url, QString title)
 #if DEBUG_LOGS
     qDebug() << "created link:" << linkId << "with history id:" << historyId << "for tab:" << tabId << url;
 #endif
-    return linkId;
+
+    return Tab(tabId, Link(linkId, url, "", title));
 }
 
 void DBWorker::updateTab(int tabId, int tabHistoryId)

--- a/src/storage/dbworker.cpp
+++ b/src/storage/dbworker.cpp
@@ -242,7 +242,7 @@ Tab DBWorker::createTab(int tabId, QString url, QString title)
     qDebug() << "created link:" << linkId << "with history id:" << historyId << "for tab:" << tabId << url;
 #endif
 
-    return Tab(tabId, Link(linkId, url, "", title));
+    return Tab(tabId, url, title, "");
 }
 
 void DBWorker::updateTab(int tabId, int tabHistoryId)
@@ -309,7 +309,7 @@ void DBWorker::removeAllTabs()
 void DBWorker::getAllTabs()
 {
     QList<Tab> tabList;
-    QSqlQuery query = prepare("SELECT tab.tab_id, link.link_id, link.url, link.thumb_path, link.title "
+    QSqlQuery query = prepare("SELECT tab.tab_id, link.url, link.title, link.thumb_path "
                               "FROM tab "
                               "INNER JOIN tab_history ON tab_history.id = tab.tab_history_id "
                               "INNER JOIN link ON tab_history.link_id = link.link_id;");
@@ -319,10 +319,9 @@ void DBWorker::getAllTabs()
 
     while (query.next()) {
         tabList.append(Tab(query.value(0).toInt(),
-                           Link(query.value(1).toInt(),
-                                query.value(2).toString(),
-                                query.value(3).toString(),
-                                query.value(4).toString())));
+                           query.value(1).toString(),
+                           query.value(2).toString(),
+                           query.value(3).toString()));
     }
     emit tabsAvailable(tabList);
 }

--- a/src/storage/dbworker.h
+++ b/src/storage/dbworker.h
@@ -40,9 +40,8 @@ public slots:
     void getAllTabs();
     void navigateTo(int tabId, QString url, QString title, QString path);
     int getMaxTabId();
-    int getMaxLinkId();
 
-    void updateTitle(int tabId, int linkId, QString url, QString title);
+    void updateTitle(int tabId, QString url, QString title);
     void updateThumbPath(int tabId, QString path);
 
     void goForward(int tabId);
@@ -58,11 +57,10 @@ public slots:
 signals:
     void tabsAvailable(QList<Tab> tabs);
     void thumbPathChanged(int tabId, QString path);
-    void titleChanged(int tabId, int linkId, QString url, QString title);
+    void titleChanged(QString url, QString title);
     void tabHistoryAvailable(int tabId, QList<Link>);
     void historyAvailable(QList<Link>);
     void error(QString query);
-    void nextLinkId(int linkId);
 
 private:
     Link getLink(int linkId);

--- a/src/storage/dbworker.h
+++ b/src/storage/dbworker.h
@@ -35,8 +35,7 @@ public:
 
 public slots:
     void init();
-    void createTab(int tabId);
-    int createLink(int tabId, QString url, QString title);
+    Tab createTab(int tabId, QString url, QString title);
     void removeTab(int tabId);
     void getAllTabs();
     void navigateTo(int tabId, QString url, QString title, QString path);

--- a/src/storage/dbworker.h
+++ b/src/storage/dbworker.h
@@ -63,15 +63,12 @@ signals:
     void error(QString query);
 
 private:
-    Link getLink(int linkId);
     HistoryResult addToBrowserHistory(QString url, QString title);
     int addToTabHistory(int tabId, int linkId);
-    Link getLinkFromTabHistory(int tabHistoryId);
     Link getCurrentLink(int tabId);
     void clearDeprecatedTabHistory(int tabId, int currentLinkId);
     int createLink(QString url, QString title = "", QString thumbPath = "");
     void updateTab(int tabId, int tabHistoryId);
-    Tab getTabData(int tabId, int historyId = 0);
     int tabCount();
     int integerQuery(const QString &statement);
     void migrateTo_1();

--- a/src/storage/dbworker.h
+++ b/src/storage/dbworker.h
@@ -58,7 +58,7 @@ signals:
     void tabsAvailable(QList<Tab> tabs);
     void thumbPathChanged(int tabId, QString path);
     void titleChanged(QString url, QString title);
-    void tabHistoryAvailable(int tabId, QList<Link>);
+    void tabHistoryAvailable(int tabId, QList<Link>, int currentLinkId);
     void historyAvailable(QList<Link>);
     void error(QString query);
 

--- a/src/storage/dbworker.h
+++ b/src/storage/dbworker.h
@@ -35,7 +35,7 @@ public:
 
 public slots:
     void init();
-    Tab createTab(int tabId, QString url, QString title);
+    void createTab(const Tab &tab);
     void removeTab(int tabId);
     void getAllTabs();
     void navigateTo(int tabId, QString url, QString title, QString path);

--- a/src/storage/tab.cpp
+++ b/src/storage/tab.cpp
@@ -11,8 +11,8 @@
 
 #include "tab.h"
 
-Tab::Tab(int tabId, Link link) :
-    m_tabId(tabId), m_link(link)
+Tab::Tab(int tabId, QString url, QString title, QString thumbPath) :
+    m_tabId(tabId), m_url(url), m_title(title), m_thumbPath(thumbPath)
 {
 }
 
@@ -33,32 +33,32 @@ void Tab::setTabId(int tabId)
 
 QString Tab::url() const
 {
-    return m_link.url();
+    return m_url;
 }
 
 void Tab::setUrl(const QString &url)
 {
-    m_link.setUrl(url);
+    m_url = url;
 }
 
 QString Tab::thumbnailPath() const
 {
-    return m_link.thumbPath();
+    return m_thumbPath;
 }
 
 void Tab::setThumbnailPath(const QString &thumbnailPath)
 {
-    m_link.setThumbPath(thumbnailPath);
+    m_thumbPath = thumbnailPath;
 }
 
 QString Tab::title() const
 {
-    return m_link.title();
+    return m_title;
 }
 
 void Tab::setTitle(const QString &title)
 {
-    m_link.setTitle(title);
+    m_title = title;
 }
 
 bool Tab::isValid() const
@@ -69,7 +69,9 @@ bool Tab::isValid() const
 bool Tab::operator==(const Tab &other) const
 {
     return (m_tabId == other.tabId() &&
-            m_link == other.m_link);
+            m_url == other.url() &&
+            m_title == other.title() &&
+            m_thumbPath == other.thumbnailPath());
 }
 
 bool Tab::operator!=(const Tab &other) const

--- a/src/storage/tab.cpp
+++ b/src/storage/tab.cpp
@@ -11,8 +11,8 @@
 
 #include "tab.h"
 
-Tab::Tab(int tabId, Link currentLink) :
-    m_tabId(tabId), m_currentLink(currentLink)
+Tab::Tab(int tabId, Link link) :
+    m_tabId(tabId), m_link(link)
 {
 }
 
@@ -31,44 +31,34 @@ void Tab::setTabId(int tabId)
     m_tabId = tabId;
 }
 
-int Tab::currentLink() const
-{
-    return m_currentLink.linkId();
-}
-
-void Tab::setCurrentLink(int currentLinkId)
-{
-    m_currentLink.setLinkId(currentLinkId);
-}
-
 QString Tab::url() const
 {
-    return m_currentLink.url();
+    return m_link.url();
 }
 
 void Tab::setUrl(const QString &url)
 {
-    m_currentLink.setUrl(url);
+    m_link.setUrl(url);
 }
 
 QString Tab::thumbnailPath() const
 {
-    return m_currentLink.thumbPath();
+    return m_link.thumbPath();
 }
 
 void Tab::setThumbnailPath(const QString &thumbnailPath)
 {
-    m_currentLink.setThumbPath(thumbnailPath);
+    m_link.setThumbPath(thumbnailPath);
 }
 
 QString Tab::title() const
 {
-    return m_currentLink.title();
+    return m_link.title();
 }
 
 void Tab::setTitle(const QString &title)
 {
-    m_currentLink.setTitle(title);
+    m_link.setTitle(title);
 }
 
 bool Tab::isValid() const
@@ -79,7 +69,7 @@ bool Tab::isValid() const
 bool Tab::operator==(const Tab &other) const
 {
     return (m_tabId == other.tabId() &&
-            m_currentLink == other.m_currentLink);
+            m_link == other.m_link);
 }
 
 bool Tab::operator!=(const Tab &other) const
@@ -92,7 +82,7 @@ QDebug operator<<(QDebug dbg, const Tab *tab) {
         return dbg << "Tab (this = 0x0)";
     }
 
-    dbg.nospace() << "Tab(tabId = " << tab->tabId() << ", isValid = " << tab->isValid() << ", linkId = " << tab->currentLink()
+    dbg.nospace() << "Tab(tabId = " << tab->tabId() << ", isValid = " << tab->isValid()
                   << ", url = " << tab->url() << ", title = " << tab->title() << ", thumbnailPath = " << tab->thumbnailPath() << ")";
     return dbg.space();
 }

--- a/src/storage/tab.h
+++ b/src/storage/tab.h
@@ -20,14 +20,11 @@
 class Tab
 {
 public:
-    explicit Tab(int tabId, Link currentLink);
+    explicit Tab(int tabId, Link link);
     explicit Tab();
 
     int tabId() const;
     void setTabId(int tabId);
-
-    int currentLink() const;
-    void setCurrentLink(int currentLinkId);
 
     QString url() const;
     void setUrl(const QString &url);
@@ -45,7 +42,7 @@ public:
 
 private:
     int m_tabId;
-    Link m_currentLink;
+    Link m_link;
 };
 
 QDebug operator<<(QDebug, const Tab *);

--- a/src/storage/tab.h
+++ b/src/storage/tab.h
@@ -15,12 +15,10 @@
 #include <QString>
 #include <QDebug>
 
-#include "link.h"
-
 class Tab
 {
 public:
-    explicit Tab(int tabId, Link link);
+    explicit Tab(int tabId, QString url, QString title, QString thumbPath);
     explicit Tab();
 
     int tabId() const;
@@ -42,7 +40,9 @@ public:
 
 private:
     int m_tabId;
-    Link m_link;
+    QString m_url;
+    QString m_title;
+    QString m_thumbPath;
 };
 
 QDebug operator<<(QDebug, const Tab *);

--- a/src/storage/tab.h
+++ b/src/storage/tab.h
@@ -46,7 +46,6 @@ public:
 private:
     int m_tabId;
     Link m_currentLink;
-    int m_nextLinkId;
 };
 
 QDebug operator<<(QDebug, const Tab *);

--- a/tests/auto/tests.xml
+++ b/tests/auto/tests.xml
@@ -17,7 +17,7 @@
                <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_linkvalidator</step>
            </case>
            <case manual="false" name="dbmanager">
-               <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_dbmanager -platform wayland-egl -iterations 10</step>
+               <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_dbmanager</step>
            </case>
            <case manual="false" timeout="300" name="webview">
                <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; LOW_MEMORY_DISABLED=1 ./tst_webview -platform wayland-egl</step>

--- a/tests/auto/tst_dbmanager/tst_dbmanager.cpp
+++ b/tests/auto/tst_dbmanager/tst_dbmanager.cpp
@@ -120,7 +120,7 @@ void tst_dbmanager::cleanupTestCase()
 
 void tst_dbmanager::createTab(QString url, QString title)
 {
-    DBManager::instance()->createTab(1000, url, title);
+    DBManager::instance()->createTab(Tab(1000, url, title, ""));
 }
 
 int main(int argc, char *argv[])

--- a/tests/auto/tst_dbmanager/tst_dbmanager.cpp
+++ b/tests/auto/tst_dbmanager/tst_dbmanager.cpp
@@ -120,8 +120,7 @@ void tst_dbmanager::cleanupTestCase()
 
 void tst_dbmanager::createTab(QString url, QString title)
 {
-    int tabId = DBManager::instance()->createTab();
-    DBManager::instance()->createLink(tabId, url, title);
+    DBManager::instance()->createTab(url, title);
 }
 
 int main(int argc, char *argv[])

--- a/tests/auto/tst_dbmanager/tst_dbmanager.cpp
+++ b/tests/auto/tst_dbmanager/tst_dbmanager.cpp
@@ -120,7 +120,7 @@ void tst_dbmanager::cleanupTestCase()
 
 void tst_dbmanager::createTab(QString url, QString title)
 {
-    DBManager::instance()->createTab(url, title);
+    DBManager::instance()->createTab(1000, url, title);
 }
 
 int main(int argc, char *argv[])

--- a/tests/auto/tst_dbmanager/tst_dbmanager.cpp
+++ b/tests/auto/tst_dbmanager/tst_dbmanager.cpp
@@ -391,9 +391,13 @@ void tst_dbmanager::getHistory()
     QList<QVariant> arguments = historyAvailableSpy.at(0);
     QList<Link> links = arguments.at(0).value<QList<Link> >();
     QCOMPARE(links.count(), 3);
-    QCOMPARE(links.at(0).url(), QString("http://example1.com"));
-    QCOMPARE(links.at(1).url(), QString("http://example2.com"));
-    QCOMPARE(links.at(2).url(), QString("http://example3-long.com"));
+    QSet<QString> linkset;
+    for (Link link : links) {
+        linkset.insert(link.url());
+    }
+    QVERIFY(linkset.contains(QString("http://example1.com")));
+    QVERIFY(linkset.contains(QString("http://example2.com")));
+    QVERIFY(linkset.contains(QString("http://example3-long.com")));
 
     // 2. empty filter
     DBManager::instance()->getHistory(QString());
@@ -402,11 +406,15 @@ void tst_dbmanager::getHistory()
     arguments = historyAvailableSpy.at(1);
     links = arguments.at(0).value<QList<Link> >();
     QCOMPARE(links.count(), 5);
-    QCOMPARE(links.at(0).url(), QString("http://example1.com"));
-    QCOMPARE(links.at(1).url(), QString("http://example3-long.com"));
-    QCOMPARE(links.at(2).url(), QString("http://unneeded1.net"));
-    QCOMPARE(links.at(3).url(), QString("http://example2.com"));
-    QCOMPARE(links.at(4).url(), QString("http://unneeded2.net"));
+    linkset.clear();
+    for (Link link : links) {
+        linkset.insert(link.url());
+    }
+    QVERIFY(linkset.contains(QString("http://example1.com")));
+    QVERIFY(linkset.contains(QString("http://example2.com")));
+    QVERIFY(linkset.contains(QString("http://example3-long.com")));
+    QVERIFY(linkset.contains(QString("http://unneeded1.net")));
+    QVERIFY(linkset.contains(QString("http://unneeded2.net")));
 }
 
 void tst_dbmanager::getTabHistory()

--- a/tests/auto/tst_dbmanager/tst_dbmanager.pro
+++ b/tests/auto/tst_dbmanager/tst_dbmanager.pro
@@ -3,7 +3,6 @@ TARGET = tst_dbmanager
 QT += quick concurrent sql
 
 include(../test_common.pri)
-include(../common/testobject.pri)
 include(../../../src/storage/storage.pri)
 
 SOURCES += tst_dbmanager.cpp

--- a/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.cpp
+++ b/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.cpp
@@ -17,15 +17,14 @@
 #include "persistenttabmodel.h"
 #include "declarativehistorymodel.h"
 #include "testobject.h"
+#include "dbmanager.h"
 
 static const QByteArray QML_SNIPPET = \
         "import QtQuick 2.0\n" \
         "import Sailfish.Browser 1.0\n" \
         "Item {\n" \
         "   width: 100; height: 100\n" \
-        "   property alias tabModel: tabModel\n" \
         "   property alias historyModel: historyModel\n" \
-        "   PersistentTabModel { id: tabModel }\n" \
         "   HistoryModel { id: historyModel }\n" \
         "}\n";
 
@@ -65,12 +64,13 @@ private:
 tst_declarativehistorymodel::tst_declarativehistorymodel()
     : TestObject(QML_SNIPPET)
 {
-    tabModel = TestObject::qmlObject<DeclarativeTabModel>("tabModel");
-    historyModel = TestObject::qmlObject<DeclarativeHistoryModel>("historyModel");
 }
 
 void tst_declarativehistorymodel::initTestCase()
 {
+    tabModel = new PersistentTabModel(DBManager::instance()->getMaxTabId() + 1);
+    historyModel = TestObject::qmlObject<DeclarativeHistoryModel>("historyModel");
+
     QVERIFY(tabModel);
     QVERIFY(historyModel);
 
@@ -258,6 +258,7 @@ void tst_declarativehistorymodel::cleanupTestCase()
 {
     tabModel->clear();
     QVERIFY(tabModel->count() == 0);
+    delete tabModel;
 
     // Wait for event loop of db manager
     QTest::qWait(1000);
@@ -272,7 +273,6 @@ int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
     app.setAttribute(Qt::AA_Use96Dpi, true);
-    qmlRegisterType<PersistentTabModel>("Sailfish.Browser", 1, 0, "PersistentTabModel");
     qmlRegisterType<DeclarativeHistoryModel>("Sailfish.Browser", 1, 0, "HistoryModel");
     tst_declarativehistorymodel testcase;
     return QTest::qExec(&testcase, argc, argv); \

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.cpp
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.cpp
@@ -17,6 +17,8 @@
 #include "settingmanager.h"
 #include "tab.h"
 
+#define NEXT_TAB_ID 1000
+
 using ::testing::Return;
 using ::testing::_;
 
@@ -120,7 +122,7 @@ void tst_declarativewebcontainer::setWebPage()
 void tst_declarativewebcontainer::setTabModel()
 {
     // Set up
-    PrivateTabModel model;
+    PrivateTabModel model(NEXT_TAB_ID);
     model.setWaitingForNewTab(false);
     Tab tab;
     model.m_tabs.append(tab);
@@ -188,7 +190,7 @@ void tst_declarativewebcontainer::setPrivateMode()
     QSignalSpy privateModeChangedSpy(m_webContainer, SIGNAL(privateModeChanged()));
     QSignalSpy contentItemChangedSpy(m_webContainer, SIGNAL(contentItemChanged()));
 
-    PrivateTabModel model;
+    PrivateTabModel model(NEXT_TAB_ID);
     Tab tab;
     model.m_tabs.append(tab);
     m_webContainer->m_privateTabModel = &model;
@@ -217,7 +219,7 @@ void tst_declarativewebcontainer::setPrivateMode()
 void tst_declarativewebcontainer::loading()
 {
     DeclarativeWebPage page;
-    PrivateTabModel model;
+    PrivateTabModel model(NEXT_TAB_ID);
     Tab tab;
     model.m_tabs.append(tab);
 
@@ -269,7 +271,7 @@ void tst_declarativewebcontainer::load()
     QCOMPARE(m_webContainer->m_initialUrl, QString("http://example1.com"));
 
     // Initialized container, empty model => add new tab to model
-    PrivateTabModel model;
+    PrivateTabModel model(NEXT_TAB_ID);
     m_webContainer->setTabModel(&model);
     EXPECT_CALL(*QMozContext::GetInstance(), initialized()).WillOnce(Return(true));
     EXPECT_CALL(page, completed()).WillOnce(Return(false));
@@ -285,7 +287,7 @@ void tst_declarativewebcontainer::load()
 void tst_declarativewebcontainer::reload()
 {
     // Set up
-    PrivateTabModel model;
+    PrivateTabModel model(NEXT_TAB_ID);
     model.addTab(QString("http://example.com"), QString("Test title"), 0);
     m_webContainer->setTabModel(&model);
 
@@ -303,7 +305,7 @@ void tst_declarativewebcontainer::goBackAndGoForward()
 
 void tst_declarativewebcontainer::activatePage()
 {
-    PrivateTabModel model;
+    PrivateTabModel model(NEXT_TAB_ID);
     Tab tab;
     tab.setTabId(1);
 

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -100,6 +100,8 @@ void tst_persistenttabmodel::initTestCase()
     mDbFile = QString("%1/%2")
             .arg(QStandardPaths::writableLocation(QStandardPaths::DataLocation))
             .arg(QLatin1String(DB_NAME));
+    QFile dbFile(mDbFile);
+    dbFile.remove();
 }
 
 void tst_persistenttabmodel::cleanupTestCase()

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -136,7 +136,6 @@ void tst_persistenttabmodel::addTab()
 
     QSignalSpy countChangeSpy(tabModel, SIGNAL(countChanged()));
     QSignalSpy tabAddedSpy(tabModel, SIGNAL(tabAdded(int)));
-    QSignalSpy nextTabIdChangedSpy(tabModel, SIGNAL(nextTabIdChanged()));
     QSignalSpy dataChangedSpy(tabModel, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)));
     QSignalSpy activeTabIndexChangedSpy(tabModel, SIGNAL(activeTabIndexChanged()));
     QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
@@ -150,7 +149,6 @@ void tst_persistenttabmodel::addTab()
     QList<QVariant> arguments = tabAddedSpy.at(0);
     QCOMPARE(arguments.at(0).toInt(), initialTabs.count() + 1);
 
-    QCOMPARE(nextTabIdChangedSpy.count(), 1);
     QCOMPARE(tabModel->nextTabId(), initialTabs.count() + 2);
 
     QCOMPARE(activeTabChangedSpy.count(), 1);

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -460,7 +460,6 @@ void tst_persistenttabmodel::updateUrl()
         QCOMPARE(dataChangedSpy.count(), 1);
         Tab tab = tabModel->tabs().at(tabModel->findTabIndex(tabId));
         QCOMPARE(tab.url(), url);
-        QCOMPARE(tab.title(), QString(""));
     } else {
         QCOMPARE(dataChangedSpy.count(), 0);
     }

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -464,6 +464,7 @@ void tst_persistenttabmodel::updateUrl()
         Tab tab = tabModel->tabs().at(tabModel->findTabIndex(tabId));
         QCOMPARE(tab.url(), url);
         QCOMPARE(tab.currentLink(), 4);
+        QCOMPARE(tab.title(), QString(""));
     } else {
         QCOMPARE(dataChangedSpy.count(), 0);
     }

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -169,20 +169,17 @@ void tst_persistenttabmodel::addTab()
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString(), tabToAdd.url);
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), tabToAdd.title);
     QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TabIdRole).toInt(), initialTabs.count() + 1);
-    QCOMPARE(tabModel->m_tabs.at(insertToIndex).currentLink(), initialTabs.count() + 1);
 
     if (insertToIndex > 0) {
         modelIndex = tabModel->createIndex(insertToIndex - 1, 0);
         QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString(), initialTabs.at(insertToIndex - 1).url);
         QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), initialTabs.at(insertToIndex - 1).title);
         QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TabIdRole).toInt(), insertToIndex);
-        QCOMPARE(tabModel->m_tabs.at(insertToIndex - 1).currentLink(), insertToIndex);
     } else if (insertToIndex < initialTabs.count()) {
         modelIndex = tabModel->createIndex(insertToIndex + 1, 0);
         QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::UrlRole).toString(), initialTabs.at(insertToIndex).url);
         QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString(), initialTabs.at(insertToIndex).title);
         QCOMPARE(tabModel->data(modelIndex, DeclarativeTabModel::TabIdRole).toInt(), insertToIndex + 1);
-        QCOMPARE(tabModel->m_tabs.at(insertToIndex + 1).currentLink(), insertToIndex + 1);
     }
 }
 
@@ -463,7 +460,6 @@ void tst_persistenttabmodel::updateUrl()
         QCOMPARE(dataChangedSpy.count(), 1);
         Tab tab = tabModel->tabs().at(tabModel->findTabIndex(tabId));
         QCOMPARE(tab.url(), url);
-        QCOMPARE(tab.currentLink(), 4);
         QCOMPARE(tab.title(), QString(""));
     } else {
         QCOMPARE(dataChangedSpy.count(), 0);

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.pro
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.pro
@@ -2,7 +2,7 @@ TARGET = tst_persistenttabmodel
 
 QMAKE_LFLAGS += -lgtest -lgmock
 
-QT += quick qml sql
+QT += qml sql
 
 include(../test_common.pri)
 include(../mocks/declarativewebpage/declarativewebpage_mock.pri)


### PR DESCRIPTION
* Don't maintain `maxTabId` in `DBManager`. Initialize tab models' `nextTabId` once upon their creation instead.
* Encapsulate `Link` creation into `DBWorker` (`TabModel` doesn't have to know about this implementation detail). Also this makes possible  dropping `TabModel`'s `nextLinkId` members and their maintenance code.
* `TabModel`'s `nextTabId` property is used nowhere - drop it from public API.
* Reduce data exchange between SQLite and DBWorker by using SQL inner joins.
* Don't include `Link` to `Tab` as a member to avoid maintaining linkId in `Tab`.
* Fully cover the storage subsystem with unit tests.