### PR TITLE
[sailfish-browser] Add site specific overrides. Contributes to JB#34904

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -1,7 +1,7 @@
 Name:       sailfish-browser
 
 Summary:    Sailfish Browser
-Version:    1.13.53
+Version:    1.13.69
 Release:    1
 Group:      Applications/Internet
 License:    MPLv2
@@ -27,7 +27,7 @@ BuildRequires:  libgmock-devel
 Requires: sailfishsilica-qt5 >= 0.22.13
 Requires: jolla-ambient >= 0.7.12
 Requires: xulrunner-qt5 >= 31.8.0.3
-Requires: embedlite-components-qt5 >= 1.8.11
+Requires: embedlite-components-qt5 >= 1.8.22
 Requires: qtmozembed-qt5 >= 1.12.30
 Requires: sailfish-browser-settings = %{version}
 Requires: qt5-plugin-imageformat-ico

--- a/src/declarativewebutils.cpp
+++ b/src/declarativewebutils.cpp
@@ -207,6 +207,9 @@ void DeclarativeWebUtils::updateWebEngineSettings()
     setContentScaling();
     setRenderingPreferences();
 
+    // Set site specific overrides
+    setSiteSpecificOverrides();
+
     // Theme.fontSizeSmall
     mozContext->setPref(QStringLiteral("embedlite.inputItemSize"), QVariant(m_inputItemSize));
     mozContext->setPref(QStringLiteral("embedlite.zoomMargin"), QVariant(m_zoomMargin));
@@ -473,4 +476,19 @@ void DeclarativeWebUtils::setRenderingPreferences()
         // a bit the blurriness.
         mozContext->setPref(QString("layers.low-precision-resolution"), QString("0.5f"));
     }
+}
+
+void DeclarativeWebUtils::setSiteSpecificOverrides()
+{
+    QMozContext* mozContext = QMozContext::GetInstance();
+    Q_ASSERT(mozContext->initialized());
+
+    mozContext->setPref(QStringLiteral("general.useragent.override.dailymotion.com"), QStringLiteral("Maemo; Linux;#Android 4.4.2;"));
+    mozContext->setPref(QStringLiteral("general.useragent.override.le.com"), QStringLiteral("Maemo; Linux;#Android 4.4.2;"));
+    mozContext->setPref(QStringLiteral("general.useragent.override.youku.com"), QStringLiteral("Maemo; Linux;#Android 4.4.2;"));
+    mozContext->setPref(QStringLiteral("general.useragent.override.iqiyi.com"), QStringLiteral("Maemo; Linux; U; #Android;"));
+    mozContext->setPref(QStringLiteral("general.useragent.override.facebook.com"), QStringLiteral("Maemo; Linux; U; Jolla; # ; "));
+    mozContext->setPref(QStringLiteral("general.useragent.override.fbcdn.net"), QStringLiteral("Maemo; Linux; U; Jolla; # ; "));
+    mozContext->setPref(QStringLiteral("general.useragent.override.engadget.com"), QStringLiteral("Maemo; Linux; U; Jolla; # ;"));
+    mozContext->setPref(QStringLiteral("general.useragent.override.youtube.com"), QStringLiteral("Mozilla/5.0 (Maemo; Android 4.4.2; U; Jolla; Sailfish; ; rv:31.0) Gecko/31.0 Firefox/31.0 SailfishBrowser/1.0 like Safari/538.1"));
 }

--- a/src/declarativewebutils.h
+++ b/src/declarativewebutils.h
@@ -85,6 +85,7 @@ private:
     ~DeclarativeWebUtils();
     void setContentScaling();
     void setRenderingPreferences();
+    void setSiteSpecificOverrides();
 
     MGConfItem m_homePage;
     bool m_firstUseDone;


### PR DESCRIPTION
Let's override youtube.com here so that site specific override gets triggered. Noticed that navigating from other site that was overridden to youtube.com there was just a network request. Thus, previous mapped user-agent override got picked. Will cleanup Embedlite Components side more once we get this one in. 

Furthermore, I'll add means to configure browser specific overrides in easier manner.