### PR TITLE
Soft load new active tab when a tab is removed

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -192,8 +192,8 @@ void DeclarativeWebContainer::setTabModel(DeclarativeTabModel *model)
         m_model = model;
         int newCount = 0;
         if (m_model) {
-            connect(m_model, SIGNAL(activeTabChanged(int,bool)), this, SLOT(onActiveTabChanged(int,bool)));
-            connect(m_model, SIGNAL(activeTabChanged(int,bool)), this, SIGNAL(tabIdChanged()));
+            connect(m_model, SIGNAL(activeTabChanged(int)), this, SLOT(onActiveTabChanged(int)));
+            connect(m_model, SIGNAL(activeTabChanged(int)), this, SIGNAL(tabIdChanged()));
             connect(m_model, SIGNAL(loadedChanged()), this, SLOT(initialize()));
             connect(m_model, SIGNAL(tabClosed(int)), this, SLOT(releasePage(int)));
             connect(m_model, SIGNAL(newTabRequested(QString,QString,int)), this, SLOT(onNewTabRequested(QString,QString,int)));
@@ -721,13 +721,9 @@ qreal DeclarativeWebContainer::contentHeight() const
     }
 }
 
-void DeclarativeWebContainer::onActiveTabChanged(int activeTabId, bool loadActiveTab)
+void DeclarativeWebContainer::onActiveTabChanged(int activeTabId)
 {
     if (activeTabId <= 0) {
-        return;
-    }
-
-    if (!loadActiveTab) {
         return;
     }
 

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -200,7 +200,7 @@ public slots:
 
 private slots:
     void initialize();
-    void onActiveTabChanged(int activeTabId, bool loadActiveTab);
+    void onActiveTabChanged(int activeTabId);
     void onDownloadStarted();
     void onNewTabRequested(QString url, QString title, int parentId);
     void releasePage(int tabId);

--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -68,7 +68,7 @@ void DeclarativeTabModel::addTab(const QString& url, const QString &title, int i
     // We should trigger this only when
     // tab is added through new window request. In all other
     // case we should keep the new tab in background.
-    updateActiveTab(tab, true);
+    updateActiveTab(tab);
 
     emit countChanged();
     emit tabAdded(tab.tabId());
@@ -91,7 +91,7 @@ void DeclarativeTabModel::remove(int index) {
 
         removeTab(m_tabs.at(index).tabId(), m_tabs.at(index).thumbnailPath(), index);
         if (removingActiveTab) {
-            activateTab(newActiveIndex, true);
+            activateTab(newActiveIndex);
         }
     }
 }
@@ -131,7 +131,7 @@ bool DeclarativeTabModel::activateTab(const QString& url)
     return false;
 }
 
-void DeclarativeTabModel::activateTab(int index, bool loadActiveTab)
+void DeclarativeTabModel::activateTab(int index)
 {
     if (m_tabs.isEmpty()) {
         return;
@@ -142,7 +142,7 @@ void DeclarativeTabModel::activateTab(int index, bool loadActiveTab)
 #if DEBUG_LOGS
     qDebug() << "activate tab: " << index << &newActiveTab;
 #endif
-    updateActiveTab(newActiveTab, loadActiveTab);
+    updateActiveTab(newActiveTab);
 }
 
 bool DeclarativeTabModel::activateTabById(int tabId)
@@ -167,7 +167,7 @@ void DeclarativeTabModel::closeActiveTab()
         int index = activeTabIndex();
         int newActiveIndex = nextActiveTabIndex(index);
         removeTab(m_activeTabId, m_tabs.at(index).thumbnailPath(), index);
-        activateTab(newActiveIndex, true);
+        activateTab(newActiveIndex);
     }
 }
 
@@ -337,7 +337,7 @@ int DeclarativeTabModel::findTabIndex(int tabId) const
     return -1;
 }
 
-void DeclarativeTabModel::updateActiveTab(const Tab &activeTab, bool loadActiveTab)
+void DeclarativeTabModel::updateActiveTab(const Tab &activeTab)
 {
 #if DEBUG_LOGS
     qDebug() << "new active tab:" << &activeTab << "old active tab:" << m_activeTabId << "count:" << m_tabs.count();
@@ -367,7 +367,7 @@ void DeclarativeTabModel::updateActiveTab(const Tab &activeTab, bool loadActiveT
         // Instead, we pass current contentItem and activeTabIndex
         // when pushing the TabPage to the PageStack. This is the signal changes the
         // contentItem of WebView.
-        emit activeTabChanged(activeTab.tabId(), loadActiveTab);
+        emit activeTabChanged(activeTab.tabId());
     }
 }
 

--- a/src/history/declarativetabmodel.cpp
+++ b/src/history/declarativetabmodel.cpp
@@ -91,7 +91,7 @@ void DeclarativeTabModel::remove(int index) {
 
         removeTab(m_tabs.at(index).tabId(), m_tabs.at(index).thumbnailPath(), index);
         if (removingActiveTab) {
-            activateTab(newActiveIndex, false);
+            activateTab(newActiveIndex, true);
         }
     }
 }

--- a/src/history/declarativetabmodel.h
+++ b/src/history/declarativetabmodel.h
@@ -45,7 +45,7 @@ public:
     Q_INVOKABLE void remove(int index);
     Q_INVOKABLE void clear();
     Q_INVOKABLE bool activateTab(const QString &url);
-    Q_INVOKABLE void activateTab(int index, bool loadActiveTab = true);
+    Q_INVOKABLE void activateTab(int index);
     Q_INVOKABLE void closeActiveTab();
     Q_INVOKABLE void newTab(const QString &url, const QString &title, int parentId = 0);
     Q_INVOKABLE QString url(int tabId) const;
@@ -84,9 +84,7 @@ public slots:
 signals:
     void activeTabIndexChanged();
     void countChanged();
-    void activeTabChanged(int activeTabId, bool loadActiveTab = true);
-    // TODO: Update test to use activeTabChanged instead. Currently this is here
-    // only for testing purposes.
+    void activeTabChanged(int activeTabId);
     void tabAdded(int tabId);
     void tabClosed(int tabId);
     void loadedChanged();
@@ -97,7 +95,7 @@ protected:
     void addTab(const QString &url, const QString &title, int index);
     void removeTab(int tabId, const QString &thumbnail, int index);
     int findTabIndex(int tabId) const;
-    void updateActiveTab(const Tab &activeTab, bool loadActiveTab);
+    void updateActiveTab(const Tab &activeTab);
     void updateUrl(int tabId, const QString &url, bool initialLoad);
 
     virtual void createTab(const Tab &tab) = 0;

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -77,15 +77,6 @@ Background {
             overlay.animator.hide()
         }
         searchField.enteringNewTabUrl = false
-        loadActiveTab()
-    }
-
-    function loadActiveTab() {
-        // Activate tab if we don't have content item but we have a valid tab id.
-        if (active && !webView.contentItem && !searchField.enteringNewTabUrl && webView.tabId > 0) {
-            // Don't force reloading tab change if already loaded.
-            webView.reload(false)
-        }
     }
 
     y: webView.fullscreenHeight - toolBar.toolsHeight
@@ -100,8 +91,6 @@ Background {
     height: historyContainer.height + virtualKeyboardObserver.panelSize
     // `visible` is controlled by Browser.OverlayAnimator
     enabled: visible
-
-    onActiveChanged: loadActiveTab()
 
     // This is an invisible object responsible to hide/show Overlay in an animated way
     Browser.OverlayAnimator {

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -139,7 +139,7 @@ void tst_persistenttabmodel::addTab()
     QSignalSpy tabAddedSpy(tabModel, SIGNAL(tabAdded(int)));
     QSignalSpy dataChangedSpy(tabModel, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)));
     QSignalSpy activeTabIndexChangedSpy(tabModel, SIGNAL(activeTabIndexChanged()));
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
 
     // actual test
     tabModel->addTab(tabToAdd.url, tabToAdd.title, insertToIndex);
@@ -155,7 +155,6 @@ void tst_persistenttabmodel::addTab()
     QCOMPARE(activeTabChangedSpy.count(), 1);
     arguments = activeTabChangedSpy.at(0);
     QCOMPARE(arguments.at(0).toInt(), initialTabs.count() + 1);
-    QCOMPARE(arguments.at(1).toBool(), true);
 
     QCOMPARE(tabModel->activeTab().url(), tabToAdd.url);
     QCOMPARE(tabModel->activeTab().title(), tabToAdd.title);
@@ -197,7 +196,7 @@ void tst_persistenttabmodel::addTabInvalidInput_data()
 void tst_persistenttabmodel::addTabInvalidInput()
 {
     QSignalSpy countChangeSpy(tabModel, SIGNAL(countChanged()));
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
 
     QFETCH(QString, url);
     QFETCH(QString, title);
@@ -215,7 +214,7 @@ void tst_persistenttabmodel::remove()
     QSignalSpy tabClosedSpy(tabModel, SIGNAL(tabClosed(int)));
     QSignalSpy dataChangedSpy(tabModel, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)));
     QSignalSpy activeTabIndexChangedSpy(tabModel, SIGNAL(activeTabIndexChanged()));
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
 
     // nothing should happen
     tabModel->remove(-1);
@@ -276,7 +275,7 @@ void tst_persistenttabmodel::removeTabById()
     QFETCH(bool, isValid);
 
     QSignalSpy tabClosedSpy(tabModel, SIGNAL(tabClosed(int)));
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
 
     tabModel->removeTabById(tabId, activeTab);
 
@@ -325,7 +324,7 @@ void tst_persistenttabmodel::activateTabByUrl()
     QFETCH(QString, expectedUrl);
     QFETCH(QString, expectedTitle);
 
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
 
     tabModel->activateTab(url);
 
@@ -359,7 +358,7 @@ void tst_persistenttabmodel::activateTabById()
     QFETCH(QString, expectedUrl);
     QFETCH(QString, expectedTitle);
 
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
 
     tabModel->activateTabById(tabId);
 
@@ -393,7 +392,7 @@ void tst_persistenttabmodel::activateTabByIndex()
     QFETCH(QString, expectedUrl);
     QFETCH(QString, expectedTitle);
 
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
 
     tabModel->activateTab(tabIndex);
 
@@ -409,7 +408,7 @@ void tst_persistenttabmodel::closeActiveTab()
     // make the first tab active
     tabModel->activateTabById(1);
 
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
     QSignalSpy tabCountChangedSpy(tabModel, SIGNAL(countChanged()));
     QSignalSpy activeTabIndexChangedSpy(tabModel, SIGNAL(activeTabIndexChanged()));
 

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -154,7 +154,7 @@ void tst_webview::testNewTab()
     QSignalSpy titleChangedSpy(webContainer, SIGNAL(titleChanged()));
 
     QSignalSpy tabCountSpy(tabModel, SIGNAL(countChanged()));
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
     QSignalSpy tabAddedSpy(tabModel, SIGNAL(tabAdded(int)));
     QSignalSpy contentItemSpy(webContainer, SIGNAL(contentItemChanged()));
     QSignalSpy loadingChanged(webContainer, SIGNAL(loadingChanged()));
@@ -242,7 +242,7 @@ void tst_webview::testActivateTab()
     QString newActiveTitle = tabModel->data(modelIndex, DeclarativeTabModel::TitleRole).toString();
     int newActiveTabId = tabModel->data(modelIndex, DeclarativeTabModel::TabIdRole).toInt();
 
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
     QSignalSpy urlChangedSpy(webContainer, SIGNAL(urlChanged()));
     QSignalSpy titleChangedSpy(webContainer, SIGNAL(titleChanged()));
     QSignalSpy contentItemSpy(webContainer, SIGNAL(contentItemChanged()));
@@ -279,7 +279,7 @@ void tst_webview::testCloseActiveTab()
     // "testuseragent.html", "TestUserAgent" (2)
     // "testnavigation.html", "TestNavigation" (3)
 
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
     QSignalSpy tabClosedSpy(tabModel, SIGNAL(tabClosed(int)));
     QSignalSpy urlChangedSpy(webContainer, SIGNAL(urlChanged()));
     QSignalSpy titleChangedSpy(webContainer, SIGNAL(titleChanged()));
@@ -337,7 +337,7 @@ void tst_webview::testRemoveTab()
     // "testuseragent.html", "TestUserAgent" (1)
     // "testnavigation.html", "TestNavigation" (2)
 
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
     QSignalSpy tabClosedSpy(tabModel, SIGNAL(tabClosed(int)));
 
     QSignalSpy urlChangedSpy(webContainer, SIGNAL(urlChanged()));
@@ -431,7 +431,7 @@ void tst_webview::testLiveTabCount()
     QFETCH(int, liveTabCount);
 
     QSignalSpy tabCountSpy(tabModel, SIGNAL(countChanged()));
-    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int,bool)));
+    QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
     QSignalSpy tabAddedSpy(tabModel, SIGNAL(tabAdded(int)));
     QSignalSpy loadingChanged(webContainer, SIGNAL(loadingChanged()));
     QSignalSpy urlChangedSpy(webContainer, SIGNAL(urlChanged()));


### PR DESCRIPTION
@pvuorela could you review.

There are two commits.

1) Contains actual fix
2) Cleans up code that became deadcode after the fix

See also: https://github.com/sailfishos/sailfish-browser/issues/506