### PR TITLE
[sailfish-browser] Remove default search engine guard. Fixes JB#32815

### DIFF
--- a/src/core/settingmanager.cpp
+++ b/src/core/settingmanager.cpp
@@ -199,11 +199,9 @@ void SettingManager::handleObserve(const QString &message, const QVariant &data)
                 mozContext->sendObserve(QLatin1String("embedui:search"), QVariant(removeMsg));
             }
 
-            // After first start we can update the default search engine immediately
-            // without
-            if (m_searchEnginesInitialized && defaultSearchEngine.isEmpty()) {
-                setSearchEngine();
-            }
+            // Try to set search engine. After first start we can update the default search
+            // engine immediately.
+            setSearchEngine();
         } else if (msg == QLatin1String("search-engine-added")) {
             // We're only interrested about the very first start. Then the m_addedSearchEngines
             // contains engines.


### PR DESCRIPTION
It's enough to check that search engines has been initialized.

@pvuorela / @jpetrell quick one to review ?