### PR TITLE
[sailfish-browser] Mark tab as renderer also when dom content is loaded. Fixes JB#35310

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -151,7 +151,9 @@ void DeclarativeWebContainer::setWebPage(DeclarativeWebPage *webPage, bool trigg
 
             // Wait for one frame to be rendered and schedule update if tab is ready to render.
             connect(m_mozWindow.data(), SIGNAL(compositingFinished()), this, SLOT(updateActiveTabRendered()), Qt::UniqueConnection);
-            if (m_webPage->completed() && m_webPage->active()) {
+            connect(m_webPage, SIGNAL(domContentLoadedChanged()), this, SLOT(updateActiveTabRendered()), Qt::UniqueConnection);
+
+            if (m_webPage->completed() && m_webPage->active() && m_webPage->domContentLoaded()) {
                 m_webPage->update();
             }
         }
@@ -864,7 +866,7 @@ void DeclarativeWebContainer::updateLoading()
 
 void DeclarativeWebContainer::updateActiveTabRendered()
 {
-    if (m_webPage && !m_webPage->completed()) {
+    if (m_webPage && !m_webPage->completed() && !m_webPage->domContentLoaded()) {
         return;
     }
 

--- a/src/qtmozembed/declarativewebpage.h
+++ b/src/qtmozembed/declarativewebpage.h
@@ -31,6 +31,7 @@ class DeclarativeWebPage : public QOpenGLWebPage {
     Q_PROPERTY(bool userHasDraggedWhileLoading MEMBER m_userHasDraggedWhileLoading NOTIFY userHasDraggedWhileLoadingChanged FINAL)
     Q_PROPERTY(bool fullscreen READ fullscreen NOTIFY fullscreenChanged FINAL)
     Q_PROPERTY(bool forcedChrome READ forcedChrome NOTIFY forcedChromeChanged FINAL)
+    Q_PROPERTY(bool domContentLoaded READ domContentLoaded NOTIFY domContentLoadedChanged FINAL)
     Q_PROPERTY(QString favicon MEMBER m_favicon NOTIFY faviconChanged FINAL)
     Q_PROPERTY(QVariant resurrectedContentRect READ resurrectedContentRect WRITE setResurrectedContentRect NOTIFY resurrectedContentRectChanged)
 

--- a/tests/auto/mocks/declarativewebpage/declarativewebpage.h
+++ b/tests/auto/mocks/declarativewebpage/declarativewebpage.h
@@ -76,6 +76,7 @@ public:
     MOCK_METHOD1(setInitialTab, void(const Tab&));
 
     MOCK_METHOD1(forceChrome, void(bool));
+    MOCK_CONST_METHOD0(domContentLoaded, bool());
 
     MOCK_CONST_METHOD0(tabId, int());
 


### PR DESCRIPTION
Embedlite-components reports domContentLoaded, telling also
if it was root frame. In practice this means that from this
point onwards there is nothing blocking browser to render.

Some references:
https://developer.mozilla.org/en-US/docs/Web/Events/DOMContentLoaded
