### PR TITLE
[sailfish-browser] Mark contet loaded when page is loaded. Contributes to JB#35681

### DIFF
--- a/src/qtmozembed/declarativewebpage.h
+++ b/src/qtmozembed/declarativewebpage.h
@@ -104,6 +104,7 @@ private slots:
 private:
     QString saveToFile(QImage image);
     void restoreHistory();
+    void setContentLoaded();
 
     QPointer<DeclarativeWebContainer> m_container;
     // Tab data fetched upon web page initialization. It never changes afterwards.


### PR DESCRIPTION
For instance when loading images directly to a new tab, chrome does
not get domContentLoaded message from the engine.