### PR TITLE
[user-agent] Add mobile friendlier UA for Yandex. Contributes to JB#25096

### DIFF
--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -58,5 +58,9 @@
   "facebook.com": "Maemo; Linux; U; Jolla; # ; ",
   "fbcdn.net": "Maemo; Linux; U; Jolla; # ; ",
   "engadget.com": "Maemo; Linux; U; Jolla; # ;",
-  "youtube.com": "Mozilla/5.0 (Maemo; Android 4.4.2; U; Jolla; Sailfish; ; rv:31.0) Gecko/31.0 Firefox/31.0 SailfishBrowser/1.0 like Safari/538.1"
+  "youtube.com": "Mozilla/5.0 (Maemo; Android 4.4.2; U; Jolla; Sailfish; ; rv:31.0) Gecko/31.0 Firefox/31.0 SailfishBrowser/1.0 like Safari/538.1",
+  "yandex.com": "Mozilla/5.0 (Mobile; rv:31.0) Gecko/31.0 Firefox/31.0",
+  "yandex.net": "Mozilla/5.0 (Mobile; rv:31.0) Gecko/31.0 Firefox/31.0",
+  "yandex.ru": "Mozilla/5.0 (Mobile; rv:31.0) Gecko/31.0 Firefox/31.0",
+  "yastatic.net": "Mozilla/5.0 (Mobile; rv:31.0) Gecko/31.0 Firefox/31.0"
 }


### PR DESCRIPTION
Search result page doesn't return optimal web page. There could
something wrong elsewhere that affects layout maximum width. As
Android Firefox UA agent also reproduced wrong search result page.

Image search works better.