### PR TITLE
[sailfish-browser] Don't take focus away from the page when VKBD is closed. Fixes JB#31646.

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -123,11 +123,6 @@ Page {
         orientation: browserPage.orientation
 
         onWindowChanged: webView.chromeWindow = window
-        onClosedChanged: {
-            if (closed) {
-                webView.updatePageFocus(false)
-            }
-        }
 
         // Update content height only after virtual keyboard fully opened.
         states: State {


### PR DESCRIPTION
The fact that virtual keyboard was closed for some reason does not imply
that the view is no longer focused. In the problematic case the fact
that we manually unfocused the view made the browser ignore subsequent
virtual keyboard show requests which originated from the engine. The
user is not the only source of focus changes, web pages can also modify
it's own focused element from JavaScript code.