### PR TITLE
[sailfish-browser] Open orientation fader aften pending orientation is effective orientation. Fixes JB#35447

### DIFF
--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -73,6 +73,8 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     Q_PROPERTY(QObject *chromeWindow READ chromeWindow WRITE setChromeWindow NOTIFY chromeWindowChanged FINAL)
     Q_PROPERTY(bool readyToPaint READ readyToPaint WRITE setReadyToPaint NOTIFY readyToPaintChanged FINAL)
 
+    Q_PROPERTY(Qt::ScreenOrientation pendingWebContentOrientation READ pendingWebContentOrientation NOTIFY pendingWebContentOrientationChanged FINAL)
+
 public:
     DeclarativeWebContainer(QWindow *parent = 0);
     ~DeclarativeWebContainer();
@@ -116,6 +118,8 @@ public:
 
     bool readyToPaint() const;
     void setReadyToPaint(bool ready);
+
+    Qt::ScreenOrientation pendingWebContentOrientation() const;
 
     int tabId() const;
     QString title() const;
@@ -175,6 +179,7 @@ signals:
     void chromeExposed();
     void readyToPaintChanged();
 
+    void pendingWebContentOrientationChanged();
     void webContentOrientationChanged(Qt::ScreenOrientation orientation);
 
 protected:
@@ -211,6 +216,8 @@ private slots:
     // QMozWindow related slots:
     void createGLContext();
     void drawUnderlay();
+
+    void handleContentOrientationChanged(Qt::ScreenOrientation orientation);
 
 private:
     void setWebPage(DeclarativeWebPage *webPage, bool triggerSignals = false);

--- a/tests/auto/mocks/qmozwindow/qmozwindow.h
+++ b/tests/auto/mocks/qmozwindow/qmozwindow.h
@@ -34,6 +34,7 @@ public:
     MOCK_METHOD0(size, QSize(void));
     MOCK_METHOD1(setContentOrientation, void(Qt::ScreenOrientation));
     MOCK_METHOD0(contentOrientation, Qt::ScreenOrientation());
+    MOCK_METHOD0(pendingOrientation, Qt::ScreenOrientation());
     MOCK_METHOD2(getPlatformImage, void(int*, int*));
     MOCK_METHOD0(suspendRendering, void(void));
     MOCK_METHOD0(resumeRendering, void(void));
@@ -42,6 +43,8 @@ public:
     MOCK_METHOD1(setReadyToPaint, bool(bool));
 
 signals:
+    void pendingOrientationChanged(Qt::ScreenOrientation orientation);
+    void orientationChangeFiltered(Qt::ScreenOrientation orientation);
     void requestGLContext();
     void initialized();
     void drawOverlay(QRect);


### PR DESCRIPTION
See also:
https://git.merproject.org/mer-core/embedlite-components/merge_requests/17
https://git.merproject.org/mer-core/qtmozembed/merge_requests/9

