### PR TITLE
[sailfish-browser] Open orientation fader after content orientation has changed. Fixes JB#35447

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -145,6 +145,9 @@ void DeclarativeWebContainer::setWebPage(DeclarativeWebPage *webPage, bool trigg
             connect(m_webPage, SIGNAL(windowCloseRequested()), this, SLOT(closeWindow()), Qt::UniqueConnection);
             connect(m_webPage, SIGNAL(loadingChanged()), this, SLOT(updateLoading()), Qt::UniqueConnection);
             connect(m_webPage, SIGNAL(loadProgressChanged()), this, SLOT(updateLoadProgress()), Qt::UniqueConnection);
+            connect(m_webPage, SIGNAL(contentOrientationChanged(Qt::ScreenOrientation)),
+                    this, SIGNAL(webContentOrientationChanged(Qt::ScreenOrientation)), Qt::UniqueConnection);
+
             // NB: these signals are not disconnected upon setting current m_webPage.
             connect(m_webPage, SIGNAL(urlChanged()), m_model, SLOT(onUrlChanged()), Qt::UniqueConnection);
             connect(m_webPage, SIGNAL(titleChanged()), m_model, SLOT(onTitleChanged()), Qt::UniqueConnection);
@@ -335,8 +338,6 @@ void DeclarativeWebContainer::setChromeWindow(QObject *chromeWindow)
             m_chromeWindow->setTransientParent(this);
             m_chromeWindow->showFullScreen();
             updateContentOrientation(m_chromeWindow->contentOrientation());
-            connect(m_chromeWindow.data(), &QWindow::contentOrientationChanged,
-                    this, &DeclarativeWebContainer::updateContentOrientation);
         }
         emit chromeWindowChanged();
     }

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -175,6 +175,8 @@ signals:
     void chromeExposed();
     void readyToPaintChanged();
 
+    void webContentOrientationChanged(Qt::ScreenOrientation orientation);
+
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
     virtual void exposeEvent(QExposeEvent *event);

--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -164,7 +164,11 @@ Page {
             }
         }
 
+        onWebContentOrientationChanged: orientationFader.waitForWebContentOrientationChanged = false
+
         function applyContentOrientation(orientation) {
+            orientationFader.waitForWebContentOrientationChanged = (contentItem && contentItem.active)
+
             switch (orientation) {
             case Orientation.None:
             case Orientation.Portrait:

--- a/src/pages/components/OrientationFader.qml
+++ b/src/pages/components/OrientationFader.qml
@@ -19,11 +19,12 @@ Rectangle {
     property alias page: propertyAction.target
     property alias fadeTarget: fadeOut.target
     readonly property alias running: transition.running
+    property bool waitForWebContentOrientationChanged
 
     signal applyContentOrientation
 
     anchors.fill: parent
-    opacity: running ? 1.0 : 0.0
+    opacity: running || waitForWebContentOrientationChanged ? 1.0 : 0.0
 
     Behavior on opacity {
         FadeAnimation {
@@ -65,17 +66,10 @@ Rectangle {
                 }
             }
 
-            SequentialAnimation {
-                PauseAnimation { duration: 350 }
-                FadeAnimation {
-                    target: fadeTarget
-                    to: 1
-                    duration: 200
-                }
-
-                // End-2-end implementation for OnUpdateDisplayPort should
-                // give better solution and reduce visible relayoutting.
-                PauseAnimation { duration: 350 }
+            FadeAnimation {
+                target: fadeTarget
+                to: 1
+                duration: 150
             }
 
             PropertyAction {

--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -21,6 +21,7 @@
 static const QString gFullScreenMessage("embed:fullscreenchanged");
 static const QString gDomContentLoadedMessage("embed:domcontentloaded");
 
+static const QString gContentOrientationChanged("embed:contentOrientationChanged");
 static const QString gLinkAddedMessage("chrome:linkadded");
 static const QString gAlertMessage("embed:alert");
 static const QString gConfirmMessage("embed:confirm");
@@ -86,6 +87,7 @@ DeclarativeWebPage::DeclarativeWebPage(QObject *parent)
     addMessageListener(gSelectionCopiedMessage);
     addMessageListener(gSelectAsyncMessage);
     addMessageListener(gFilePickerMessage);
+    addMessageListener(gContentOrientationChanged);
 
     loadFrameScript("chrome://embedlite/content/SelectAsyncHelper.js");
     loadFrameScript("chrome://embedlite/content/embedhelper.js");
@@ -412,6 +414,18 @@ void DeclarativeWebPage::onRecvAsyncMessage(const QString& message, const QVaria
     } else if (message == gDomContentLoadedMessage && data.toMap().value("rootFrame").toBool()) {
         m_domContentLoaded = true;
         emit domContentLoadedChanged();
+    }
+    else if (message == gContentOrientationChanged) {
+        QString orientation = data.toMap().value("orientation").toString();
+        Qt::ScreenOrientation mappedOrientation = Qt::PortraitOrientation;
+        if (orientation == QStringLiteral("landscape-primary")) {
+            mappedOrientation = Qt::LandscapeOrientation;
+        } else if (orientation == QStringLiteral("landscape-secondary")) {
+            mappedOrientation = Qt::InvertedLandscapeOrientation;
+        } else if (orientation == QStringLiteral("portrait-secondary")) {
+            mappedOrientation = Qt::InvertedPortraitOrientation;
+        }
+        contentOrientationChanged(mappedOrientation);
     }
 }
 

--- a/src/qtmozembed/declarativewebpage.h
+++ b/src/qtmozembed/declarativewebpage.h
@@ -70,6 +70,7 @@ public:
     Q_INVOKABLE void forceChrome(bool forcedChrome);
 
 signals:
+    void contentOrientationChanged(Qt::ScreenOrientation orientation);
     void containerChanged();
     void tabIdChanged();
     void userHasDraggedWhileLoadingChanged();


### PR DESCRIPTION
Embedlite-components reports now "embed:contentOrientationChanged"
message after content orientation has actually changed. This
commit takes that into use. Now orientation fader is opened immediately
when orientation change is effective.