### PR TITLE
[sailfish-browser] Activate tab loading when overlay is dismissed. Fixes JB#35991

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -230,11 +230,7 @@ Page {
         MouseArea {
             anchors.fill: parent
             enabled: overlay.animator.atTop && webView.tabModel.count > 0
-            onClicked: {
-                overlay.dismiss(true)
-                // trigger overlay.onActiveChanged() handler to activate a web page in case it's inactive
-                overlay.activeChanged()
-            }
+            onClicked: overlay.dismiss(true)
         }
 
         Browser.PrivateModeTexture {

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -77,6 +77,15 @@ Background {
             overlay.animator.hide()
         }
         searchField.enteringNewTabUrl = false
+        loadActiveTab()
+    }
+
+    function loadActiveTab() {
+        // Activate tab if we don't have content item but we have a valid tab id.
+        if (active && !webView.contentItem && !searchField.enteringNewTabUrl && webView.tabId > 0) {
+            // Don't force reloading tab change if already loaded.
+            webView.reload(false)
+        }
     }
 
     y: webView.fullscreenHeight - toolBar.toolsHeight
@@ -92,12 +101,7 @@ Background {
     // `visible` is controlled by Browser.OverlayAnimator
     enabled: visible
 
-    onActiveChanged: {
-        if (active && !webView.contentItem && !searchField.enteringNewTabUrl && webView.tabId > 0) {
-            // Don't force reloading tab change if already loaded.
-            webView.reload(false)
-        }
-    }
+    onActiveChanged: loadActiveTab()
 
     // This is an invisible object responsible to hide/show Overlay in an animated way
     Browser.OverlayAnimator {


### PR DESCRIPTION
If active tab was closed from tabs view, new tab was triggered from
tab view, and cancelled from overlay by dragging the overlay, the active
tab id was not activated. The error did not occur, if overlay was
cancelled by clicking the mouse area above the overlay. This fixes
the error by activating tab always when overlay is dismissed.