### PR TITLE
[sailfish-browser] Enable asmjs. Fixes JB#22349

### DIFF
--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -188,9 +188,6 @@ void DeclarativeWebUtils::updateWebEngineSettings()
 
     mozContext->setPref(QString("media.resource_handler_disabled"), QVariant(true));
 
-    // Disable asmjs
-    mozContext->setPref(QString("javascript.options.asmjs"), QVariant(false));
-
     // subscribe to gecko messages
     mozContext->addObservers(QStringList()
                              << "clipboard:setdata"


### PR DESCRIPTION
See also https://github.com/sailfishos/sailfish-browser/issues/124 and
https://git.merproject.org/mer-core/embedlite-components/merge_requests/13

Using the correct AppInfo also allows use to enable asmjs. Likely
fixed by processId, processType, or/and XPCOMABI property fixes.