### PR TITLE
[sailfish-browser] Do not wait for new tab when active tab is changed. Fixes JB#35786

### DIFF
--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -350,8 +350,6 @@ void DeclarativeTabModel::updateActiveTab(const Tab &activeTab, bool loadActiveT
         int oldTabId = m_activeTabId;
         m_activeTabId = activeTab.tabId();
 
-        setWaitingForNewTab(true);
-
         // If tab has changed, update active tab role.
         int tabIndex = activeTabIndex();
         if (tabIndex >= 0) {


### PR DESCRIPTION
When we are about to create a new tab we wait for new tab. However,
when tab is switched or new tab is created it is not needed to
wait for new tab.

This caused a glitch that occasionally that loaded website
was still on the waiting mode (blank view) even thou it was
already loaded.