### PR TITLE
Move WebPage creation to a factory object.

### DIFF
--- a/settings/Privacy.qml
+++ b/settings/Privacy.qml
@@ -15,11 +15,6 @@ import org.nemomobile.configuration 1.0
 import org.sailfishos.browser.settings 1.0
 
 Page {
-    property bool clearPrivateData: clearHistory.checked &&
-                                    clearCookies.checked &&
-                                    clearSavedPasswords.checked &&
-                                    clearCache.checked &&
-                                    clearBookmarks.checked
 
     RemorsePopup {
         id: clearDataRemorse
@@ -117,24 +112,20 @@ Page {
                     //% "Clearing"
                     clearDataRemorse.execute(qsTrId("settings_browser-la-clearing_private_data"),
                                              function() {
-                                                 if (clearPrivateData) {
-                                                     clearPrivateDataConfig.value = true
-                                                 } else {
-                                                     if (clearHistory.checked) {
-                                                         clearHistoryConfig.value = true
-                                                     }
-                                                     if (clearCookies.checked) {
-                                                         clearCookiesConfig.value = true
-                                                     }
-                                                     if (clearSavedPasswords.checked) {
-                                                         clearSavedPasswordsConfig.value = true
-                                                     }
-                                                     if (clearCache.checked) {
-                                                         clearCacheConfig.value = true
-                                                     }
-                                                     if (clearBookmarks.checked) {
-                                                         clearBookmarksConfig.value = true
-                                                     }
+                                                 if (clearHistory.checked) {
+                                                     clearHistoryConfig.value = true
+                                                 }
+                                                 if (clearCookies.checked) {
+                                                     clearCookiesConfig.value = true
+                                                 }
+                                                 if (clearSavedPasswords.checked) {
+                                                     clearSavedPasswordsConfig.value = true
+                                                 }
+                                                 if (clearCache.checked) {
+                                                     clearCacheConfig.value = true
+                                                 }
+                                                 if (clearBookmarks.checked) {
+                                                     clearBookmarksConfig.value = true
                                                  }
                                              }
                     );
@@ -147,13 +138,6 @@ Page {
         id: doNotTrackConfig
 
         key: "/apps/sailfish-browser/settings/do_not_track"
-        defaultValue: false
-    }
-
-    ConfigurationValue {
-        id: clearPrivateDataConfig
-
-        key: "/apps/sailfish-browser/actions/clear_private_data"
         defaultValue: false
     }
 

--- a/src/bookmarks/bookmarkmanager.cpp
+++ b/src/bookmarks/bookmarkmanager.cpp
@@ -19,11 +19,19 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QRegularExpression>
+#include <MGConfItem>
 
 #include "bookmark.h"
 
 BookmarkManager::BookmarkManager()
+  : QObject(nullptr)
 {
+    m_clearBookmarksConfItem = new MGConfItem("/apps/sailfish-browser/actions/clear_bookmarks", this);
+
+    clearBookmarks();
+
+    connect(m_clearBookmarksConfItem, SIGNAL(valueChanged()),
+            this, SLOT(clearBookmarks()));
 }
 
 BookmarkManager* BookmarkManager::instance()
@@ -111,4 +119,12 @@ QList<Bookmark*> BookmarkManager::load() {
     }
     file->close();
     return bookmarks;
+}
+
+void BookmarkManager::clearBookmarks()
+{
+    if (m_clearBookmarksConfItem->value(false).toBool()) {
+        clear();
+        m_clearBookmarksConfItem->set(false);
+    }
 }

--- a/src/bookmarks/bookmarkmanager.h
+++ b/src/bookmarks/bookmarkmanager.h
@@ -14,8 +14,10 @@
 
 #include <QObject>
 #include <QList>
+#include <QPointer>
 
 class Bookmark;
+class MGConfItem;
 
 class BookmarkManager : public QObject
 {
@@ -31,9 +33,13 @@ public:
 signals:
     void cleared();
 
+private slots:
+    void clearBookmarks();
+
 private:
     BookmarkManager();
 
+    QPointer<MGConfItem> m_clearBookmarksConfItem;
 };
 
 #endif // BOOKMARKMANAGER_H

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -418,11 +418,6 @@ int DeclarativeWebContainer::findParentTabId(int tabId) const
     return 0;
 }
 
-bool DeclarativeWebContainer::alive(int tabId)
-{
-    return m_webPages->alive(tabId);
-}
-
 void DeclarativeWebContainer::updateMode()
 {
     setTabModel(privateMode() ? m_privateTabModel.data() : m_persistentTabModel.data());

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -247,6 +247,11 @@ void DeclarativeWebContainer::setMaxLiveTabCount(int count)
     }
 }
 
+QQmlComponent* DeclarativeWebContainer::webPageComponent() const
+{
+    return m_webPageComponent;
+}
+
 void DeclarativeWebContainer::setWebPageComponent(QQmlComponent *qmlComponent)
 {
     if (m_webPageComponent.data() != qmlComponent) {

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -70,7 +70,7 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     Q_PROPERTY(bool privateMode READ privateMode WRITE setPrivateMode NOTIFY privateModeChanged FINAL)
     Q_PROPERTY(bool activeTabRendered READ activeTabRendered NOTIFY activeTabRenderedChanged FINAL)
 
-    Q_PROPERTY(QQmlComponent* webPageComponent MEMBER m_webPageComponent WRITE setWebPageComponent NOTIFY webPageComponentChanged FINAL)
+    Q_PROPERTY(QQmlComponent* webPageComponent READ webPageComponent WRITE setWebPageComponent NOTIFY webPageComponentChanged FINAL)
     Q_PROPERTY(QObject *chromeWindow READ chromeWindow WRITE setChromeWindow NOTIFY chromeWindowChanged FINAL)
 public:
     DeclarativeWebContainer(QWindow *parent = 0);
@@ -87,6 +87,8 @@ public:
 
     int maxLiveTabCount() const;
     void setMaxLiveTabCount(int count);
+
+    QQmlComponent* webPageComponent() const;
     void setWebPageComponent(QQmlComponent* qmlComponent);
 
     bool privateMode() const;

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -70,7 +70,7 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     Q_PROPERTY(bool privateMode READ privateMode WRITE setPrivateMode NOTIFY privateModeChanged FINAL)
     Q_PROPERTY(bool activeTabRendered READ activeTabRendered NOTIFY activeTabRenderedChanged FINAL)
 
-    Q_PROPERTY(QQmlComponent* webPageComponent MEMBER m_webPageComponent NOTIFY webPageComponentChanged FINAL)
+    Q_PROPERTY(QQmlComponent* webPageComponent MEMBER m_webPageComponent WRITE setWebPageComponent NOTIFY webPageComponentChanged FINAL)
     Q_PROPERTY(QObject *chromeWindow READ chromeWindow WRITE setChromeWindow NOTIFY chromeWindowChanged FINAL)
 public:
     DeclarativeWebContainer(QWindow *parent = 0);
@@ -87,6 +87,7 @@ public:
 
     int maxLiveTabCount() const;
     void setMaxLiveTabCount(int count);
+    void setWebPageComponent(QQmlComponent* qmlComponent);
 
     bool privateMode() const;
     void setPrivateMode(bool);
@@ -159,7 +160,7 @@ signals:
     void privateModeChanged();
     void activeTabRenderedChanged();
 
-    void webPageComponentChanged();
+    void webPageComponentChanged(QQmlComponent *newComponent);
     void chromeWindowChanged();
     void chromeExposed();
 

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -123,8 +123,6 @@ public:
     Q_INVOKABLE void updatePageFocus(bool focus);
     Q_INVOKABLE void clearSurface() {  postClearWindowSurfaceTask(); }
 
-    Q_INVOKABLE bool alive(int tabId);
-
     Q_INVOKABLE void dumpPages() const;
 
     QObject *focusObject() const;

--- a/src/core/settingmanager.h
+++ b/src/core/settingmanager.h
@@ -39,24 +39,20 @@ signals:
     void toolbarLargeChanged();
 
 private slots:
-    bool clearPrivateData();
     bool clearHistory();
     bool clearCookies();
     bool clearPasswords();
     bool clearCache();
-    bool clearBookmarks();
     void setSearchEngine();
     void doNotTrack();
 
 private:
     explicit SettingManager(QObject *parent = 0);
 
-    MGConfItem *m_clearPrivateDataConfItem;
     MGConfItem *m_clearHistoryConfItem;
     MGConfItem *m_clearCookiesConfItem;
     MGConfItem *m_clearPasswordsConfItem;
     MGConfItem *m_clearCacheConfItem;
-    MGConfItem *m_clearBookmarksConfItem;
     MGConfItem *m_searchEngineConfItem;
     MGConfItem *m_doNotTrackConfItem;
     MGConfItem *m_autostartPrivateBrowsing;

--- a/src/core/webpagequeue.h
+++ b/src/core/webpagequeue.h
@@ -13,6 +13,7 @@
 #define WEBPAGEQUEUE_H
 
 #include <QQueue>
+#include <QPointer>
 
 class QRectF;
 class DeclarativeWebPage;
@@ -44,7 +45,7 @@ private:
         WebPageEntry(DeclarativeWebPage *webPage, QRectF *cssContentRect);
         ~WebPageEntry();
 
-        DeclarativeWebPage *webPage;
+        QPointer<DeclarativeWebPage> webPage;
         int tabId;
         int uniqueId;
         int parentId;

--- a/src/core/webpages.h
+++ b/src/core/webpages.h
@@ -18,6 +18,7 @@
 #include <QPointer>
 
 class QQmlComponent;
+class WebPageFactory;
 class QDBusPendingCallWatcher;
 class DeclarativeWebContainer;
 class DeclarativeWebPage;
@@ -38,10 +39,10 @@ class WebPages : public QObject
     Q_OBJECT
 
 public:
-    explicit WebPages(QObject *parent = 0);
+    explicit WebPages(WebPageFactory *pageFactory, QObject *parent = 0);
     ~WebPages();
 
-    void initialize(DeclarativeWebContainer *webContainer, QQmlComponent *webPageComponent);
+    void initialize(DeclarativeWebContainer *webContainer);
     bool initialized() const;
     int count() const;
 
@@ -66,13 +67,14 @@ private:
     void updateStates(DeclarativeWebPage *oldActivePage, DeclarativeWebPage *newActivePage);
 
     QPointer<DeclarativeWebContainer> m_webContainer;
-    QPointer<QQmlComponent> m_webPageComponent;
+    QPointer<WebPageFactory> m_pageFactory;
     // Contains both virtual and real
     WebPageQueue m_activePages;
     qint64 m_backgroundTimestamp;
     QString m_memoryLevel;
 
     friend class tst_webview;
+    friend class tst_webpages;
 };
 
 #endif

--- a/src/factories/factories.pri
+++ b/src/factories/factories.pri
@@ -1,0 +1,9 @@
+INCLUDEPATH += $$PWD
+
+# C++ sources
+SOURCES += \
+    $$PWD/webpagefactory.cpp \
+
+# C++ headers
+HEADERS += \
+    $$PWD/webpagefactory.h \

--- a/src/factories/webpagefactory.cpp
+++ b/src/factories/webpagefactory.cpp
@@ -1,0 +1,69 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QQmlComponent>
+
+#include <qqmlinfo.h>
+
+#include "webpagefactory.h"
+#include "declarativewebcontainer.h"
+#include "declarativewebpage.h"
+#include "tab.h"
+
+#define DEBUG_LOGS 0
+
+DeclarativeWebPage* WebPageFactory::createWebPage(DeclarativeWebContainer *webContainer,
+                                                  const Tab &initialTab,
+                                                  int parentId)
+{
+    if (!m_qmlComponent) {
+        qWarning() << "WebPageContainer not initialized!";
+        return nullptr;
+    }
+
+    QQmlContext *creationContext = m_qmlComponent->creationContext();
+    QQmlContext *context = new QQmlContext(creationContext ? creationContext : QQmlEngine::contextForObject(webContainer));
+    QObject *object = m_qmlComponent->beginCreate(context);
+    if (object) {
+        context->setParent(object);
+        object->setParent(webContainer);
+        DeclarativeWebPage* webPage = qobject_cast<DeclarativeWebPage *>(object);
+        if (webPage) {
+            webPage->setParentID(parentId);
+            webPage->setPrivateMode(webContainer->privateMode());
+            webPage->setInitialTab(initialTab);
+            webPage->setContainer(webContainer);
+            webPage->initialize();
+            m_qmlComponent->completeCreate();
+#if DEBUG_LOGS
+            qDebug() << "New view id:" << webPage->uniqueID() << "parentId:" << webPage->parentId() << "tab id:" << webPage->tabId();
+#endif
+            QQmlEngine::setObjectOwnership(webPage, QQmlEngine::CppOwnership);
+            return webPage;
+        } else {
+            qmlInfo(webContainer) << "webPage component must be a WebPage component";
+            m_qmlComponent->completeCreate();
+            delete object;
+        }
+    } else {
+        qmlInfo(webContainer) << "Creation of the web page failed. Error: " << m_qmlComponent->errorString();
+        delete context;
+    }
+
+    return nullptr;
+}
+
+void WebPageFactory::updateQmlComponent(QQmlComponent *newComponent)
+{
+    m_qmlComponent = newComponent;
+}

--- a/src/factories/webpagefactory.h
+++ b/src/factories/webpagefactory.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WEBPAGEFACTORY_H
+#define WEBPAGEFACTORY_H
+
+#include <QPointer>
+#include <QObject>
+
+class DeclarativeWebPage;
+class DeclarativeWebContainer;
+class Tab;
+class QQmlComponent;
+
+class WebPageFactory : public QObject
+{
+    Q_OBJECT
+public:
+    WebPageFactory(QObject *parent = 0) : QObject(parent) {};
+
+    DeclarativeWebPage* createWebPage(DeclarativeWebContainer *webContainer,
+                                      const Tab &initialTab,
+                                      int parentId);
+public slots:
+    void updateQmlComponent(QQmlComponent *newComponent);
+
+private:
+    QPointer<QQmlComponent> m_qmlComponent;
+};
+
+#endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -50,6 +50,7 @@ include(core/core.pri)
 include(history/history.pri)
 include(bookmarks/bookmarks.pri)
 include(qtmozembed/qtmozembed.pri)
+include(factories/factories.pri)
 
 # C++ sources
 SOURCES += \

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,4 +1,3 @@
-# TODO: Change this to subdirs once we get first C++ test
 TEMPLATE = subdirs
 
 SUBDIRS += tst_dbmanager \
@@ -9,6 +8,8 @@ SUBDIRS += tst_dbmanager \
     tst_desktopbookmarkwriter \
     tst_linkvalidator \
     tst_webutils \
+    tst_webpages \
+    tst_webpagefactory \
     tst_webview
 
 OTHER_FILES += \

--- a/tests/auto/mocks/webpagefactory/webpagefactory.h
+++ b/tests/auto/mocks/webpagefactory/webpagefactory.h
@@ -1,7 +1,7 @@
 /****************************************************************************
 **
 ** Copyright (C) 2015 Jolla Ltd.
-** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+** Contact: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
 **
 ****************************************************************************/
 
@@ -9,27 +9,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef DECLARATIVEWEBCONTAINER_H
-#define DECLARATIVEWEBCONTAINER_H
-
-#include <QObject>
+#include <QQmlComponent>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-class DeclarativeWebPage;
+#include "tab.h"
+#include "declarativewebcontainer.h"
+#include "declarativewebpage.h"
 
-class DeclarativeWebContainer : public QObject
+class WebPageFactory : public QObject
 {
     Q_OBJECT
-
 public:
-    explicit DeclarativeWebContainer(QObject *parent = 0);
+    WebPageFactory(QObject *parent = 0) : QObject(parent) {};
 
-    int findParentTabId(int) const;
-    MOCK_CONST_METHOD0(webPage, DeclarativeWebPage*());
-    MOCK_CONST_METHOD0(privateMode, bool());
+    MOCK_METHOD3(createWebPage, DeclarativeWebPage*(DeclarativeWebContainer*, const Tab&, int));
+
+public slots:
+    void updateQmlComponent(QQmlComponent*) {};
 };
-
-
-#endif

--- a/tests/auto/mocks/webpagefactory/webpagefactory.pri
+++ b/tests/auto/mocks/webpagefactory/webpagefactory.pri
@@ -1,0 +1,3 @@
+HEADERS += $$PWD/webpagefactory.h
+
+INCLUDEPATH += $$PWD

--- a/tests/auto/tests.xml
+++ b/tests/auto/tests.xml
@@ -31,6 +31,12 @@
            <case manual="false" name="webutils">
                <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_webutils</step>
            </case>
+           <case manual="false" name="webpages">
+               <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_webpages</step>
+           </case>
+           <case manual="false" name="webpagefactory">
+               <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_webpagefactory</step>
+           </case>
            <case manual="false" name="declarativewebcontainer">
                <step>cd /opt/tests/sailfish-browser/auto/ &amp;&amp; ./tst_declarativewebcontainer</step>
            </case>

--- a/tests/auto/tst_declarativebookmarkmodel/tst_declarativebookmarkmodel.pro
+++ b/tests/auto/tst_declarativebookmarkmodel/tst_declarativebookmarkmodel.pro
@@ -2,6 +2,10 @@ TARGET = tst_declarativebookmarkmodel
 
 QT += quick concurrent
 
+CONFIG += link_pkgconfig
+
+PKGCONFIG += mlite5
+
 include(../test_common.pri)
 include(../common/testobject.pri)
 include(../../../src/bookmarks/bookmarks.pri)

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
@@ -16,8 +16,6 @@ include(../mocks/downloadmanager/downloadmanager_mock.pri)
 include(../test_common.pri)
 include(../../../src/core/core.pri)
 include(../../../src/history/history.pri)
-# TODO: drop this include (decouple SettingManager from bookmarks)
-include(../../../src/bookmarks/bookmarks.pri)
 
 SOURCES += tst_declarativewebcontainer.cpp
 

--- a/tests/auto/tst_webpagefactory/tst_webpagefactory.cpp
+++ b/tests/auto/tst_webpagefactory/tst_webpagefactory.cpp
@@ -1,0 +1,110 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QtTest>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQuickView>
+
+#include "webpagefactory.h"
+#include "declarativewebpage.h"
+#include "declarativewebcontainer.h"
+#include "tab.h"
+
+static const QByteArray QML_SNIPPET = \
+        "import QtQuick 2.0\n" \
+        "import Sailfish.Browser 1.0\n" \
+        "WebPage {\n" \
+        "}\n";
+
+static const QByteArray QML_WRONG_SNIPPET = \
+        "import QtQuick 2.0\n" \
+        "Item {\n" \
+        "}\n";
+
+static const QByteArray QML_BROKEN_SNIPPET = \
+        "import QtQuick 2.0\n" \
+        "import Sailfish.Browser 1.0\n" \
+        "WebPage \n" \
+        "}\n";
+
+using ::testing::NiceMock;
+
+class tst_webpagefactory : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void init();
+    void cleanup();
+
+    void createWebPage_data();
+    void createWebPage();
+    void createWebPageUninitialized();
+
+private:
+    WebPageFactory *m_pageFactory;
+};
+
+void tst_webpagefactory::initTestCase()
+{
+    qmlRegisterType<NiceMock<DeclarativeWebPage> >("Sailfish.Browser", 1, 0, "WebPage");
+}
+
+void tst_webpagefactory::init()
+{
+    m_pageFactory = new WebPageFactory();
+}
+
+void tst_webpagefactory::cleanup()
+{
+    delete m_pageFactory;
+}
+
+void tst_webpagefactory::createWebPage_data()
+{
+    QTest::addColumn<QByteArray>("qml");
+    QTest::addColumn<bool>("isSuccessExpected");
+
+    QTest::newRow("ok_qml") << QML_SNIPPET << true;
+    QTest::newRow("wrong_qml") << QML_WRONG_SNIPPET << false;
+    QTest::newRow("broken_qml") << QML_BROKEN_SNIPPET << false;
+}
+
+void tst_webpagefactory::createWebPage()
+{
+    QFETCH(QByteArray, qml);
+    QFETCH(bool, isSuccessExpected);
+
+    DeclarativeWebPage* page;
+    DeclarativeWebContainer webContainer;
+    QQuickView view;
+    QQmlComponent fakeComponent(view.engine());
+    QQmlEngine::setContextForObject(&webContainer, view.engine()->rootContext());
+
+    fakeComponent.setData(qml, QUrl());
+    m_pageFactory->updateQmlComponent(&fakeComponent);
+    if (isSuccessExpected) {
+        EXPECT_CALL(webContainer, privateMode());
+    }
+    page = m_pageFactory->createWebPage(&webContainer, Tab(1, "http://example.com", "Title", ""), 0);
+    QCOMPARE(!!page, isSuccessExpected);
+}
+
+void tst_webpagefactory::createWebPageUninitialized()
+{
+    DeclarativeWebContainer webContainer;
+    QVERIFY(!m_pageFactory->createWebPage(&webContainer, Tab(1, "http://example.com", "Title", ""), 0));
+}
+
+QTEST_MAIN(tst_webpagefactory)
+#include "tst_webpagefactory.moc"

--- a/tests/auto/tst_webpagefactory/tst_webpagefactory.pro
+++ b/tests/auto/tst_webpagefactory/tst_webpagefactory.pro
@@ -1,0 +1,14 @@
+TARGET = tst_webpagefactory
+
+QT += qml quick sql concurrent
+
+QMAKE_LFLAGS += -lgtest -lgmock
+
+include(../mocks/declarativewebcontainer/declarativewebcontainer_mock.pri)
+include(../mocks/declarativewebpage/declarativewebpage_mock.pri)
+
+include(../test_common.pri)
+include(../../../src/storage/storage.pri)
+include(../../../src/factories/factories.pri)
+
+SOURCES += tst_webpagefactory.cpp

--- a/tests/auto/tst_webpages/tst_webpages.cpp
+++ b/tests/auto/tst_webpages/tst_webpages.cpp
@@ -1,0 +1,354 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QtTest>
+
+#include "webpagefactory.h"
+#include "declarativewebcontainer.h"
+#include "declarativewebpage.h"
+#include "tab.h"
+
+#include "webpages.h"
+
+Q_DECLARE_METATYPE(QList<Tab>)
+Q_DECLARE_METATYPE(Tab)
+
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::AnyNumber;
+using ::testing::_;
+
+class tst_webpages : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void init();
+    void cleanup();
+
+    void initialize();
+    void count();
+    void setMaxLivePages();
+    void maxLivePages();
+    void alive();
+    void page_data();
+    void page();
+    void pageWithBrokenPageFactory();
+    void release_data();
+    void release();
+    void clear_data();
+    void clear();
+    void parentTabId_data();
+    void parentTabId();
+
+private:
+    WebPages* m_webPages;
+    WebPageFactory m_pageFactory;
+};
+
+void tst_webpages::initTestCase()
+{
+    QMozContext::GetInstance();
+}
+
+void tst_webpages::cleanupTestCase()
+{
+    delete QMozContext::GetInstance();
+}
+
+void tst_webpages::init()
+{
+    m_webPages = new WebPages(&m_pageFactory);
+}
+
+void tst_webpages::cleanup()
+{
+    delete m_webPages;
+}
+
+void tst_webpages::initialize()
+{
+    EXPECT_CALL(*QMozContext::GetInstance(), setPixelRatio(_));
+    DeclarativeWebContainer webContainer;
+    webContainer.setForeground(true);
+
+    QVERIFY(!m_webPages->initialized());
+    m_webPages->initialize(&webContainer);
+    QVERIFY(m_webPages->initialized());
+
+    // check that the connection with ::updateBackgroundTimestamp() has been created
+    webContainer.setForeground(false);
+    QVERIFY(m_webPages->m_backgroundTimestamp > 0);
+}
+
+void tst_webpages::count()
+{
+    EXPECT_CALL(*QMozContext::GetInstance(), setPixelRatio(_));
+    DeclarativeWebContainer webContainer;
+    m_webPages->initialize(&webContainer);
+
+    QCOMPARE(m_webPages->count(), 0);
+
+    DeclarativeWebPage* page = new DeclarativeWebPage();
+    EXPECT_CALL(m_pageFactory, createWebPage(_, _, _)).WillOnce(Return(page));
+
+    // add one page and check count()
+    EXPECT_CALL(*page, tabId());
+    EXPECT_CALL(*page, uniqueID());
+    EXPECT_CALL(*page, parentId());
+    EXPECT_CALL(*page, completed());
+    m_webPages->page(Tab(1, "http://example.com", "Test title", ""));
+    QCOMPARE(m_webPages->count(), 1);
+}
+
+void tst_webpages::setMaxLivePages()
+{
+    m_webPages->setMaxLivePages(171);
+    QCOMPARE(m_webPages->m_activePages.maxLivePages(), 171);
+}
+
+void tst_webpages::maxLivePages()
+{
+    QCOMPARE(m_webPages->maxLivePages(), 5);
+}
+
+void tst_webpages::alive()
+{
+    QCOMPARE(m_webPages->alive(1), false);
+}
+
+void tst_webpages::page_data()
+{
+    QTest::addColumn<QList<Tab> >("initialTabs");
+    QTest::addColumn<Tab>("tab");
+    QTest::addColumn<int>("parentId");
+    QTest::addColumn<int>("maxLiveTabs");
+    QTest::addColumn<bool>("isPageCreationExpected");
+
+    QList<Tab> noInitialTabs;
+    QList<Tab> threeTabs {
+        Tab(1, "http://example1.com", "Title1", ""),
+        Tab(2, "http://example2.com", "Title2", ""),
+        Tab(3, "http://example3.com", "Title3", "")
+    };
+
+    QTest::newRow("no_initial_tabs") << noInitialTabs << Tab(1, "http://example.com", "Title1", "") << 0 << 5 << true;
+    QTest::newRow("add_new_tab") << threeTabs << Tab(4, "http://example4.com", "Title4", "") << 0 << 5 << true;
+    QTest::newRow("activate_live_tab") << threeTabs << Tab(1, "http://example1.com", "Title1", "") << 0 << 5 << false;
+    QTest::newRow("activate_dead_tab") << threeTabs << Tab(1, "http://example1.com", "Title1", "") << 0 << 2 << true;
+    QTest::newRow("activate_active_tab") << threeTabs << Tab(3, "http://example3.com", "Title3", "") << 0 << 5 << false;
+}
+
+void tst_webpages::page()
+{
+    QFETCH(QList<Tab>, initialTabs);
+    QFETCH(Tab, tab);
+    QFETCH(int, parentId);
+    QFETCH(int, maxLiveTabs);
+    QFETCH(bool, isPageCreationExpected);
+
+    // set up test case
+
+    EXPECT_CALL(*QMozContext::GetInstance(), setPixelRatio(_));
+    DeclarativeWebContainer webContainer;
+    m_webPages->initialize(&webContainer);
+
+    DeclarativeWebPage* page = nullptr;
+
+    m_webPages->setMaxLivePages(maxLiveTabs);
+    foreach (Tab initialTab, initialTabs) {
+        page = new DeclarativeWebPage();
+        EXPECT_CALL(*page, tabId()).Times(2).WillRepeatedly(Return(initialTab.tabId()));
+        EXPECT_CALL(*page, uniqueID()).Times(AnyNumber()).WillRepeatedly(Return(initialTab.tabId()));
+        EXPECT_CALL(*page, parentId()).Times(initialTab.tabId() == 1 && (tab.tabId() != 1 || maxLiveTabs < initialTabs.count()) ? 1 : 2);
+        EXPECT_CALL(*page, resumeView()).Times(AnyNumber());
+        EXPECT_CALL(*page, update()).Times(initialTab.tabId() == 1 && tab.tabId() == 1 && maxLiveTabs > initialTabs.count() ? 2 : 1);
+        EXPECT_CALL(*page, completed()).WillOnce(Return(true));
+        EXPECT_CALL(*page, contentRect()).Times(AnyNumber()).WillRepeatedly(Return(QRectF()));
+        EXPECT_CALL(m_pageFactory, createWebPage(_, _, _)).WillOnce(Return(page));
+        if (!(initialTab.tabId() == 3 && tab.tabId() == 3)) {
+            // no need to suspend active view
+            EXPECT_CALL(*page, suspendView());
+            EXPECT_CALL(*page, loading()).WillOnce(Return(false));
+        }
+
+        m_webPages->page(initialTab);
+    }
+
+
+    // actual test
+    if (isPageCreationExpected) {
+        page = new DeclarativeWebPage();
+        if (!(tab.tabId() == 1 && maxLiveTabs < initialTabs.count())) {
+            EXPECT_CALL(*page, tabId()).WillOnce(Return(tab.tabId()));
+        }
+        EXPECT_CALL(*page, uniqueID()).WillOnce(Return(tab.tabId()));
+        EXPECT_CALL(*page, parentId()).Times(initialTabs.count() ? 2 : 1).WillRepeatedly(Return(parentId));
+        EXPECT_CALL(*page, resumeView());
+        EXPECT_CALL(*page, update());
+        EXPECT_CALL(*page, completed()).WillOnce(Return(true));
+        EXPECT_CALL(*page, setResurrectedContentRect(_)).Times(tab.tabId() == 1 && maxLiveTabs < initialTabs.count() ? 1 : 0);
+        EXPECT_CALL(m_pageFactory, createWebPage(_, _, _)).WillOnce(Return(page));
+    }
+    WebPageActivationData data = m_webPages->page(tab, parentId);
+    if (tab.tabId() == 3) {
+        // the third tab is active already
+        QVERIFY(!data.activated);
+    } else {
+        QVERIFY(data.activated);
+    }
+    QVERIFY(data.webPage);
+}
+
+void tst_webpages::pageWithBrokenPageFactory()
+{
+    EXPECT_CALL(m_pageFactory, createWebPage(_, _, _)).WillOnce(Return(nullptr));
+    WebPageActivationData data = m_webPages->page(Tab(1, "http://example.com", "Title1", ""), 0);
+    QVERIFY(!data.activated);
+    QVERIFY(!data.webPage);
+}
+
+void tst_webpages::release_data()
+{
+    QTest::addColumn<QList<Tab> >("initialTabs");
+    QTest::addColumn<int>("tabId");
+    QTest::addColumn<int>("maxLiveTabs");
+    QTest::addColumn<int>("expectedCount");
+
+    QList<Tab> noInitialTabs;
+    QList<Tab> threeTabs {
+        Tab(1, "http://example1.com", "Title1", ""),
+        Tab(2, "http://example2.com", "Title2", ""),
+        Tab(3, "http://example3.com", "Title3", "")
+    };
+
+    QTest::newRow("release_from_empty_list") << noInitialTabs << 1 << 5 << 0;
+    QTest::newRow("release_non_existent_tab") << threeTabs << 10 << 5 << 3;
+    QTest::newRow("release_live") << threeTabs << 2 << 5 << 2;
+    QTest::newRow("release_virtualized") << threeTabs << 1 << 2 << 2;
+}
+
+void tst_webpages::release()
+{
+    QFETCH(QList<Tab>, initialTabs);
+    QFETCH(int, tabId);
+    QFETCH(int, maxLiveTabs);
+    QFETCH(int, expectedCount);
+
+    m_webPages->setMaxLivePages(maxLiveTabs);
+    DeclarativeWebPage* page = nullptr;
+
+    foreach (Tab initialTab, initialTabs) {
+        page = new DeclarativeWebPage();
+        EXPECT_CALL(*page, tabId()).Times(AnyNumber()).WillRepeatedly(Return(initialTab.tabId()));
+        EXPECT_CALL(*page, uniqueID()).Times(AnyNumber()).WillRepeatedly(Return(initialTab.tabId()));
+        EXPECT_CALL(*page, parentId()).Times(AnyNumber());
+        EXPECT_CALL(*page, resumeView()).Times(AnyNumber());
+        EXPECT_CALL(*page, update()).Times(AnyNumber());
+        EXPECT_CALL(*page, completed()).WillOnce(Return(true));
+        EXPECT_CALL(*page, contentRect()).Times(AnyNumber()).WillRepeatedly(Return(QRectF()));
+        EXPECT_CALL(*page, loading()).Times(AnyNumber()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*page, suspendView()).Times(AnyNumber());
+
+        EXPECT_CALL(m_pageFactory, createWebPage(_, _, _)).WillOnce(Return(page));
+        m_webPages->page(initialTab);
+    }
+
+    m_webPages->release(tabId);
+    QCOMPARE(m_webPages->count(), expectedCount);
+}
+
+void tst_webpages::clear_data()
+{
+    QTest::addColumn<QList<Tab> >("initialTabs");
+
+    QList<Tab> noInitialTabs;
+    QList<Tab> threeTabs {
+        Tab(1, "http://example1.com", "Title1", ""),
+        Tab(2, "http://example2.com", "Title2", ""),
+        Tab(3, "http://example3.com", "Title3", "")
+    };
+
+    QTest::newRow("empty_queue") << noInitialTabs;
+    QTest::newRow("non_empty_queue") << threeTabs;
+}
+
+void tst_webpages::clear()
+{
+    QFETCH(QList<Tab>, initialTabs);
+
+    NiceMock<DeclarativeWebPage>* page = nullptr;
+
+    foreach (Tab initialTab, initialTabs) {
+        page = new NiceMock<DeclarativeWebPage>();
+        EXPECT_CALL(*page, tabId()).Times(AnyNumber()).WillRepeatedly(Return(initialTab.tabId()));
+        EXPECT_CALL(*page, uniqueID()).Times(AnyNumber()).WillRepeatedly(Return(initialTab.tabId()));
+        EXPECT_CALL(*page, completed()).WillOnce(Return(true));
+        EXPECT_CALL(*page, contentRect()).Times(AnyNumber()).WillRepeatedly(Return(QRectF()));
+
+        EXPECT_CALL(m_pageFactory, createWebPage(_, _, _)).WillOnce(Return(page));
+        m_webPages->page(initialTab);
+    }
+
+    m_webPages->clear();
+    QCOMPARE(m_webPages->count(), 0);
+}
+
+void tst_webpages::parentTabId_data()
+{
+    QTest::addColumn<QList<Tab> >("initialTabs");
+    QTest::addColumn<QList<int> >("initialParentIds");
+    QTest::addColumn<int>("tabId");
+    QTest::addColumn<int>("expectedParentId");
+
+    QList<Tab> threeTabs {
+        Tab(1, "http://example1.com", "Title1", ""),
+        Tab(2, "http://example2.com", "Title2", ""),
+        Tab(3, "http://example3.com", "Title3", "")
+    };
+
+    QList<int> threeParentIds {0, 1, 0};
+
+    QTest::newRow("no_parent") << threeTabs << threeParentIds << 1 << 0;
+    QTest::newRow("parent1") << threeTabs << threeParentIds << 2 << 1;
+}
+
+void tst_webpages::parentTabId()
+{
+    QFETCH(QList<Tab>, initialTabs);
+    QFETCH(QList<int>, initialParentIds);
+    QFETCH(int, tabId);
+    QFETCH(int, expectedParentId);
+
+    NiceMock<DeclarativeWebPage>* page = nullptr;
+
+    for (int i = 0; i < initialTabs.count(); i++) {
+        Tab initialTab = initialTabs.at(i);
+        int parentId = initialParentIds.at(i);
+
+        page = new NiceMock<DeclarativeWebPage>();
+        EXPECT_CALL(*page, parentId()).Times(AnyNumber()).WillRepeatedly(Return(parentId));
+        EXPECT_CALL(*page, tabId()).Times(AnyNumber()).WillRepeatedly(Return(initialTab.tabId()));
+        EXPECT_CALL(*page, uniqueID()).Times(AnyNumber()).WillRepeatedly(Return(initialTab.tabId()));
+        EXPECT_CALL(*page, completed()).WillOnce(Return(true));
+        EXPECT_CALL(*page, contentRect()).Times(AnyNumber()).WillRepeatedly(Return(QRectF()));
+
+        EXPECT_CALL(m_pageFactory, createWebPage(_, _, _)).WillOnce(Return(page));
+        m_webPages->page(initialTab);
+    }
+
+    QCOMPARE(m_webPages->parentTabId(tabId), expectedParentId);
+}
+
+QTEST_MAIN(tst_webpages)
+#include "tst_webpages.moc"

--- a/tests/auto/tst_webpages/tst_webpages.pro
+++ b/tests/auto/tst_webpages/tst_webpages.pro
@@ -1,12 +1,12 @@
-TARGET = tst_declarativewebcontainer
+TARGET = tst_webpages
 
 CONFIG += link_pkgconfig
 
+PKGCONFIG += mlite5
+
+QT += qml quick concurrent sql gui-private
+
 QMAKE_LFLAGS += -lgtest -lgmock
-
-PKGCONFIG += mlite5 nemotransferengine-qt5
-
-QT += quick qml concurrent sql gui-private
 
 include(../mocks/qmozcontext/qmozcontext.pri)
 include(../mocks/webpagefactory/webpagefactory.pri)
@@ -18,7 +18,7 @@ include(../test_common.pri)
 include(../../../src/core/core.pri)
 include(../../../src/history/history.pri)
 
-SOURCES += tst_declarativewebcontainer.cpp
+SOURCES += tst_webpages.cpp
 
 # Avoid inclusion of qtmozembed headers in devel environment
 INCLUDEPATH -= $$absolute_path(../../../../qtmozembed/src)

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -12,6 +12,7 @@ include(../mocks/declarativewebutils/declarativewebutils_mock.pri)
 include(../common/testobject.pri)
 include(../../../src/core/core.pri)
 include(../../../src/qtmozembed/qtmozembed.pri)
+include(../../../src/factories/factories.pri)
 include(../../../src/bookmarks/bookmarks.pri)
 include(../../../src/history/history.pri)
 


### PR DESCRIPTION
* Decouple `BookmarkManager` from `SettingsManager` (this is the reason for simplification of private data settings).
* Factor out `DeclarativeWebPage` creation to a dedicated factory object. This way it's easier to test the `WebPages` class and different scenarios of web page creation.
* Add unit tests for `WebPages`.