### PR TITLE
[sailfish-browser] Hide open-url.desktop now that D-bus activated des…

### DIFF
--- a/open-url.desktop
+++ b/open-url.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Browser
-NotShowIn=X-MeeGo;
+NoDisplay=true
 X-MeeGo-Logical-Id=sailfish-browser-ap-name
 X-MeeGo-Translation-Catalog=sailfish-browser
 MimeType=text/html;x-maemo-urischeme/http;x-maemo-urischeme/https;


### PR DESCRIPTION
…ktop files are allowed on app grid. Contributes to JB#5771

Alternate implementation to https://git.merproject.org/mer-core/lipstick/merge_requests/25