### PR TITLE
[sailfish-browser] Show / hide toolbar when content hits edge. Fixes JB#14628

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -124,6 +124,19 @@ WebContainer {
             // Image data is base64 encoded which can be directly used as source in Image element
             onThumbnailResult: tabModel.updateThumbnailPath(tabId, data)
 
+            onAtYBeginningChanged: {
+                if (atYBeginning && activeWebPage) {
+                    chrome = true
+                }
+            }
+
+            onAtYEndChanged: {
+                // Don't hide chrome if content lenght is short e.i. forcedChrome is enabled.
+                if (atYEnd && !forcedChrome && chrome && activeWebPage) {
+                    chrome = false
+                }
+            }
+
             onUrlChanged: {
                 if (url == "about:blank") return
 


### PR DESCRIPTION
As there are now atYBeginning and atYEnd properties, let's use those
to fix some minor toolbar issue.

1) Pan content to the beginning so that you pan only half of the toolbar
height on each pan gesture (or less). Toolbar was not shown when content
reached top if it was hidden.

2) Pan content to the end so that you pan only half of the toolbar height
on each pan gesture (or less). When there's enough content (chrome gesture
was enabled) and you reached, toolbar should animate away.

3) If web content is scrolled from JavaScript (I count also anchors),
toolbar was not animated in when content reached beginning. Similarly toolbar
was not animated away when content reached end.