### PR TITLE
Jb32815

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -1,11 +1,11 @@
 %global min_xulrunner_version 38.8.0.5
 %global min_qtmozembed_version 1.13.9
-%global min_embedlite_components_version 1.9.13
+%global min_embedlite_components_version 1.9.14
 
 Name:       sailfish-browser
 
 Summary:    Sailfish Browser
-Version:    1.14.20
+Version:    1.14.21
 Release:    1
 Group:      Applications/Internet
 License:    MPLv2

--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -30,7 +30,6 @@
 #include <math.h>
 #include "declarativewebutils.h"
 #include "qmozcontext.h"
-#include "opensearchconfigs.h"
 #include "browserpaths.h"
 
 static const QString gSystemComponentsTimeStamp("/var/lib/_MOZEMBED_CACHE_CLEAN_");
@@ -382,45 +381,12 @@ QString DeclarativeWebUtils::displayableUrl(QString fullUrl) const
 void DeclarativeWebUtils::handleObserve(const QString message, const QVariant data)
 {
     const QVariantMap dataMap = data.toMap();
-
     if (message == "clipboard:setdata") {
         QClipboard *clipboard = QGuiApplication::clipboard();
 
         // check if we copied password
         if (!dataMap.value("private").toBool()) {
             clipboard->setText(dataMap.value("data").toString());
-        }
-    } else if (message == "embed:search") {
-        QString msg = dataMap.value("msg").toString();
-
-        if (msg == "init") {
-            const StringMap configs(OpenSearchConfigs::getAvailableOpenSearchConfigs());
-            QStringList registeredSearches(dataMap.value("engines").toStringList());
-            QMozContext *mozContext = QMozContext::GetInstance();
-
-            // Add newly installed configs
-            foreach (QString searchName, configs.keys()) {
-
-                if (registeredSearches.contains(searchName)) {
-                    registeredSearches.removeAll(searchName);
-                } else {
-                    QVariantMap loadsearch;
-                    // load opensearch descriptions
-                    loadsearch.insert(QString("msg"), QVariant(QString("loadxml")));
-                    loadsearch.insert(QString("uri"), QVariant(QString("file://") + configs[searchName]));
-                    loadsearch.insert(QString("confirm"), QVariant(false));
-                    mozContext->sendObserve("embedui:search", QVariant(loadsearch));
-
-                }
-            }
-
-            // Remove uninstalled OpenSearch configs
-            foreach(QString searchName, registeredSearches) {
-                QVariantMap removeMsg;
-                removeMsg.insert(QString("msg"), QVariant(QString("remove")));
-                removeMsg.insert(QString("name"), QVariant(searchName));
-                mozContext->sendObserve("embedui:search", QVariant(removeMsg));
-            }
         }
     }
 }

--- a/src/core/settingmanager.cpp
+++ b/src/core/settingmanager.cpp
@@ -11,6 +11,7 @@
 
 #include "settingmanager.h"
 #include "dbmanager.h"
+#include "opensearchconfigs.h"
 
 #include <MGConfItem>
 #include <qmozcontext.h>
@@ -21,6 +22,8 @@ static SettingManager *gSingleton = 0;
 SettingManager::SettingManager(QObject *parent)
     : QObject(parent)
     , m_initialized(false)
+    , m_searchEnginesInitialized(false)
+    , m_addedSearchEngines(0)
 {
     m_clearHistoryConfItem = new MGConfItem("/apps/sailfish-browser/actions/clear_history", this);
     m_clearCookiesConfItem = new MGConfItem("/apps/sailfish-browser/actions/clear_cookies", this);
@@ -35,6 +38,8 @@ SettingManager::SettingManager(QObject *parent)
     m_toolbarLarge = new MGConfItem("/apps/sailfish-browser/settings/toolbar_large", this);
     connect(m_toolbarSmall, SIGNAL(valueChanged()), this, SIGNAL(toolbarSmallChanged()));
     connect(m_toolbarLarge, SIGNAL(valueChanged()), this, SIGNAL(toolbarLargeChanged()));
+    connect(QMozContext::GetInstance(), SIGNAL(recvObserve(QString, QVariant)),
+            this, SLOT(handleObserve(QString, QVariant)));
 }
 
 bool SettingManager::clearHistoryRequested() const
@@ -133,14 +138,92 @@ bool SettingManager::clearCache()
 
 void SettingManager::setSearchEngine()
 {
-    QVariant searchEngine = m_searchEngineConfItem->value(QVariant(QString("Google")));
-    QMozContext::GetInstance()->setPref(QString("browser.search.defaultenginename"), searchEngine);
+    if (m_searchEnginesInitialized) {
+        QVariant searchEngine = m_searchEngineConfItem->value(QVariant(QString("Google")));
+        QMozContext *context = QMozContext::GetInstance();
+        context->setPref(QString("browser.search.defaultenginename"), searchEngine);
+
+        // Let nsSearchService update the search engine (through EmbedLiteSearchEngine).
+        QVariantMap defaultSearchEngine;
+        defaultSearchEngine.insert(QLatin1String("msg"), QLatin1String("setdefault"));
+        defaultSearchEngine.insert(QLatin1String("name"), searchEngine);
+        context->sendObserve(QLatin1String("embedui:search"), QVariant(defaultSearchEngine));
+    }
 }
 
 void SettingManager::doNotTrack()
 {
     QMozContext::GetInstance()->setPref(QString("privacy.donottrackheader.enabled"),
                                         m_doNotTrackConfItem->value(false));
+}
+
+void SettingManager::handleObserve(const QString &message, const QVariant &data)
+{
+    const QVariantMap dataMap = data.toMap();
+    if (message == QLatin1String("embed:search")) {
+        QString msg = dataMap.value("msg").toString();
+        if (msg == QLatin1String("init")) {
+            const StringMap configs(OpenSearchConfigs::getAvailableOpenSearchConfigs());
+            const QStringList configuredEngines = configs.keys();
+            QStringList registeredSearches(dataMap.value(QLatin1String("engines")).toStringList());
+            QString defaultSearchEngine = dataMap.value(QLatin1String("defaultEngine")).toString();
+            m_searchEnginesInitialized = !registeredSearches.isEmpty();
+
+            // Upon first start, engine doesn't know about the search engines.
+            // Engine load requests are send within the for loop below.
+            if (!m_searchEnginesInitialized) {
+                m_addedSearchEngines = new QStringList(configuredEngines);
+            }
+
+            QMozContext *mozContext = QMozContext::GetInstance();
+
+            // Add newly installed configs
+            foreach (QString searchName, configuredEngines) {
+                if (registeredSearches.contains(searchName)) {
+                    registeredSearches.removeAll(searchName);
+                } else {
+                    QVariantMap loadsearch;
+                    // load opensearch descriptions
+                    loadsearch.insert(QLatin1String("msg"), QVariant(QLatin1String("loadxml")));
+                    loadsearch.insert(QLatin1String("uri"), QVariant(QString("file://%1").arg(configs[searchName])));
+                    loadsearch.insert(QLatin1String("confirm"), QVariant(false));
+                    mozContext->sendObserve(QLatin1String("embedui:search"), QVariant(loadsearch));
+                }
+            }
+
+            // Remove uninstalled OpenSearch configs
+            foreach(QString searchName, registeredSearches) {
+                QVariantMap removeMsg;
+                removeMsg.insert(QLatin1String("msg"), QVariant(QLatin1String("remove")));
+                removeMsg.insert(QLatin1String("name"), QVariant(searchName));
+                mozContext->sendObserve(QLatin1String("embedui:search"), QVariant(removeMsg));
+            }
+
+            // After first start we can update the default search engine immediately
+            // without
+            if (m_searchEnginesInitialized && defaultSearchEngine.isEmpty()) {
+                setSearchEngine();
+            }
+        } else if (msg == QLatin1String("search-engine-added")) {
+            // We're only interrested about the very first start. Then the m_addedSearchEngines
+            // contains engines.
+            int errorCode = dataMap.value(QLatin1String("errorCode")).toInt();
+            bool firstStart = m_addedSearchEngines && !m_addedSearchEngines->isEmpty();
+            if (errorCode != 0) {
+                qWarning() << "An error occurred while adding a search engine, error code: " << errorCode << ", see nsIBrowserSearchService for more details.";
+            } else if (m_addedSearchEngines) {
+                QString engine = dataMap.value(QLatin1String("engine")).toString();
+                m_addedSearchEngines->removeAll(engine);
+                m_searchEnginesInitialized = m_addedSearchEngines->isEmpty();
+                // All engines are added.
+                if (firstStart && m_searchEnginesInitialized) {
+                    setSearchEngine();
+                    delete m_addedSearchEngines;
+                    m_addedSearchEngines = 0;
+                }
+            }
+        }
+    }
 }
 
 void SettingManager::setAutostartPrivateBrowsing(bool privateMode)

--- a/src/core/settingmanager.h
+++ b/src/core/settingmanager.h
@@ -45,6 +45,7 @@ private slots:
     bool clearCache();
     void setSearchEngine();
     void doNotTrack();
+    void handleObserve(const QString &message, const QVariant &data);
 
 private:
     explicit SettingManager(QObject *parent = 0);
@@ -61,6 +62,9 @@ private:
     MGConfItem *m_toolbarLarge;
 
     bool m_initialized;
+    bool m_searchEnginesInitialized;
+
+    QStringList *m_addedSearchEngines;
 };
 
 #endif

--- a/tests/auto/mocks/declarativewebpage/declarativewebpage.h
+++ b/tests/auto/mocks/declarativewebpage/declarativewebpage.h
@@ -103,6 +103,7 @@ signals:
     void loadProgressChanged();
     void requestGLContext();
 
+    void contentOrientationChanged(Qt::ScreenOrientation orientation);
     void containerChanged();
     void tabIdChanged();
     void urlChanged();

--- a/tests/auto/mocks/opensearchconfigs/opensearchconfigs.cpp
+++ b/tests/auto/mocks/opensearchconfigs/opensearchconfigs.cpp
@@ -1,0 +1,22 @@
+/****************************************************************************
+**
+** Copyright (C) 2016
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "opensearchconfigs.h"
+
+const StringMap OpenSearchConfigs::getAvailableOpenSearchConfigs()
+{
+    return StringMap();
+}
+
+const QStringList OpenSearchConfigs::getSearchEngineList()
+{
+    return QStringList();
+}

--- a/tests/auto/mocks/opensearchconfigs/opensearchconfigs.h
+++ b/tests/auto/mocks/opensearchconfigs/opensearchconfigs.h
@@ -1,0 +1,25 @@
+/****************************************************************************
+**
+** Copyright (C) 2016
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QStringList>
+#include <QMap>
+
+typedef QMap<QString, QString> StringMap;
+
+class OpenSearchConfigs : public QObject {
+
+public:
+    static const StringMap getAvailableOpenSearchConfigs();
+    static const QStringList getSearchEngineList();
+
+private:
+    OpenSearchConfigs(QObject* parent=0);
+};

--- a/tests/auto/mocks/opensearchconfigs/opensearchconfigs_mock.pri
+++ b/tests/auto/mocks/opensearchconfigs/opensearchconfigs_mock.pri
@@ -1,0 +1,8 @@
+# Mock interface for OpenSearchConfig. Interface is not complete.
+# Currently it includes only methods needed at runtime.
+# This pri is included indirectly from unit tests cases that
+# are at the same level in the file hierarchy.
+SOURCES += $$PWD/opensearchconfigs.cpp
+HEADERS += $$PWD/opensearchconfigs.h
+
+INCLUDEPATH += $$PWD

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.cpp
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.cpp
@@ -129,6 +129,8 @@ void tst_declarativewebcontainer::setTabModel()
 
     QSignalSpy countChangeSpy(&model, SIGNAL(countChanged()));
 
+    bool wasInitialized = m_webContainer->m_initialized;
+    m_webContainer->m_initialized = true;
     // Setting model1
     m_webContainer->setTabModel(&model);
     QCOMPARE(m_webContainer->m_model.data(), &model);
@@ -139,6 +141,7 @@ void tst_declarativewebcontainer::setTabModel()
     m_webContainer->setTabModel(0);
     QCOMPARE(!!m_webContainer->m_model.data(), false);
     QCOMPARE(model.waitingForNewTab(), false);
+    m_webContainer->m_initialized = wasInitialized;
 }
 
 void tst_declarativewebcontainer::setForeground()

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
@@ -14,6 +14,7 @@ include(../mocks/webpagefactory/webpagefactory.pri)
 include(../mocks/declarativewebpage/declarativewebpage_mock.pri)
 include(../mocks/declarativewebutils/declarativewebutils_mock.pri)
 include(../mocks/downloadmanager/downloadmanager_mock.pri)
+include(../mocks/opensearchconfigs/opensearchconfigs_mock.pri)
 
 include(../test_common.pri)
 include(../../../common/paths.pri)

--- a/tests/auto/tst_webpages/tst_webpages.pro
+++ b/tests/auto/tst_webpages/tst_webpages.pro
@@ -14,6 +14,7 @@ include(../mocks/webpagefactory/webpagefactory.pri)
 include(../mocks/declarativewebpage/declarativewebpage_mock.pri)
 include(../mocks/declarativewebutils/declarativewebutils_mock.pri)
 include(../mocks/downloadmanager/downloadmanager_mock.pri)
+include(../mocks/opensearchconfigs/opensearchconfigs_mock.pri)
 
 include(../test_common.pri)
 include(../../../common/paths.pri)

--- a/tests/auto/tst_webutils/tst_webutils.cpp
+++ b/tests/auto/tst_webutils/tst_webutils.cpp
@@ -129,7 +129,7 @@ void tst_webutils::uniquePictureName()
 
     // actual test
     DeclarativeWebUtils *webUtils = DeclarativeWebUtils::instance();
-    QCOMPARE(webUtils->createUniqueFileUrl(fileName, targetPath), "file://" + targetPath + "/" + expectedName);
+    QCOMPARE(webUtils->createUniqueFileUrl(fileName, targetPath), targetPath + "/" + expectedName);
 
     // tear down
     // set up test case

--- a/tests/auto/tst_webview/ResourceControllerMock.qml
+++ b/tests/auto/tst_webview/ResourceControllerMock.qml
@@ -12,7 +12,7 @@
 import QtQuick 2.1
 
 QtObject {
-    property QtObject webView
+    property QtObject webPage
     property bool videoActive
     property bool audioActive
     property bool background

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -667,6 +667,11 @@ void tst_webview::restart()
     tabModel->deleteLater();
     QTest::waitForEvents();
 
+    // Fake closing the window.
+    QEvent closeEvent(QEvent::Close);
+    qGuiApp->sendEvent(webContainer, &closeEvent);
+    QTest::waitForEvents();
+
     delete historyModel;
     historyModel = 0;
     delete webContainer;

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -9,6 +9,7 @@ QT += quick concurrent sql gui-private
 include(../test_common.pri)
 include(../mocks/downloadmanager/downloadmanager_mock.pri)
 include(../mocks/declarativewebutils/declarativewebutils_mock.pri)
+include(../mocks/opensearchconfigs/opensearchconfigs_mock.pri)
 include(../common/testobject.pri)
 include(../../../src/core/core.pri)
 include(../../../src/qtmozembed/qtmozembed.pri)


### PR DESCRIPTION
When browser is launched for the first time, the browser engine does not
know about the search engines. Once the browser engine is ready,
we request the engine to load the default configured search engines.

This commit changes browser initialization to listen "search-engine-added"
message. Once all initially configured engines are added, the default
search engine is set.

Browser does not handle yet a case where all search engines would
be changed on the fly but that is another issue.

See also:
https://git.merproject.org/mer-core/embedlite-components/merge_requests/16

As I touched unit tests, fixed them to pass as well.