### PR TITLE
[sailfish-browser] Prevent gecko from rendering when screen is off. Fixes JB#31866.

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -494,8 +494,6 @@ bool DeclarativeWebContainer::eventFilter(QObject *obj, QEvent *event)
         // Make sure gecko does not use GL context we gave it in ::createGLContext
         // after the window has been closed.
         m_webPage->suspendView();
-    } else if (event->type() == QEvent::Expose && !isExposed() && !m_allowHiding) {
-        return true;
     }
 
     // Emit chrome exposed when both chrome window and browser window has been exposed. This way chrome

--- a/src/pages/components/ResourceController.qml
+++ b/src/pages/components/ResourceController.qml
@@ -20,6 +20,7 @@ Item {
     property QtObject webView
     property bool videoActive
     property bool audioActive
+    readonly property alias displayOff: screenBlanked.value
     property bool background
 
     property string _mediaState: "pause"

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -97,7 +97,8 @@ WebContainer {
             width: container.rotationHandler && container.rotationHandler.width || 0
             fullscreenHeight: container.fullscreenHeight
             toolbarHeight: container.toolbarHeight
-            throttlePainting: !foreground && !resourceController.videoActive
+            throttlePainting: !foreground && !resourceController.videoActive || resourceController.displayOff
+            readyToPaint: !resourceController.displayOff
             enabled: webView.enabled
 
             // There needs to be enough content for enabling chrome gesture


### PR DESCRIPTION
When the screen goes off we'd like to prevent gecko from doing any
rendering. We don't want to completely pause the compositor, but we also
don't want it to execute any GL/EGL commands, especially eglSwapBuffers.
The reason for this is because it seems that on sailfish eglSwapBuffers
can currently block indefinitely when the display is turned off.

Blocked compositor thread was the main reason for huge memory leak
observed when the video was being played in the browser and the screen was
turned off. Gecko media thread produced new frame data which was never
consumed by the compositor thread. The data kept piling up until the
system run out of memory.