### PR TITLE
[sailfish-browser] Suspend / resume rendering when ready to paint changes. Contributes to JB#35379

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -351,6 +351,12 @@ bool DeclarativeWebContainer::readyToPaint() const
 void DeclarativeWebContainer::setReadyToPaint(bool ready)
 {
     if (m_mozWindow && m_mozWindow->setReadyToPaint(ready)) {
+        if (ready) {
+            m_mozWindow->resumeRendering();
+        } else {
+            m_mozWindow->suspendRendering();
+        }
+
         emit readyToPaintChanged();
     }
 }


### PR DESCRIPTION
This pauses compositor when we are not ready to render making
LayerManagerComposite to return early from
LayerManagerComposite::BeginTransaction.

Occasionally we can see "chessboard" like garbage textures when you start loading web pages. Not sure if all error are caused due to this. Nevertheless, we should pause the gecko compositor.