### PR TITLE
[sailfish-browser] Cleanup deprecated mozcontext calls. Fixes JB#36499

### DIFF
--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -32,7 +32,6 @@
 
 #include <math.h>
 #include "declarativewebutils.h"
-#include "qmozcontext.h"
 #include "browserpaths.h"
 
 static const QString gSystemComponentsTimeStamp("/var/lib/_MOZEMBED_CACHE_CLEAN_");

--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -51,7 +51,7 @@ DeclarativeWebUtils::DeclarativeWebUtils()
     , m_homePage("/apps/sailfish-browser/settings/home_page", this)
 {
     updateWebEngineSettings();
-    connect(QMozContext::instance(), SIGNAL(recvObserve(QString, QVariant)),
+    connect(SailfishOS::WebEngine::instance(), SIGNAL(recvObserve(QString, QVariant)),
             this, SLOT(handleObserve(QString, QVariant)));
 
     QString path = BrowserPaths::dataLocation() + QStringLiteral("/.firstUseDone");
@@ -176,9 +176,9 @@ void DeclarativeWebUtils::setFirstUseDone(bool firstUseDone) {
 
 qreal DeclarativeWebUtils::cssPixelRatio() const
 {
-    QMozContext* mozContext = QMozContext::instance();
-    if (mozContext) {
-        return mozContext->pixelRatio();
+    SailfishOS::WebEngineSettings *webEngineSettings = SailfishOS::WebEngineSettings::instance();
+    if (webEngineSettings) {
+        return webEngineSettings->pixelRatio();
     }
     return 1.0;
 }

--- a/src/browser/downloadmanager.cpp
+++ b/src/browser/downloadmanager.cpp
@@ -20,6 +20,8 @@
 #include <QFile>
 #include <QDebug>
 
+#include <webenginesettings.h>
+
 #if defined(arm) \
     || defined(__arm__) \
     || defined(ARM) \
@@ -230,22 +232,22 @@ void DownloadManager::restartTransfer(int transferId)
 
 void DownloadManager::setPreferences()
 {
-    QMozContext* mozContext = QMozContext::instance();
+    SailfishOS::WebEngineSettings *webEngineSettings = SailfishOS::WebEngineSettings::instance();
     // Use autodownload, never ask
-    mozContext->setPref(QString("browser.download.useDownloadDir"), QVariant(true));
-    mozContext->setPref(QString("browser.download.useJSTransfer"), QVariant(true));
+    webEngineSettings->setPreference(QString("browser.download.useDownloadDir"), QVariant(true));
+    webEngineSettings->setPreference(QString("browser.download.useJSTransfer"), QVariant(true));
     // see https://developer.mozilla.org/en-US/docs/Download_Manager_preferences
     // Use custom downloads location defined in browser.download.dir
-    mozContext->setPref(QString("browser.download.folderList"), QVariant(2));
-    mozContext->setPref(QString("browser.download.dir"), BrowserPaths::downloadLocation());
+    webEngineSettings->setPreference(QString("browser.download.folderList"), QVariant(2));
+    webEngineSettings->setPreference(QString("browser.download.dir"), BrowserPaths::downloadLocation());
     // Downloads should never be removed automatically
-    mozContext->setPref(QString("browser.download.manager.retention"), QVariant(2));
+    webEngineSettings->setPreference(QString("browser.download.manager.retention"), QVariant(2));
     // Downloads will be canceled on quit
     // TODO: this doesn't really work. Instead the incomplete downloads get restarted
     //       on browser launch.
-    mozContext->setPref(QString("browser.download.manager.quitBehavior"), QVariant(2));
+    webEngineSettings->setPreference(QString("browser.download.manager.quitBehavior"), QVariant(2));
     // TODO: this doesn't really work too
-    mozContext->setPref(QString("browser.helperApps.deleteTempFileOnExit"), QVariant(true));
+    webEngineSettings->setPreference(QString("browser.helperApps.deleteTempFileOnExit"), QVariant(true));
 
     DownloadMimetypeHandler::update();
 }

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -75,8 +75,6 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     setTitle("BrowserContent");
     setObjectName("WebView");
 
-    QMozContext::instance()->setPixelRatio(2.0);
-
     WebPageFactory* pageFactory = new WebPageFactory(this);
     connect(this, SIGNAL(webPageComponentChanged(QQmlComponent*)),
             pageFactory, SLOT(updateQmlComponent(QQmlComponent*)));

--- a/src/pages/components/ConfigDialog.qml
+++ b/src/pages/components/ConfigDialog.qml
@@ -12,6 +12,7 @@
 
 import QtQuick 2.2
 import Sailfish.Silica 1.0
+import Sailfish.WebEngine 1.0
 
 Dialog {
     id: configDialog
@@ -19,14 +20,14 @@ Dialog {
     property var changedConfigs: ({})
 
     // Get all the preferences
-    Component.onCompleted: MozContext.notifyObservers("embedui:allprefs", {})
+    Component.onCompleted: WebEngine.notifyObservers("embedui:allprefs", {})
 
     // If dialog is accepted, save all the changed configs
     onAccepted: {
         for (var key in changedConfigs) {
-            MozContext.setPref(key, changedConfigs[key]);
+            WebEngineSettings.setPreference(key, changedConfigs[key]);
         }
-        MozContext.notifyObservers("embedui:saveprefs", {})
+        WebEngine.notifyObservers("embedui:saveprefs", {})
     }
 
     function filterModel(value) {
@@ -46,7 +47,7 @@ Dialog {
     }
 
     Connections {
-        target: MozContext
+        target: WebEngine
         onRecvObserve: {
             if (message === "embed:allprefs") {
                 var allprefs = data;

--- a/src/pages/components/DownloadMenuItem.qml
+++ b/src/pages/components/DownloadMenuItem.qml
@@ -12,6 +12,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Browser 1.0
+import Sailfish.WebEngine 1.0
 
 MenuItem {
     id: root
@@ -38,14 +39,14 @@ MenuItem {
 
     onClicked: {
         if (downloadFileTargetUrl) {
-            MozContext.notifyObservers("embedui:download",
-                                       {
-                                           "msg": "addDownload",
-                                           "from": root.linkUrl,
-                                           "to": downloadFileTargetUrl,
-                                           "contentType": root.contentType,
-                                           "viewId": root.viewId
-                                       })
+            WebEngine.notifyObservers("embedui:download",
+                                      {
+                                          "msg": "addDownload",
+                                          "from": root.linkUrl,
+                                          "to": downloadFileTargetUrl,
+                                          "contentType": root.contentType,
+                                          "viewId": root.viewId
+                                      })
         }
     }
 }

--- a/src/pages/components/ResourceController.qml
+++ b/src/pages/components/ResourceController.qml
@@ -12,6 +12,7 @@
 
 import QtQuick 2.0
 import Sailfish.Media 1.0
+import Sailfish.WebEngine 1.0
 import org.freedesktop.contextkit 1.0
 import org.nemomobile.policy 1.0
 
@@ -78,7 +79,7 @@ Item {
     }
 
     Connections {
-        target: MozContext
+        target: WebEngine
         onRecvObserve: {
             if (message === "media-decoder-info") {
                 if (data.state === "meta") {

--- a/tests/auto/mocks/declarativewebutils/declarativewebutils.cpp
+++ b/tests/auto/mocks/declarativewebutils/declarativewebutils.cpp
@@ -12,6 +12,7 @@
 #include "declarativewebutils.h"
 
 #include <qmozcontext.h>
+#include <webenginesettings.h>
 
 static DeclarativeWebUtils *gSingleton = 0;
 
@@ -51,25 +52,25 @@ void DeclarativeWebUtils::setFirstUseDone(bool firstUseDone)
 
 void DeclarativeWebUtils::updateWebEngineSettings()
 {
-    QMozContext* mozContext = QMozContext::instance();
+    SailfishOS::WebEngineSettings *webEngineSettings = SailfishOS::WebEngineSettings::instance();
 
     // Add only mandatory preferences for unit tests.
 
     // Don't force 16bit color depth
-    mozContext->setPref(QString("gfx.qt.rgb16.force"), QVariant(false));
+    webEngineSettings->setPreference(QString("gfx.qt.rgb16.force"), QVariant(false));
 
     // Use external Qt window for rendering content
-    mozContext->setPref(QString("gfx.compositor.external-window"), QVariant(true));
-    mozContext->setPref(QString("gfx.compositor.clear-context"), QVariant(false));
-    mozContext->setPref(QString("embedlite.compositor.external_gl_context"), QVariant(true));
-    mozContext->setPref(QString("embedlite.compositor.request_external_gl_context_early"), QVariant(true));
+    webEngineSettings->setPreference(QString("gfx.compositor.external-window"), QVariant(true));
+    webEngineSettings->setPreference(QString("gfx.compositor.clear-context"), QVariant(false));
+    webEngineSettings->setPreference(QString("embedlite.compositor.external_gl_context"), QVariant(true));
+    webEngineSettings->setPreference(QString("embedlite.compositor.request_external_gl_context_early"), QVariant(true));
 
     // Progressive painting.
-    mozContext->setPref(QString("layers.progressive-paint"), QVariant(true));
-    mozContext->setPref(QString("layers.low-precision-buffer"), QVariant(true));
+    webEngineSettings->setPreference(QString("layers.progressive-paint"), QVariant(true));
+    webEngineSettings->setPreference(QString("layers.low-precision-buffer"), QVariant(true));
 
     // Set max active layers
-    mozContext->setPref(QString("layers.max-active"), QVariant(20));
+    webEngineSettings->setPreference(QString("layers.max-active"), QVariant(20));
 }
 
 DeclarativeWebUtils *DeclarativeWebUtils::instance()

--- a/tests/auto/mocks/qmozcontext/qmozcontext.h
+++ b/tests/auto/mocks/qmozcontext/qmozcontext.h
@@ -46,7 +46,7 @@ public:
 
 signals:
     void onInitialized();
-    void destroyed();
+    void contextDestroyed();
     void lastViewDestroyed();
     void lastWindowDestroyed();
     void recvObserve(const QString, const QVariant);

--- a/tests/auto/mocks/webengine/webengine.cpp
+++ b/tests/auto/mocks/webengine/webengine.cpp
@@ -1,0 +1,22 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelaine@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "webengine.h"
+
+static SailfishOS::WebEngine *gSingleton = 0;
+
+SailfishOS::WebEngine* SailfishOS::WebEngine::instance()
+{
+    if (!gSingleton) {
+        gSingleton = new SailfishOS::WebEngine();
+    }
+    return gSingleton;
+}

--- a/tests/auto/mocks/webengine/webengine.h
+++ b/tests/auto/mocks/webengine/webengine.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelaine@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WEBENGINE_H
+#define WEBENGINE_H
+
+#include <QObject>
+#include <QVariant>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+namespace SailfishOS {
+
+class WebEngine : public QObject
+{
+    Q_OBJECT
+
+public:
+    typedef void (*TaskCallback)(void* data);
+    typedef void* TaskHandle;
+
+    explicit WebEngine(QObject *parent = 0) : QObject(parent) {};
+
+    static void initialize(const QString &profilePath, const QString &userAgent = QLatin1String(""));
+    static WebEngine* instance();
+    MOCK_CONST_METHOD0(initialized, bool());
+    MOCK_METHOD1(CancelTask, void(void *));
+    MOCK_METHOD2(PostCompositorTask, TaskHandle(TaskCallback, void *));
+    MOCK_METHOD2(sendObserve, void(const QString &, const QString &));
+    MOCK_METHOD2(sendObserve, void(const QString &, const QVariant &));
+
+    MOCK_METHOD2(notifyObservers, void(const QString &, const QString &));
+    MOCK_METHOD2(notifyObservers, void(const QString &, const QVariant &));
+
+    MOCK_METHOD1(addObserver, void(const QString &));
+    MOCK_METHOD1(addObservers, void(const QStringList &));
+
+signals:
+    void onInitialized();
+    void contextDestroyed();
+    void lastViewDestroyed();
+    void lastWindowDestroyed();
+    void recvObserve(const QString, const QVariant);
+};
+}
+
+#endif // WEBENGINE_H

--- a/tests/auto/mocks/webengine/webengine.pri
+++ b/tests/auto/mocks/webengine/webengine.pri
@@ -1,0 +1,7 @@
+INCLUDEPATH += $$PWD
+
+HEADERS += $$PWD/webengine.h \
+    $$PWD/webenginesettings.h
+
+SOURCES += $$PWD/webengine.cpp \
+    $$PWD/webenginesettings.cpp

--- a/tests/auto/mocks/webengine/webenginesettings.cpp
+++ b/tests/auto/mocks/webengine/webenginesettings.cpp
@@ -1,0 +1,26 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelaine@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "webenginesettings.h"
+
+static SailfishOS::WebEngineSettings *gSingleton = 0;
+
+SailfishOS::WebEngineSettings *SailfishOS::WebEngineSettings::instance()
+{
+    if (!gSingleton) {
+        gSingleton = new SailfishOS::WebEngineSettings();
+    }
+    return gSingleton;
+}
+
+void SailfishOS::WebEngineSettings::initialize()
+{
+}

--- a/tests/auto/mocks/webengine/webenginesettings.h
+++ b/tests/auto/mocks/webengine/webenginesettings.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelaine@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WEBENGINE_SETTINGS_H
+#define WEBENGINE_SETTINGS_H
+
+#include <QObject>
+#include <QVariant>
+#include <QSize>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+namespace SailfishOS {
+
+class WebEngineSettings : public QObject
+{
+    Q_OBJECT
+
+public:
+    static WebEngineSettings *instance();
+    static void initialize();
+
+    explicit WebEngineSettings(QObject *parent = 0) : QObject(parent) {}
+
+    MOCK_CONST_METHOD0(isInitialized, bool());
+
+    MOCK_CONST_METHOD0(autoLoadImages, bool());
+    MOCK_METHOD1(setAutoLoadImages, void(bool));
+
+    MOCK_CONST_METHOD0(javascriptEnabled, bool());
+    MOCK_METHOD1(setJavascriptEnabled, void(bool));
+
+    MOCK_METHOD1(setTileSize, void(const QSize &));
+
+    MOCK_CONST_METHOD0(pixelRatio, qreal());
+    MOCK_METHOD1(setPixelRatio, void(qreal));
+
+    MOCK_METHOD1(enableProgressivePainting, void(bool));
+    MOCK_METHOD1(enableLowPrecisionBuffers, void(bool));
+
+    MOCK_METHOD2(setPreference, void(const QString &, const QVariant &));
+
+signals:
+    void autoLoadImagesChanged();
+    void javascriptEnabledChanged();
+    void initialized();
+};
+
+}
+
+#endif // WEBENGINE_SETTINGS_H

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.cpp
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.cpp
@@ -62,7 +62,6 @@ void tst_declarativewebcontainer::cleanupTestCase()
 void tst_declarativewebcontainer::init()
 {
     SettingManager::instance()->setAutostartPrivateBrowsing(false);
-    EXPECT_CALL(*QMozContext::instance(), setPixelRatio(_));
     m_webContainer = new DeclarativeWebContainer();
 }
 

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
@@ -4,7 +4,8 @@ CONFIG += link_pkgconfig
 
 QMAKE_LFLAGS += -lgtest -lgmock
 
-PKGCONFIG += mlite5 nemotransferengine-qt5
+PKGCONFIG += mlite5 nemotransferengine-qt5 sailfishwebengine
+INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
 
 QT += quick qml concurrent sql gui-private
 

--- a/tests/auto/tst_webpages/tst_webpages.cpp
+++ b/tests/auto/tst_webpages/tst_webpages.cpp
@@ -78,7 +78,6 @@ void tst_webpages::cleanup()
 
 void tst_webpages::initialize()
 {
-    EXPECT_CALL(*QMozContext::instance(), setPixelRatio(_));
     DeclarativeWebContainer webContainer;
     webContainer.setForeground(true);
 
@@ -93,7 +92,6 @@ void tst_webpages::initialize()
 
 void tst_webpages::count()
 {
-    EXPECT_CALL(*QMozContext::instance(), setPixelRatio(_));
     DeclarativeWebContainer webContainer;
     m_webPages->initialize(&webContainer);
 
@@ -159,7 +157,6 @@ void tst_webpages::page()
 
     // set up test case
 
-    EXPECT_CALL(*QMozContext::instance(), setPixelRatio(_));
     DeclarativeWebContainer webContainer;
     m_webPages->initialize(&webContainer);
 

--- a/tests/auto/tst_webpages/tst_webpages.pro
+++ b/tests/auto/tst_webpages/tst_webpages.pro
@@ -2,13 +2,13 @@ TARGET = tst_webpages
 
 CONFIG += link_pkgconfig
 
-PKGCONFIG += mlite5 sailfishwebengine
-INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
+PKGCONFIG += mlite5
 
 QT += qml quick concurrent sql gui-private
 
 QMAKE_LFLAGS += -lgtest -lgmock
 
+include(../mocks/webengine/webengine.pri)
 include(../mocks/qmozcontext/qmozcontext.pri)
 include(../mocks/qmozwindow/qmozwindow.pri)
 include(../mocks/webpagefactory/webpagefactory.pri)

--- a/tests/auto/tst_webpages/tst_webpages.pro
+++ b/tests/auto/tst_webpages/tst_webpages.pro
@@ -2,7 +2,8 @@ TARGET = tst_webpages
 
 CONFIG += link_pkgconfig
 
-PKGCONFIG += mlite5
+PKGCONFIG += mlite5 sailfishwebengine
+INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
 
 QT += qml quick concurrent sql gui-private
 

--- a/tests/auto/tst_webutils/tst_webutils.pro
+++ b/tests/auto/tst_webutils/tst_webutils.pro
@@ -1,16 +1,15 @@
 TARGET = tst_webutils
 CONFIG += link_pkgconfig
 QMAKE_LFLAGS += -lgtest -lgmock
-PKGCONFIG += mlite5 sailfishwebengine
+PKGCONFIG += mlite5
 
-include(../mocks/qmozcontext/qmozcontext.pri)
+include(../mocks/webengine/webengine.pri)
 include(../test_common.pri)
 include(../../../common/opensearchconfigs.pri)
 include(../../../common/paths.pri)
 
 INCLUDEPATH += $$SRCDIR \
-    $$BROWSERSRCDIR \
-    $$system(pkg-config --cflags sailfishwebengine)
+    $$BROWSERSRCDIR
 
 SOURCES += tst_webutils.cpp \
            $$BROWSERSRCDIR/declarativewebutils.cpp

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -11,7 +11,7 @@
 
 #include <QtTest>
 #include <QQuickView>
-#include <qmozcontext.h>
+#include <webenginesettings.h>
 
 #include "declarativehistorymodel.h"
 #include "persistenttabmodel.h"
@@ -114,7 +114,8 @@ void tst_webview::initTestCase()
 
     QCOMPARE(tabAddedSpy.count(), 1);
 
-    QMozContext::instance()->setPref(QString("media.resource_handler_disabled"), QVariant(true));
+    SailfishOS::WebEngineSettings *webEngineSettings = SailfishOS::WebEngineSettings::instance();
+    webEngineSettings->setPreference(QString("media.resource_handler_disabled"), QVariant(true));
 }
 
 void tst_webview::testNewTab_data()


### PR DESCRIPTION
More or less find & replacing deprecated method calls. This also fixes one signal name for QMozContext mock (2nd commit), fixes WebUtils unit tests (3rd commit), and fixes WebPage unit tests  (4th commit).

There are still references to QMozContext but at least logs are no longer full of deprecated API calls.