### PR TITLE
[sailfish-browser] Do not allow margins updates when browser is in background. Fixes JB#35305

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -117,7 +117,7 @@ WebContainer {
 
             // There needs to be enough content for enabling chrome gesture
             chromeGestureThreshold: toolbarHeight / 2
-            chromeGestureEnabled: (contentHeight > fullscreenHeight + toolbarHeight) && !forcedChrome && enabled && !webView.imOpened
+            chromeGestureEnabled: !forcedChrome && enabled && !webView.imOpened
 
             onGrabResult: tabModel.updateThumbnailPath(tabId, fileName)
 


### PR DESCRIPTION
When browser is cover by another application and user peeks
the top most application a bit so that switcher becomes visible also
browser activates and continues rendering. However, this peek
should not update content margins which can happen if
contentHeight changes.

This also moves toolbar / chrome handling to C++ side. Chrome gesture
is now enabled / disabled based forcedChrome property. Chrome is
reset when nagivating from one web page to another.

See also : https://git.merproject.org/mer-core/qtmozembed/merge_requests/27