### PR TITLE
Jb35163

### DIFF
--- a/src/pages/components/ResourceController.qml
+++ b/src/pages/components/ResourceController.qml
@@ -17,7 +17,7 @@ import org.nemomobile.policy 1.0
 
 // QtObject cannot have children
 Item {
-    property QtObject webView
+    property QtObject webPage
     property bool videoActive
     property bool audioActive
     readonly property alias displayOff: screenBlanked.value
@@ -51,14 +51,14 @@ Item {
     }
 
     function resumeView() {
-        if (webView) {
-            webView.resumeView()
+        if (webPage) {
+            webPage.resumeView()
         }
     }
 
     function suspendView() {
-        if (webView) {
-            webView.suspendView()
+        if (webPage) {
+            webPage.suspendView()
         }
     }
 

--- a/src/pages/components/ResourceController.qml
+++ b/src/pages/components/ResourceController.qml
@@ -128,6 +128,8 @@ Item {
             } else {
                 resumeView()
             }
+            // Reset suspend intention.
+            suspendIntention = false
         }
 
         onSuspendIntentionChanged: {

--- a/src/pages/components/ResourceController.qml
+++ b/src/pages/components/ResourceController.qml
@@ -29,8 +29,6 @@ Item {
     property bool _isAudioStream
     property bool _isVideoStream
 
-    signal webViewSuspended
-
     function calculateStatus() {
         var video = false
         var audio = false
@@ -62,7 +60,6 @@ Item {
         if (webView) {
             webView.suspendView()
         }
-        webViewSuspended()
     }
 
     onAudioActiveChanged: {

--- a/src/pages/components/WebPopupHandler.js
+++ b/src/pages/components/WebPopupHandler.js
@@ -19,7 +19,6 @@ var popups
 var pageStack
 var auxTimer
 var contextMenuComponent
-var resourceController
 var tabModel
 // TODO: WebUtils context property. Should be singleton.
 var WebUtils

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -112,7 +112,7 @@ WebContainer {
 
             fullscreenHeight: container.fullscreenHeight
             toolbarHeight: container.toolbarHeight
-            throttlePainting: !foreground && !resourceController.videoActive && webView.visible || resourceController.displayOff
+            throttlePainting: !foreground && !resourceController.videoActive && webView.visible || !webView.visible
             enabled: webView.enabled
 
             // There needs to be enough content for enabling chrome gesture

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -360,7 +360,6 @@ WebContainer {
         PopupHandler.pageStack = pageStack
         PopupHandler.webView = webView
         PopupHandler.browserPage = browserPage
-        PopupHandler.resourceController = resourceController
         PopupHandler.WebUtils = WebUtils
         PopupHandler.tabModel = tabModel
         PopupHandler.pickerCreator = _pickerCreator

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -25,7 +25,7 @@ WebContainer {
     property bool findInPageHasResult
 
     property var resourceController: ResourceController {
-        webView: contentItem
+        webPage: contentItem
         background: !webView.visible
     }
 

--- a/tests/auto/tst_webview/ResourceControllerMock.qml
+++ b/tests/auto/tst_webview/ResourceControllerMock.qml
@@ -18,8 +18,6 @@ QtObject {
     property bool background
     property bool displayOff
 
-    signal webViewSuspended
-
     function calculateStatus() {}
 
     function resumeView() {}


### PR DESCRIPTION
PR contains two small cleanup commits.

Throttle always when browser content window is invisible. Throttling
is disabled on switcher if there is video playing. Browser
content window is invisible when display is turned off.

This also resets suspend intention after timer has triggered.