### PR TITLE
[sailfish-browser] Do not update view margins upon suspend/resume. Fixes JB#33119

### DIFF
--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -95,7 +95,6 @@ DeclarativeWebPage::DeclarativeWebPage(QObject *parent)
     connect(&m_grabWritter, SIGNAL(finished()), this, SLOT(grabWritten()));
     connect(this, SIGNAL(urlChanged()), this, SLOT(onUrlChanged()));
     connect(this, &QOpenGLWebPage::contentHeightChanged, this, &DeclarativeWebPage::updateViewMargins);
-    connect(this, &QOpenGLWebPage::activeChanged, this, &DeclarativeWebPage::updateViewMargins);
 }
 
 DeclarativeWebPage::~DeclarativeWebPage()
@@ -346,8 +345,9 @@ void DeclarativeWebPage::updateViewMargins()
         return;
     }
 
+    qreal threshold = qMax(m_fullScreenHeight * 1.5f, (m_fullScreenHeight + (m_toolbarHeight*2)));
     QMargins margins;
-    if (!m_fullscreen && (contentHeight() < (m_fullScreenHeight + m_toolbarHeight))) {
+    if (!m_fullscreen && (contentHeight() < threshold)) {
         margins.setBottom(m_toolbarHeight);
     }
 


### PR DESCRIPTION
Updating bottom margin upon suspend/resume may trigger infinite
rendering loop between zero bottom margin and toolbar height margin.

In addition to above, require at least 1.5x times fullscreen height
in order to set the bottom margin. Setting bottom margin normally
triggers another content height change as the available height
changed. Normal case when bottom margin is set to zero is when
a web page has plenty of content.

Bottom margin with virtual keyboard is updated separately.