### PR TITLE
[sailfish-browser] Improve tab thumbnailing logic. Fixes JB#23670

### DIFF
--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -177,6 +177,15 @@ void DeclarativeTabModel::newTab(const QString &url, const QString &title, int p
     emit newTabRequested(url, title, parentId);
 }
 
+QString DeclarativeTabModel::url(int tabId) const
+{
+    int index = findTabIndex(tabId);
+    if (index >= 0) {
+        return m_tabs.at(index).url();
+    }
+    return "";
+}
+
 void DeclarativeTabModel::dumpTabs() const
 {
     for (int i = 0; i < m_tabs.size(); i++) {
@@ -279,13 +288,12 @@ void DeclarativeTabModel::updateUrl(int tabId, const QString &url, bool initialL
     bool updateDb = false;
     if (tabIndex >= 0 && (m_tabs.at(tabIndex).url() != url || isActiveTab)) {
         QVector<int> roles;
-        roles << UrlRole << ThumbPathRole;
+        roles << UrlRole;
         m_tabs[tabIndex].setUrl(url);
 
         if (!initialLoad) {
             updateDb = true;
         }
-        m_tabs[tabIndex].setThumbnailPath("");
 
         emit dataChanged(index(tabIndex, 0), index(tabIndex, 0), roles);
     }
@@ -389,13 +397,15 @@ void DeclarativeTabModel::updateThumbnailPath(int tabId, QString path)
     QVector<int> roles;
     roles << ThumbPathRole;
     for (int i = 0; i < m_tabs.count(); i++) {
-        if (m_tabs.at(i).tabId() == tabId && m_tabs.at(i).thumbnailPath() != path) {
+        if (m_tabs.at(i).tabId() == tabId) {
 #if DEBUG_LOGS
             qDebug() << "model tab thumbnail updated: " << path << i << tabId;
 #endif
-            m_tabs[i].setThumbnailPath(path);
             QModelIndex start = index(i, 0);
             QModelIndex end = index(i, 0);
+            m_tabs[i].setThumbnailPath("");
+            emit dataChanged(start, end, roles);
+            m_tabs[i].setThumbnailPath(path);
             emit dataChanged(start, end, roles);
             updateThumbPath(tabId, path);
         }

--- a/src/history/declarativetabmodel.h
+++ b/src/history/declarativetabmodel.h
@@ -48,6 +48,7 @@ public:
     Q_INVOKABLE void activateTab(int index, bool loadActiveTab = true);
     Q_INVOKABLE void closeActiveTab();
     Q_INVOKABLE void newTab(const QString &url, const QString &title, int parentId = 0);
+    Q_INVOKABLE QString url(int tabId) const;
 
     Q_INVOKABLE void dumpTabs() const;
 

--- a/src/pages/components/TabItem.qml
+++ b/src/pages/components/TabItem.qml
@@ -38,16 +38,23 @@ BackgroundItem {
     // contentItem is hidden so this cannot be children of the contentItem.
     // So, making them as siblings of the contentItem.
     data: [
+        Rectangle {
+            color: "#202020"
+            width: root.implicitWidth
+            height: root.implicitHeight
+        },
         Image {
             id: image
 
             source: thumbnailPath
             width: root.implicitWidth
             height: root.implicitHeight
+
             cache: false
             asynchronous: true
+            opacity: status !== Image.Ready && source !== "" ? 0.0 : 1.0
+            Behavior on opacity { FadeAnimation {} }
         },
-
         Rectangle {
             anchors.bottom: parent.bottom
             width: parent.width

--- a/src/pages/components/TabView.qml
+++ b/src/pages/components/TabView.qml
@@ -35,6 +35,8 @@ SilicaListView {
     }
     footer: spacer
 
+    spacing: Theme.paddingMedium
+
     delegate: TabItem {
         id: tabItem
 

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -65,7 +65,7 @@ WebContainer {
     }
 
     function grabActivePage() {
-        if (webView.contentItem) {
+        if (webView.contentItem && webView.activeTabRendered) {
             webView.privateMode ? webView.contentItem.grabThumbnail(thumbnailCaptureSize())
                                 : webView.contentItem.grabToFile(thumbnailCaptureSize())
         }
@@ -88,11 +88,19 @@ WebContainer {
 
             property int iconSize
             property string iconType
+            property int frameCounter
+            property bool rendered
             readonly property bool activeWebPage: container.tabId == tabId
 
             signal selectionRangeUpdated(variant data)
             signal selectionCopied(variant data)
             signal contextMenuRequested(variant data)
+
+            function grabItem() {
+                if (rendered && activeWebPage && active) {
+                    webView.privateMode ? grabThumbnail(thumbnailCaptureSize()) : grabToFile(thumbnailCaptureSize())
+                }
+            }
 
             width: container.rotationHandler && container.rotationHandler.width || 0
             fullscreenHeight: container.fullscreenHeight
@@ -105,7 +113,6 @@ WebContainer {
             chromeGestureThreshold: toolbarHeight / 2
             chromeGestureEnabled: (contentHeight > fullscreenHeight + toolbarHeight) && !forcedChrome && enabled && !webView.imOpened
 
-            onClearGrabResult: tabModel.updateThumbnailPath(tabId, "")
             onGrabResult: tabModel.updateThumbnailPath(tabId, fileName)
 
             // Image data is base64 encoded which can be directly used as source in Image element
@@ -115,6 +122,17 @@ WebContainer {
                 if (url == "about:blank") return
 
                 webView.findInPageHasResult = false
+                var modelUrl = tabModel.url(tabId)
+
+                rendered = false
+                frameCounter = 0
+
+                // If url has changed or url doesn't exists in the model,
+                // clear the thumbnail. Preserve the thumbnails in the model
+                // if it has the same url (restarting browser / resurrecting a tab).
+                if (!modelUrl || modelUrl != url) {
+                    tabModel.updateThumbnailPath(tabId, "")
+                }
             }
 
             onBgcolorChanged: {
@@ -144,26 +162,25 @@ WebContainer {
             }
 
             onLoadedChanged: {
-                if (loaded && !userHasDraggedWhileLoading) {
-                    resetHeight(false)
-                    if (resurrectedContentRect) {
-                        sendAsyncMessage("embedui:zoomToRect",
-                                         {
-                                             "x": resurrectedContentRect.x, "y": resurrectedContentRect.y,
-                                             "width": resurrectedContentRect.width, "height": resurrectedContentRect.height
-                                         })
-                        resurrectedContentRect = null
+                if (loaded) {
+                    if (!userHasDraggedWhileLoading) {
+                        resetHeight(false)
+                        if (resurrectedContentRect) {
+                            sendAsyncMessage("embedui:zoomToRect",
+                                             {
+                                                 "x": resurrectedContentRect.x, "y": resurrectedContentRect.y,
+                                                 "width": resurrectedContentRect.width, "height": resurrectedContentRect.height
+                                             })
+                            resurrectedContentRect = null
+                        }
                     }
+                    grabItem()
                 }
 
                 // Refresh timers (if any) keep working even for suspended views. Hence
                 // suspend the view again explicitly if browser content window is in not visible (background).
                 if (loaded && !webView.visible) {
                     suspendView();
-                }
-
-                if (loaded) {
-                    webView.privateMode ? grabThumbnail(thumbnailCaptureSize()) : grabToFile(thumbnailCaptureSize())
                 }
             }
 
@@ -174,8 +191,17 @@ WebContainer {
                     favicon = ""
                     iconType = ""
                     iconSize = 0
-
                     resetHeight(false)
+                }
+            }
+
+            onAfterRendering: {
+                // Try to capture something else than glClear color.
+                if (frameCounter < 3) {
+                    ++frameCounter
+                } else if (!rendered) {
+                    rendered = true
+                    grabItem()
                 }
             }
 

--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -227,7 +227,6 @@ void DeclarativeWebPage::loadTab(QString newUrl, bool force)
 
 void DeclarativeWebPage::grabToFile(const QSize &size)
 {
-    emit clearGrabResult();
     // grabToImage handles invalid geometry.
     m_grabResult = grabToImage(size);
     if (m_grabResult) {

--- a/src/qtmozembed/declarativewebpage.h
+++ b/src/qtmozembed/declarativewebpage.h
@@ -74,7 +74,6 @@ signals:
     void domContentLoadedChanged();
     void faviconChanged();
     void resurrectedContentRectChanged();
-    void clearGrabResult();
     void grabResult(QString fileName);
     void thumbnailResult(QString data);
 

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -473,7 +473,7 @@ void tst_persistenttabmodel::updateThumbnailPath()
 
     QString path("/path/to/thumbnail");
     tabModel->updateThumbnailPath(1, path);
-    QCOMPARE(dataChangedSpy.count(), 1);
+    QCOMPARE(dataChangedSpy.count(), 2);
     QCOMPARE(tabModel->m_tabs.at(0).thumbnailPath(), path);
 }
 


### PR DESCRIPTION
It's a bit of guess work but now we capture the third frame and
when the page is fully loaded. In addition, we do not clear the thumbnails
that aggresively as we are capturing only the active web page. Down
side is more or less same as it is now. For instance, if you close the
browser and leave it closed for a while, restart it, go to tab view and
you find that there out-dated thumbnails not matching the reality.

To get updates working properly, we refresh model data so (name is always
the same, like tab-1-thumb.jpg) that the new updated capture gets
rendered to the tab view.