### PR TITLE
[sailfish-browser] Fix external link load when starting browser. Fixes JB#33892

### DIFF
--- a/org.sailfishos.browser.service
+++ b/org.sailfishos.browser.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser
-Exec=/usr/bin/invoker -s --type=browser -G /usr/bin/sailfish-browser
+Exec=/usr/bin/invoker -s --type=browser -G /usr/bin/sailfish-browser -prestart

--- a/org.sailfishos.browser.ui.service
+++ b/org.sailfishos.browser.ui.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser.ui
-Exec=/usr/bin/invoker -s --type=browser --desktop-file=sailfish-browser.desktop -G /usr/bin/sailfish-browser
+Exec=/usr/bin/invoker -s --type=browser --desktop-file=sailfish-browser.desktop -G /usr/bin/sailfish-browser -prestart

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -743,7 +743,7 @@ void DeclarativeWebContainer::initialize()
         QString url = m_initialUrl.isEmpty() ? DeclarativeWebUtils::instance()->homePage() : m_initialUrl;
         QString title = "";
         m_model->newTab(url, title);
-    } else if (m_model->count() > 0) {
+    } else if (m_model->count() > 0 && !m_webPage) {
         Tab tab = m_model->activeTab();
         if (!m_initialUrl.isEmpty()) {
             tab.setUrl(m_initialUrl);
@@ -788,6 +788,11 @@ void DeclarativeWebContainer::onNewTabRequested(QString url, QString title, int 
     Q_UNUSED(title);
     Tab tab;
     tab.setTabId(m_model->nextTabId());
+    tab.setUrl(url);
+    if (!canInitialize()) {
+        m_initialUrl = url;
+    }
+
     if (activatePage(tab, false, parentId)) {
         m_webPage->loadTab(url, false);
     }

--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -372,7 +372,7 @@ QDebug operator<<(QDebug dbg, const DeclarativeWebPage *page)
         return dbg << "DeclarativeWebPage (this = 0x0)";
     }
 
-    dbg.nospace() << "DeclarativeWebPage(url = " << page->url() << ", title = " << page->title() << ", width = " << page->width()
+    dbg.nospace() << "DeclarativeWebPage(tabId = " << page->tabId() << " url = " << page->url() << ", title = " << page->title() << ", width = " << page->width()
                   << ", height = " << page->height() << ", completed = " << page->completed()
                   << ", active = " << page->active() << ", enabled = " << page->enabled() << ")";
     return dbg.space();

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -195,11 +195,11 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 #ifdef USE_RESOURCES
     view->setSource(QUrl("qrc:///browser.qml"));
 #else
-    bool isDesktop = qApp->arguments().contains("-desktop");
+    bool isDesktop = app->arguments().contains("-desktop");
 
     QString path;
     if (isDesktop) {
-        path = qApp->applicationDirPath() + QDir::separator();
+        path = app->applicationDirPath() + QDir::separator();
     } else {
         path = QString(DEPLOYMENT_PATH);
     }
@@ -209,10 +209,12 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     // Setup embedding
     QTimer::singleShot(0, QMozContext::GetInstance(), SLOT(runEmbedding()));
 
-    if (qApp->arguments().count() > 1 && (qApp->arguments().last() != QLatin1Literal("-debugMode"))) {
-        emit utils->openUrlRequested(qApp->arguments().last());
-    } else if (!utils->firstUseDone()) {
-        emit utils->openUrlRequested("");
+    if (!app->arguments().contains(QStringLiteral("-prestart"))) {
+        if (app->arguments().count() > 1 && (app->arguments().last() != QStringLiteral("-debugMode"))) {
+            emit utils->openUrlRequested(app->arguments().last());
+        } else if (!utils->firstUseDone()) {
+            emit utils->openUrlRequested("");
+        }
     }
 
     return app->exec();


### PR DESCRIPTION
Contains two small commits. Probably still easier to review per commit.

Main problem was / is that the previous active tab got loaded when browser was launched so that there were tabs from previous browsing session. The first commit sha1 78efdd9 fixes that. The second commit sha1 41d4b76 fixes overlay flickering when browser launched via external link so that there were no tabs from previous browsing session -- overlay appears quickly on top position from where changed to chrome mode.