### PR TITLE
[sailfish-browser] Update rendering related preferences

### DIFF
--- a/src/declarativewebutils.cpp
+++ b/src/declarativewebutils.cpp
@@ -454,8 +454,9 @@ void DeclarativeWebUtils::setRenderingPreferences()
     mozContext->setPref(QString("apz.asyncscroll.timeout"), QVariant(400));
 
     // Use external Qt window for rendering content
+    mozContext->setPref(QString("gfx.compositor.external-window"), QVariant(true));
+    mozContext->setPref(QString("gfx.compositor.clear-context"), QVariant(false));
     mozContext->setPref(QString("embedlite.compositor.external_gl_context"), QVariant(true));
-    mozContext->setPref(QString("embedlite.compositor.request_external_gl_context_early"), QVariant(true));
 
     // Enable progressive painting.
     mozContext->setPref(QString("layers.progressive-paint"), QVariant(true));


### PR DESCRIPTION
Clear only once per frame. Without gfx.compositor.clear-context
both drawUnderlay and CompositorOGL would clear.

The embedlite.compositor.request_external_gl_context_early is not
needed EmbedLiteWindowBaseChild::CreateWidget instantiates EmbedLitePuppetWidget
and updates size for it. Due to size update the normal compositor
creation code path will get executed.

EmbedLitePuppetWidget::UpdateSize =>
EmbedLitePuppetWidget::Resize =>
EmbedLitePuppetWidget::Invalidate =>
EmbedLitePuppetWidget::GetLayerManager =>
EmbedLitePuppetWidget::CreateCompositor