### PR TITLE
Jb35379

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -707,6 +707,11 @@ void DeclarativeWebContainer::updateContentOrientation(Qt::ScreenOrientation ori
     reportContentOrientationChange(orientation);
 }
 
+void DeclarativeWebContainer::clearSurface()
+{
+    postClearWindowSurfaceTask();
+}
+
 qreal DeclarativeWebContainer::contentHeight() const
 {
     if (m_webPage) {

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -744,6 +744,7 @@ void DeclarativeWebContainer::initialize()
                 this, &DeclarativeWebContainer::drawUnderlay, Qt::DirectConnection);
         connect(m_mozWindow.data(), &QMozWindow::orientationChangeFiltered,
                 this, &DeclarativeWebContainer::handleContentOrientationChanged);
+        m_mozWindow->setReadyToPaint(false);
         if (m_chromeWindow) {
             updateContentOrientation(m_chromeWindow->contentOrientation());
         }
@@ -966,14 +967,10 @@ void DeclarativeWebContainer::drawUnderlay()
 {
     Q_ASSERT(m_context);
 
-    if (!m_webPage) {
-       return;
-    }
-
+    QColor bgColor = m_webPage ? m_webPage->bgcolor() : QColor(Qt::white);
     m_context->makeCurrent(this);
     QOpenGLFunctions_ES2* funcs = m_context->versionFunctions<QOpenGLFunctions_ES2>();
     if (funcs) {
-        QColor bgColor = m_webPage->bgcolor();
         funcs->glClearColor(bgColor.redF(), bgColor.greenF(), bgColor.blueF(), 0.0);
         funcs->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     }

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -136,8 +136,6 @@ public:
     Q_INVOKABLE void goBack();
 
     Q_INVOKABLE void updatePageFocus(bool focus);
-    Q_INVOKABLE void clearSurface() {  postClearWindowSurfaceTask(); }
-
     Q_INVOKABLE void dumpPages() const;
 
     QObject *focusObject() const;
@@ -198,6 +196,7 @@ protected:
 
 public slots:
     void updateContentOrientation(Qt::ScreenOrientation orientation);
+    void clearSurface();
 
 private slots:
     void initialize();

--- a/src/core/webpages.cpp
+++ b/src/core/webpages.cpp
@@ -50,6 +50,7 @@ WebPages::WebPages(WebPageFactory *pageFactory, QObject *parent)
     , m_backgroundTimestamp(0)
     , m_memoryLevel(MemNormal)
 {
+    Q_ASSERT_X(m_pageFactory, Q_FUNC_INFO, "WebPages initialized with invalid WebPageFactory.");
     if (gLowMemoryEnabled) {
         QDBusConnection systemBus = QDBusConnection::systemBus();
         systemBus.connect("com.nokia.mce", "/com/nokia/mce/signal",
@@ -76,9 +77,11 @@ void WebPages::initialize(DeclarativeWebContainer *webContainer)
 {
     if (!m_webContainer) {
         m_webContainer = webContainer;
-    }
+        Q_ASSERT_X(m_webContainer, Q_FUNC_INFO, "DeclarativeWebContainer is null");
 
-    connect(webContainer, SIGNAL(foregroundChanged()), this, SLOT(updateBackgroundTimestamp()));
+        connect(webContainer, SIGNAL(foregroundChanged()), this, SLOT(updateBackgroundTimestamp()));
+        connect(m_pageFactory, SIGNAL(aboutToInitialize(DeclarativeWebPage*)), m_webContainer, SLOT(clearSurface()));
+    }
 }
 
 void WebPages::updateBackgroundTimestamp()

--- a/src/factories/webpagefactory.cpp
+++ b/src/factories/webpagefactory.cpp
@@ -43,6 +43,7 @@ DeclarativeWebPage* WebPageFactory::createWebPage(DeclarativeWebContainer *webCo
             webPage->setPrivateMode(webContainer->privateMode());
             webPage->setInitialTab(initialTab);
             webPage->setContainer(webContainer);
+            emit aboutToInitialize(webPage);
             webPage->initialize();
             m_qmlComponent->completeCreate();
 #if DEBUG_LOGS

--- a/src/factories/webpagefactory.h
+++ b/src/factories/webpagefactory.h
@@ -29,6 +29,10 @@ public:
     DeclarativeWebPage* createWebPage(DeclarativeWebContainer *webContainer,
                                       const Tab &initialTab,
                                       int parentId);
+
+signals:
+    void aboutToInitialize(DeclarativeWebPage *webPage);
+
 public slots:
     void updateQmlComponent(QQmlComponent *newComponent);
 

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -75,7 +75,7 @@ WebContainer {
     }
 
     foreground: Qt.application.active
-    readyToPaint: resourceController.videoActive ? webView.visible && !resourceController.displayOff : webView.visible
+    readyToPaint: resourceController.videoActive ? webView.visible && !resourceController.displayOff : webView.visible && webView.contentItem && webView.contentItem.domContentLoaded
     allowHiding: !resourceController.videoActive && !resourceController.audioActive
     fullscreenMode: (contentItem && contentItem.chromeGestureEnabled && !contentItem.chrome) ||
                     (contentItem && contentItem.fullscreen)

--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -19,7 +19,7 @@
 #include <QtConcurrent>
 
 static const QString gFullScreenMessage("embed:fullscreenchanged");
-static const QString gDomContentLoadedMessage("embed:domcontentloaded");
+static const QString gDomContentLoadedMessage("chrome:contentloaded");
 
 static const QString gContentOrientationChanged("embed:contentOrientationChanged");
 static const QString gLinkAddedMessage("chrome:linkadded");
@@ -411,9 +411,11 @@ void DeclarativeWebPage::onRecvAsyncMessage(const QString& message, const QVaria
 {
     if (message == gFullScreenMessage) {
         setFullscreen(data.toMap().value(QString("fullscreen")).toBool());
-    } else if (message == gDomContentLoadedMessage && data.toMap().value("rootFrame").toBool()) {
-        m_domContentLoaded = true;
-        emit domContentLoadedChanged();
+    } else if (message == gDomContentLoadedMessage) {
+        if (!m_domContentLoaded) {
+            m_domContentLoaded = true;
+            emit domContentLoadedChanged();
+        }
     }
     else if (message == gContentOrientationChanged) {
         QString orientation = data.toMap().value("orientation").toString();


### PR DESCRIPTION
Contains three commits:

- Switch to use listen "chrome:contentloaded" messages (same as domcontentloaded)

- Clean surface when we're about to initialize a new page

- Do not allow compitor to render before content is loaded.