### PR TITLE
[sailfish-browser] Fix crashing tst_declarativewebcontainer

### DIFF
--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
@@ -4,11 +4,11 @@ CONFIG += link_pkgconfig
 
 QMAKE_LFLAGS += -lgtest -lgmock
 
-PKGCONFIG += mlite5 nemotransferengine-qt5 sailfishwebengine
-INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
+PKGCONFIG += mlite5 nemotransferengine-qt5
 
 QT += quick qml concurrent sql gui-private
 
+include(../mocks/webengine/webengine.pri)
 include(../mocks/qmozcontext/qmozcontext.pri)
 include(../mocks/qmozwindow/qmozwindow.pri)
 include(../mocks/webpagefactory/webpagefactory.pri)


### PR DESCRIPTION
This test case should have been using mock rather than linking
to the WebEngine.