### PR TITLE
[sailfish-browser] Do not add myapp to the transfer ui. Fixes JB#34283

### DIFF
--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -12,6 +12,8 @@
 #ifndef DOWNLOADMANAGER_H
 #define DOWNLOADMANAGER_H
 
+#include "downloadstatus.h"
+
 #include <QObject>
 #include <QHash>
 #include <QString>
@@ -22,7 +24,7 @@ class TransferEngineInterface;
 class DownloadManager : public QObject
 {
     Q_OBJECT
-
+    Q_ENUMS(DownloadStatus::Status)
 public:
     static DownloadManager *instance();
 
@@ -32,10 +34,12 @@ public:
 signals:
     void initializedChanged();
     void downloadStarted();
+    void downloadStatusChanged(int downloadId, int status, QVariant info);
     void allTransfersCompleted();
 
 public slots:
     void cancelActiveTransfers();
+    void cancel(int downloadId);
 
 private slots:
     void recvObserve(const QString message, const QVariant data);
@@ -47,22 +51,19 @@ private:
     explicit DownloadManager();
     ~DownloadManager();
 
-    enum Status {
-        DownloadStarted,
-        DownloadDone,
-        DownloadFailed,
-        DownloadCanceled
-    };
-
     void checkAllTransfers();
-    bool moveMyAppPackage(QString path);
+    bool moveMyAppPackage(const QString &path) const;
+
+    bool isMyApp(const QString &targetPath) const;
+    bool needPlatformTransfersUpdate(const QString &targetPath) const;
+    void finishMyAppDownload(const QString &targetPath) const;
 
     // TODO: unlike Gecko downloads and Sailfish transfers these mappings
     //       are not persistent -> after user has browser closed transfers can't be
     //       restarted.
     QHash<qulonglong, int> m_download2transferMap;
     QHash<int, qulonglong> m_transfer2downloadMap;
-    QHash<qulonglong, Status> m_statusCache;
+    QHash<qulonglong, DownloadStatus::Status> m_statusCache;
 
     TransferEngineInterface *m_transferClient;
     bool m_initialized;

--- a/src/downloadstatus.h
+++ b/src/downloadstatus.h
@@ -1,0 +1,30 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef DOWNLOAD_STATUS_H
+#define DOWNLOAD_STATUS_H
+
+#include <QObject>
+
+class DownloadStatus : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(Status)
+public:
+    enum Status {
+        Started,
+        Done,
+        Failed,
+        Canceled
+    };
+};
+
+#endif

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -30,6 +30,7 @@
 #include "declarativewebutils.h"
 #include "browserservice.h"
 #include "downloadmanager.h"
+#include "downloadstatus.h"
 #include "closeeventfilter.h"
 #include "persistenttabmodel.h"
 #include "privatetabmodel.h"
@@ -139,6 +140,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterUncreatableType<DeclarativeTabModel>(uri, 1, 0, "TabModel", "TabModel is abstract!");
     qmlRegisterUncreatableType<PersistentTabModel>(uri, 1, 0, "PersistentTabModel", "");
     qmlRegisterUncreatableType<PrivateTabModel>(uri, 1, 0, "PrivateTabModel", "");
+    qmlRegisterUncreatableType<DownloadStatus>(uri, 1, 0, "DownloadStatus", "");
     qmlRegisterType<DeclarativeHistoryModel>(uri, 1, 0, "HistoryModel");
     qmlRegisterType<DeclarativeWebContainer>(uri, 1, 0, "WebContainer");
     qmlRegisterType<DeclarativeWebPage>(uri, 1, 0, "WebPage");
@@ -172,15 +174,17 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
                    utils, SIGNAL(activateNewTabViewRequested()));
 
     utils->clearStartupCacheIfNeeded();
-    view->rootContext()->setContextProperty("WebUtils", utils);
-    view->rootContext()->setContextProperty("MozContext", QMozContext::GetInstance());
-    view->rootContext()->setContextProperty("Settings", SettingManager::instance());
 
     DownloadManager *dlMgr = DownloadManager::instance();
     dlMgr->connect(service, SIGNAL(cancelTransferRequested(int)),
             dlMgr, SLOT(cancelTransfer(int)));
     dlMgr->connect(service, SIGNAL(restartTransferRequested(int)),
             dlMgr, SLOT(restartTransfer(int)));
+
+    view->rootContext()->setContextProperty("WebUtils", utils);
+    view->rootContext()->setContextProperty("MozContext", QMozContext::GetInstance());
+    view->rootContext()->setContextProperty("Settings", SettingManager::instance());
+    view->rootContext()->setContextProperty("DownloadManager", dlMgr);
 
     CloseEventFilter * clsEventFilter = new CloseEventFilter(dlMgr, app.data());
     view->installEventFilter(clsEventFilter);

--- a/src/sailfishbrowser.cpp
+++ b/src/sailfishbrowser.cpp
@@ -129,23 +129,25 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     //% "Browser"
     view->setTitle(qtTrId("sailfish-browser-ap-name"));
 
-    // Use QtQuick 2.1 for Sailfish.Browser imports
-    qmlRegisterRevision<QQuickItem, 1>("Sailfish.Browser", 1, 0);
-    qmlRegisterRevision<QWindow, 1>("Sailfish.Browser", 1, 0);
+    const char *uri = "Sailfish.Browser";
 
-    qmlRegisterType<DeclarativeBookmarkModel>("Sailfish.Browser", 1, 0, "BookmarkModel");
-    qmlRegisterUncreatableType<DeclarativeTabModel>("Sailfish.Browser", 1, 0, "TabModel", "TabModel is abstract!");
-    qmlRegisterUncreatableType<PersistentTabModel>("Sailfish.Browser", 1, 0, "PersistentTabModel", "");
-    qmlRegisterUncreatableType<PrivateTabModel>("Sailfish.Browser", 1, 0, "PrivateTabModel", "");
-    qmlRegisterType<DeclarativeHistoryModel>("Sailfish.Browser", 1, 0, "HistoryModel");
-    qmlRegisterType<DeclarativeWebContainer>("Sailfish.Browser", 1, 0, "WebContainer");
-    qmlRegisterType<DeclarativeWebPage>("Sailfish.Browser", 1, 0, "WebPage");
-    qmlRegisterType<DeclarativeWebPageCreator>("Sailfish.Browser", 1, 0, "WebPageCreator");
-    qmlRegisterType<DeclarativeFileUploadMode>("Sailfish.Browser", 1, 0, "FileUploadMode");
-    qmlRegisterType<DeclarativeFileUploadFilter>("Sailfish.Browser", 1, 0, "FileUploadFilter");
-    qmlRegisterType<DesktopBookmarkWriter>("Sailfish.Browser", 1, 0, "DesktopBookmarkWriter");
-    qmlRegisterType<IconFetcher>("Sailfish.Browser", 1, 0, "IconFetcher");
-    qmlRegisterType<InputRegion>("Sailfish.Browser", 1, 0, "InputRegion");
+    // Use QtQuick 2.1 for Sailfish.Browser imports
+    qmlRegisterRevision<QQuickItem, 1>(uri, 1, 0);
+    qmlRegisterRevision<QWindow, 1>(uri, 1, 0);
+
+    qmlRegisterType<DeclarativeBookmarkModel>(uri, 1, 0, "BookmarkModel");
+    qmlRegisterUncreatableType<DeclarativeTabModel>(uri, 1, 0, "TabModel", "TabModel is abstract!");
+    qmlRegisterUncreatableType<PersistentTabModel>(uri, 1, 0, "PersistentTabModel", "");
+    qmlRegisterUncreatableType<PrivateTabModel>(uri, 1, 0, "PrivateTabModel", "");
+    qmlRegisterType<DeclarativeHistoryModel>(uri, 1, 0, "HistoryModel");
+    qmlRegisterType<DeclarativeWebContainer>(uri, 1, 0, "WebContainer");
+    qmlRegisterType<DeclarativeWebPage>(uri, 1, 0, "WebPage");
+    qmlRegisterType<DeclarativeWebPageCreator>(uri, 1, 0, "WebPageCreator");
+    qmlRegisterType<DeclarativeFileUploadMode>(uri, 1, 0, "FileUploadMode");
+    qmlRegisterType<DeclarativeFileUploadFilter>(uri, 1, 0, "FileUploadFilter");
+    qmlRegisterType<DesktopBookmarkWriter>(uri, 1, 0, "DesktopBookmarkWriter");
+    qmlRegisterType<IconFetcher>(uri, 1, 0, "IconFetcher");
+    qmlRegisterType<InputRegion>(uri, 1, 0, "InputRegion");
 
     QString componentPath(DEFAULT_COMPONENTS_PATH);
     QMozContext::GetInstance()->addComponentManifest(componentPath + QString("/components/EmbedLiteBinComponents.manifest"));

--- a/src/src.pro
+++ b/src/src.pro
@@ -71,6 +71,7 @@ HEADERS += \
     closeeventfilter.h \
     downloadmanager.h \
     downloadmimetypehandler.h \
+    downloadstatus.h \
     declarativewebutils.h
 
 OTHER_FILES = *.qml \


### PR DESCRIPTION
myapp is application metadata file that has custom handling. Thus, it should not be added to the transfer ui.