### PR TITLE
[sailfish-browser] Fix browser profile path. Fixes JB#36500

### DIFF
--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -41,9 +41,7 @@ Browser::Browser(QQuickView *view, QObject *parent)
     Q_ASSERT(view);
     Q_ASSERT(qGuiApp);
 
-    QString homePath = QDir::homePath();
-
-    SailfishOS::WebEngine::initialize(homePath + "/.mozilla/mozembed/");
+    SailfishOS::WebEngine::initialize("mozembed");
     SailfishOS::WebEngine *webEngine = SailfishOS::WebEngine::instance();
     SailfishOS::WebEngineSettings::initialize();
 


### PR DESCRIPTION
We accidentally changed profile path when updating browser
to use common WebEngine. Thus, previously saved passwords,
caches, preferences got lost.