### PR TITLE
[sailfish-browser] Allow Homescreen to show browser cover when launch…

### DIFF
--- a/open-url.desktop
+++ b/open-url.desktop
@@ -5,5 +5,5 @@ NotShowIn=X-MeeGo;
 X-MeeGo-Logical-Id=sailfish-browser-ap-name
 X-MeeGo-Translation-Catalog=sailfish-browser
 MimeType=text/html;x-maemo-urischeme/http;x-maemo-urischeme/https;
-X-Maemo-Service=org.sailfishos.browser
-X-Maemo-Method=org.sailfishos.browser.openUrl
+X-Maemo-Service=org.sailfishos.browser.ui
+X-Maemo-Method=org.sailfishos.browser.ui.openUrl

--- a/src/desktopbookmarkwriter.cpp
+++ b/src/desktopbookmarkwriter.cpp
@@ -90,10 +90,10 @@ QString DesktopBookmarkWriter::write(QString url, QString title, QString icon)
 {
     QString fileName = uniqueDesktopFileName(title);
     QString desktopFileData = QString("[Desktop Entry]\n" \
-                                      "Type=Link\n" \
+                                      "Type=Application\n" \
                                       "Name=%1\n" \
                                       "Icon=%2\n" \
-                                      "URL=%3\n" \
+                                      "Exec=invoker -s --type=browser /usr/bin/sailfish-browser %3\n" \
                                       "Comment=%4\n").arg(title.trimmed(), icon,
                                                           url.trimmed(), title.trimmed());
     QFile desktopFile(fileName);


### PR DESCRIPTION
…ing URLs and change favorite desktop configuration. Fixes JB#30997

Use the org.sailfishos.browser.ui service rather than
org.sailfishos.browser when opening URLs via libcontentaction. This
menas the Home screen will show the browser app cover while the app is
loading if triggered via an app-open action e.g. Qt.openUrlExternally().

However, browser bookmarks in the app grid are created using the "Link"
desktop entry, which already causes a separate desktop app to be
launched. To prevent two app covers from being displayed in in this
case, the .desktop configuration for grid bookmarks now uses the
"Application" entry type rather than "Link", with the URL passed via
the "Exec" entry. So, instead of launching a Link type that is
interpreted as a content action that should open the browser, the
favourite will now be launched directly with the browser app.