### PR TITLE
[sailfish-browser] Use /ui dbus adaptor path for org.sailfishos.brows…

### DIFF
--- a/src/browserservice.cpp
+++ b/src/browserservice.cpp
@@ -75,7 +75,7 @@ BrowserUIService::BrowserUIService(QObject * parent)
     new UIServiceDBusAdaptor(this);
     QDBusConnection connection = QDBusConnection::sessionBus();
     if(!connection.registerService(SAILFISH_BROWSER_UI_SERVICE) ||
-            !connection.registerObject("/", this)) {
+            !connection.registerObject("/ui", this)) {
         m_registered = false;
     }
 }


### PR DESCRIPTION
…er.ui service. Contributes to JB#31406

Else the name conflicts with the path for the org.sailfishos.browser
service.