### PR TITLE
[sailfish-browser] Reset MozWindow upon close event if all tabs have been closed. Fixes JB#33457

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -519,6 +519,11 @@ bool DeclarativeWebContainer::eventFilter(QObject *obj, QEvent *event)
     if (event->type() == QEvent::Close && m_mozWindow) {
         m_mozWindow->suspendRendering();
         m_closing = true;
+
+        if (m_webPages->count() == 0) {
+            m_mozWindow.reset();
+        }
+
         m_webPages->clear();
     }
 


### PR DESCRIPTION
Exit was not correctly handle on Gecko 38 if all tabs were closed (last view)
before closing the browser from the switcher.

@siteshwar review ?