### PR TITLE
[sailfish-browser] Add environment variable for enabling qml debugging. Contributes to JB#6054

### DIFF
--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -11,6 +11,7 @@
 
 #include <QGuiApplication>
 #include <QQuickView>
+#include <qqmldebug.h>
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QtQml>
@@ -56,6 +57,10 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     setlocale(LC_NUMERIC, "C");
 
     QQuickWindow::setDefaultAlphaBuffer(true);
+
+    if (!qgetenv("QML_DEBUGGING_ENABLED").isEmpty()) {
+        QQmlDebuggingEnabler qmlDebuggingEnabler;
+    }
 
 #ifdef HAS_BOOSTER
     QScopedPointer<QGuiApplication> app(MDeclarativeCache::qApplication(argc, argv));


### PR DESCRIPTION
This way there is no need to patch browser separately if you'd like to e.g. do some QML profiling. Just start the browser from command line like

> QML_DEBUGGING_ENABLED=1 sailfish-browser -qmljsdebugger=port:6666

or when profiling startup just add block.

> QML_DEBUGGING_ENABLED=1 sailfish-browser -qmljsdebugger=port:6666,block

And connect remotely to the device from the QtCreator.