### PR TITLE
[sailfish-browser] Adapt to new download manager. 

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -88,7 +88,6 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
 
     setTabModel(privateMode() ? m_privateTabModel.data() : m_persistentTabModel.data());
 
-    connect(DownloadManager::instance(), SIGNAL(initializedChanged()), this, SLOT(initialize()));
     connect(DownloadManager::instance(), SIGNAL(downloadStarted()), this, SLOT(onDownloadStarted()));
     connect(QMozContext::GetInstance(), SIGNAL(onInitialized()), this, SLOT(initialize()));
     connect(QMozContext::GetInstance(), &QMozContext::lastViewDestroyed,
@@ -893,7 +892,7 @@ void DeclarativeWebContainer::updatePageFocus(bool focus)
 
 bool DeclarativeWebContainer::canInitialize() const
 {
-    return QMozContext::GetInstance()->initialized() && DownloadManager::instance()->initialized() && m_model && m_model->loaded();
+    return QMozContext::GetInstance()->initialized() && m_model && m_model->loaded();
 }
 
 void DeclarativeWebContainer::loadTab(const Tab& tab, bool force)

--- a/src/declarativewebutils.cpp
+++ b/src/declarativewebutils.cpp
@@ -138,6 +138,7 @@ void DeclarativeWebUtils::updateWebEngineSettings()
 
     // Use autodownload, never ask
     mozContext->setPref(QString("browser.download.useDownloadDir"), QVariant(true));
+    mozContext->setPref(QString("browser.download.useJSTransfer"), QVariant(true));
     // see https://developer.mozilla.org/en-US/docs/Download_Manager_preferences
     // Use custom downloads location defined in browser.download.dir
     mozContext->setPref(QString("browser.download.folderList"), QVariant(2));
@@ -172,8 +173,7 @@ void DeclarativeWebUtils::updateWebEngineSettings()
                              << "media-decoder-info"
                              << "embed:download"
                              << "embed:allprefs"
-                             << "embed:search"
-                             << "download-manager-initialized");
+                             << "embed:search");
 
     // Enable internet search
     mozContext->setPref(QString("keyword.enabled"), QVariant(true));

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -27,7 +27,6 @@ static DownloadManager *gSingleton = 0;
 
 DownloadManager::DownloadManager()
     : QObject()
-    , m_initialized(false)
 {
     m_transferClient = new TransferEngineInterface("org.nemo.transferengine",
                                                    "/org/nemo/transferengine",
@@ -45,10 +44,7 @@ DownloadManager::~DownloadManager()
 void DownloadManager::recvObserve(const QString message, const QVariant data)
 {
 
-    if (message == "download-manager-initialized" && !m_initialized) {
-        m_initialized = true;
-        emit initializedChanged();
-    } else if (message != "embed:download") {
+    if (message != "embed:download") {
         // here we are interested in download messages only
         return;
     }
@@ -237,11 +233,6 @@ bool DownloadManager::existActiveTransfers()
         }
     }
     return exists;
-}
-
-bool DownloadManager::initialized()
-{
-    return m_initialized;
 }
 
 void DownloadManager::checkAllTransfers()

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -27,10 +27,8 @@ public:
     static DownloadManager *instance();
 
     bool existActiveTransfers();
-    bool initialized();
 
 signals:
-    void initializedChanged();
     void downloadStarted();
     void allTransfersCompleted();
 
@@ -65,7 +63,6 @@ private:
     QHash<qulonglong, Status> m_statusCache;
 
     TransferEngineInterface *m_transferClient;
-    bool m_initialized;
 };
 
 #endif

--- a/src/pages/components/BrowserContextMenu.qml
+++ b/src/pages/components/BrowserContextMenu.qml
@@ -165,7 +165,7 @@ Rectangle {
                                        {
                                            "msg": "addDownload",
                                            "from": root.imageSrc,
-                                           "to": "file://" + root.getUniqueFileName(leafName),
+                                           "to": root.getUniqueFileName(leafName),
                                            "contentType": root.contentType,
                                            "viewId": root.viewId
                                        })

--- a/tests/auto/mocks/downloadmanager/downloadmanager.cpp
+++ b/tests/auto/mocks/downloadmanager/downloadmanager.cpp
@@ -24,8 +24,3 @@ DownloadManager *DownloadManager::instance()
     }
     return s_singleton;
 }
-
-bool DownloadManager::initialized()
-{
-    return true;
-}

--- a/tests/auto/mocks/downloadmanager/downloadmanager.h
+++ b/tests/auto/mocks/downloadmanager/downloadmanager.h
@@ -20,7 +20,6 @@ class DownloadManager : public QObject
 
 public:
     static DownloadManager *instance();
-    bool initialized();
 
 signals:
     void initializedChanged();


### PR DESCRIPTION
Adaptations basically means that now
* we don't need to wait until nsDownloadManager is initialized in order start URL download upon browser launch;
* there is no need to set URL scheme `file://` when downloading an URL to a local file target.