### PR TITLE
[sailfish-browser] Pass QWindow size to QMozWindow on constructor. Contributes to JB#35100

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -709,8 +709,7 @@ void DeclarativeWebContainer::onActiveTabChanged(int activeTabId, bool loadActiv
 void DeclarativeWebContainer::initialize()
 {
     if (QMozContext::GetInstance()->initialized() && !m_mozWindow) {
-        m_mozWindow.reset(new QMozWindow);
-        m_mozWindow->setSize(QWindow::size());
+        m_mozWindow.reset(new QMozWindow(QWindow::size()));
         connect(m_mozWindow.data(), &QMozWindow::requestGLContext,
                 this, &DeclarativeWebContainer::createGLContext, Qt::DirectConnection);
         connect(m_mozWindow.data(), &QMozWindow::drawUnderlay,

--- a/tests/auto/mocks/qmozwindow/qmozwindow.h
+++ b/tests/auto/mocks/qmozwindow/qmozwindow.h
@@ -26,7 +26,9 @@ class QMozWindow : public QObject
     Q_OBJECT
 
 public:
-    explicit QMozWindow(QObject *parent = 0) : QObject(parent) {};
+    explicit QMozWindow(const QSize &size, QObject *parent = 0) : QObject(parent) {
+        Q_UNUSED(size);
+    }
 
     MOCK_METHOD1(setSize, void(QSize));
     MOCK_METHOD0(size, QSize(void));


### PR DESCRIPTION
See also:
https://git.merproject.org/mer-core/qtmozembed/merge_requests/8
https://git.merproject.org/mer-core/gecko-dev/merge_requests/22
