### PR TITLE
[sailfish-browser] Install "Search" events-view quick-action. Contributes to JB#35172

### DIFF
--- a/org.sailfishos.browser.conf
+++ b/org.sailfishos.browser.conf
@@ -1,0 +1,8 @@
+priority=2
+icon=icon-m-search
+title=sailfish-browser-quickaction-la-search_the_web
+translation-catalog=sailfish-browser
+remote-service="org.sailfishos.browser.ui"
+remote-path="/ui"
+remote-interface="org.sailfishos.browser.ui"
+remote-method="activateNewTabView"

--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -116,6 +116,7 @@ fi
 %{_datadir}/%{name}/*
 %{_datadir}/translations/sailfish-browser_eng_en.qm
 %{_datadir}/dbus-1/services/*.service
+%{_datadir}/lipstick/quickactions/*.conf
 %{_oneshotdir}/*
 
 %files settings

--- a/sailfish-browser.pro
+++ b/sailfish-browser.pro
@@ -5,6 +5,9 @@ SUBDIRS += src tests settings
 desktop.files = sailfish-browser.desktop open-url.desktop
 desktop.path = /usr/share/applications
 
+quick_actions.files = org.sailfishos.browser.conf
+quick_actions.path = /usr/share/lipstick/quickactions
+
 dbus_service.files = org.sailfishos.browser.service \
                      org.sailfishos.browser.ui.service
 dbus_service.path = /usr/share/dbus-1/services
@@ -20,7 +23,7 @@ data.files = data/prefs.js \
              data/ua-update.json.in
 data.path = /usr/share/sailfish-browser/data
 
-INSTALLS += desktop dbus_service chrome_scripts oneshots data
+INSTALLS += desktop quick_actions dbus_service chrome_scripts oneshots data
 
 OTHER_FILES += \
     rpm/*.spec

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,6 +102,9 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     translator.load(QLocale(), "sailfish-browser", "-", translationPath);
     qApp->installTranslator(&translator);
 
+    //% "Search the web"
+    QT_TRID_NOOP("sailfish-browser-quickaction-la-search_the_web");
+
     //% "Browser"
     view->setTitle(qtTrId("sailfish-browser-ap-name"));
 


### PR DESCRIPTION
Previously, the events view quick actions were installed by the
lipstick-jolla-home package.  This commit ensures that the quick
action to search the web is installed by the sailfish-browser,
so that it is only available when sailfish-browser is installed.

Contributes to JB#35172
