### PR TITLE
Add missing property to the ResourceController mock

### DIFF
--- a/tests/auto/tst_webview/ResourceControllerMock.qml
+++ b/tests/auto/tst_webview/ResourceControllerMock.qml
@@ -16,6 +16,7 @@ QtObject {
     property bool videoActive
     property bool audioActive
     property bool background
+    property bool displayOff
 
     signal webViewSuspended
 


### PR DESCRIPTION
Noticed this while running tst_webview unit tests.