### PR TITLE
[sailfish-browser] Cleanup QMozContext references. Fixes JB#36498

### DIFF
--- a/src/bookmarks/bookmarkmanager.cpp
+++ b/src/bookmarks/bookmarkmanager.cpp
@@ -29,8 +29,8 @@ BookmarkManager::BookmarkManager()
 
     clearBookmarks();
 
-    connect(m_clearBookmarksConfItem, SIGNAL(valueChanged()),
-            this, SLOT(clearBookmarks()));
+    connect(m_clearBookmarksConfItem.data(), &MGConfItem::valueChanged,
+            this, &BookmarkManager::clearBookmarks);
 }
 
 BookmarkManager* BookmarkManager::instance()

--- a/src/bookmarks/declarativebookmarkmodel.cpp
+++ b/src/bookmarks/declarativebookmarkmodel.cpp
@@ -15,7 +15,8 @@
 DeclarativeBookmarkModel::DeclarativeBookmarkModel(QObject *parent) :
     QAbstractListModel(parent)
 {
-    connect(BookmarkManager::instance(), SIGNAL(cleared()), this, SLOT(clearBookmarks()));
+    connect(BookmarkManager::instance(), &BookmarkManager::cleared,
+            this, &DeclarativeBookmarkModel::clearBookmarks);
     bookmarks = BookmarkManager::instance()->load();
 
     // Generate mapping URL -> bookmark's index in the loaded list.

--- a/src/bookmarks/desktopbookmarkwriter.cpp
+++ b/src/bookmarks/desktopbookmarkwriter.cpp
@@ -20,7 +20,8 @@ static bool dbw_testMode = false;
 DesktopBookmarkWriter::DesktopBookmarkWriter(QObject *parent)
     : QObject(parent)
 {
-    connect(&m_writter, SIGNAL(finished()), this, SLOT(desktopFileWritten()));
+    connect(&m_writter, &QFutureWatcher<QString>::finished,
+            this, &DesktopBookmarkWriter::desktopFileWritten);
 }
 
 DesktopBookmarkWriter::~DesktopBookmarkWriter()

--- a/src/bookmarks/iconfetcher.cpp
+++ b/src/bookmarks/iconfetcher.cpp
@@ -34,7 +34,10 @@ void IconFetcher::fetch(const QString &iconUrl)
     } else {
         QNetworkRequest request(url);
         QNetworkReply *reply = m_networkAccessManager.get(request);
-        connect(reply, SIGNAL(finished()), this, SLOT(dataReady()));
+        connect(reply, &QNetworkReply::finished, this, &IconFetcher::dataReady);
+        // qOverload(T functionPointer) would be handy to resolve right error method but it is introduced only
+        // in Qt5.7. QNetWorkReply has signal error(QNetworkReply::NetworkError) and method error().
+        // connect(reply, qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error), this, IconFetcher::error);
         connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(error(QNetworkReply::NetworkError)));
     }
 }

--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -22,7 +22,6 @@
 #include <QQuickView>
 #include <QTimer>
 #include <QUrl>
-#include <qmozcontext.h>
 #include <webengine.h>
 #include <webenginesettings.h>
 
@@ -42,7 +41,6 @@ Browser::Browser(QQuickView *view, QObject *parent)
     Q_ASSERT(qGuiApp);
 
     SailfishOS::WebEngine::initialize("mozembed");
-    SailfishOS::WebEngine *webEngine = SailfishOS::WebEngine::instance();
     SailfishOS::WebEngineSettings::initialize();
 
     DeclarativeWebUtils *utils = DeclarativeWebUtils::instance();
@@ -51,7 +49,6 @@ Browser::Browser(QQuickView *view, QObject *parent)
     utils->clearStartupCacheIfNeeded();
 
     d->view->rootContext()->setContextProperty("WebUtils", utils);
-    d->view->rootContext()->setContextProperty("MozContext", webEngine);
     d->view->rootContext()->setContextProperty("Settings", SettingManager::instance());
     d->view->rootContext()->setContextProperty("DownloadManager", downloadManager);
 

--- a/src/browser/closeeventfilter.cpp
+++ b/src/browser/closeeventfilter.cpp
@@ -10,8 +10,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <QCoreApplication>
+#include <webengine.h>
 #include "closeeventfilter.h"
-#include "qmozcontext.h"
 #include "declarativewebutils.h"
 #include "dbmanager.h"
 
@@ -19,9 +19,10 @@ CloseEventFilter::CloseEventFilter(DownloadManager *dlMgr, QObject *parent)
     : QObject(parent),
       m_downloadManager(dlMgr)
 {
-    connect(QMozContext::instance(), &QMozContext::lastWindowDestroyed,
+    SailfishOS::WebEngine *webEngine = SailfishOS::WebEngine::instance();
+    connect(webEngine, &SailfishOS::WebEngine::lastWindowDestroyed,
             this, &CloseEventFilter::onLastWindowDestroyed);
-    connect(QMozContext::instance(), &QMozContext::contextDestroyed,
+    connect(webEngine, &SailfishOS::WebEngine::contextDestroyed,
             this, &CloseEventFilter::onContextDestroyed);
     connect(&m_shutdownWatchdog, &QTimer::timeout,
             this, &CloseEventFilter::onWatchdogTimeout);
@@ -34,7 +35,7 @@ void CloseEventFilter::stopApplication()
         DBManager::instance()->removeAllTabs();
     }
 
-    QMozContext::instance()->stopEmbedding();
+    SailfishOS::WebEngine::instance()->stopEmbedding();
     // Give the engine 5 seconds to shut down. If it fails terminate
     // with a fatal error.
     m_shutdownWatchdog.start(5000);

--- a/src/browser/closeeventfilter.cpp
+++ b/src/browser/closeeventfilter.cpp
@@ -44,8 +44,8 @@ void CloseEventFilter::stopApplication()
 void CloseEventFilter::onLastWindowDestroyed()
 {
     if (m_downloadManager->existActiveTransfers()) {
-        connect(m_downloadManager, SIGNAL(allTransfersCompleted()),
-                this, SLOT(stopApplication()));
+        connect(m_downloadManager, &DownloadManager::allTransfersCompleted,
+                this, &CloseEventFilter::stopApplication);
     } else {
         stopApplication();
     }
@@ -63,7 +63,7 @@ void CloseEventFilter::onWatchdogTimeout()
 
 void CloseEventFilter::cancelStopApplication()
 {
-    disconnect(m_downloadManager, SIGNAL(allTransfersCompleted()),
-               this, SLOT(stopApplication()));
+    disconnect(m_downloadManager, &DownloadManager::allTransfersCompleted,
+               this, &CloseEventFilter::stopApplication);
     m_shutdownWatchdog.stop();
 }

--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -50,8 +50,8 @@ DeclarativeWebUtils::DeclarativeWebUtils()
     , m_homePage("/apps/sailfish-browser/settings/home_page", this)
 {
     updateWebEngineSettings();
-    connect(SailfishOS::WebEngine::instance(), SIGNAL(recvObserve(QString, QVariant)),
-            this, SLOT(handleObserve(QString, QVariant)));
+    connect(SailfishOS::WebEngine::instance(), &SailfishOS::WebEngine::recvObserve,
+            this, &DeclarativeWebUtils::handleObserve);
 
     QString path = BrowserPaths::dataLocation() + QStringLiteral("/.firstUseDone");
     m_firstUseDone = fileExists(path);

--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -56,7 +56,8 @@ DeclarativeWebUtils::DeclarativeWebUtils()
     QString path = BrowserPaths::dataLocation() + QStringLiteral("/.firstUseDone");
     m_firstUseDone = fileExists(path);
 
-    connect(&m_homePage, SIGNAL(valueChanged()), this, SIGNAL(homePageChanged()));
+    connect(&m_homePage, &MGConfItem::valueChanged,
+            this, &DeclarativeWebUtils::homePageChanged);
 }
 
 DeclarativeWebUtils::~DeclarativeWebUtils()

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -77,8 +77,8 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     setObjectName("WebView");
 
     WebPageFactory* pageFactory = new WebPageFactory(this);
-    connect(this, SIGNAL(webPageComponentChanged(QQmlComponent*)),
-            pageFactory, SLOT(updateQmlComponent(QQmlComponent*)));
+    connect(this, &DeclarativeWebContainer::webPageComponentChanged,
+            pageFactory, &WebPageFactory::updateQmlComponent);
     m_webPages = new WebPages(pageFactory, this);
     int maxTabid = DBManager::instance()->getMaxTabId();
     m_persistentTabModel = new PersistentTabModel(maxTabid + 1, this);
@@ -86,7 +86,8 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
 
     setTabModel(privateMode() ? m_privateTabModel.data() : m_persistentTabModel.data());
 
-    connect(DownloadManager::instance(), SIGNAL(downloadStarted()), this, SLOT(onDownloadStarted()));
+    connect(DownloadManager::instance(), &DownloadManager::downloadStarted,
+            this, &DeclarativeWebContainer::onDownloadStarted);
     SailfishOS::WebEngine *webEngine = SailfishOS::WebEngine::instance();
     connect(webEngine, &SailfishOS::WebEngine::onInitialized,
             this, &DeclarativeWebContainer::initialize);
@@ -98,7 +99,8 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
         return;
     }
 
-    connect(this, SIGNAL(foregroundChanged()), this, SLOT(updateWindowFlags()));
+    connect(this, &DeclarativeWebContainer::foregroundChanged,
+            this, &DeclarativeWebContainer::updateWindowFlags);
 
     qApp->installEventFilter(this);
 }
@@ -140,23 +142,34 @@ void DeclarativeWebContainer::setWebPage(DeclarativeWebPage *webPage, bool trigg
         setActiveTabRendered(false);
 
         if (m_webPage) {
-            connect(m_webPage, SIGNAL(canGoBackChanged()), this, SIGNAL(canGoBackChanged()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(canGoForwardChanged()), this, SIGNAL(canGoForwardChanged()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(urlChanged()), this, SIGNAL(urlChanged()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(titleChanged()), this, SIGNAL(titleChanged()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(windowCloseRequested()), this, SLOT(closeWindow()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(loadingChanged()), this, SLOT(updateLoading()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(loadProgressChanged()), this, SLOT(updateLoadProgress()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(contentOrientationChanged(Qt::ScreenOrientation)),
-                    this, SLOT(handleContentOrientationChanged(Qt::ScreenOrientation)), Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::canGoBackChanged,
+                    this, &DeclarativeWebContainer::canGoBackChanged, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::canGoForwardChanged,
+                    this, &DeclarativeWebContainer::canGoForwardChanged, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::urlChanged,
+                    this, &DeclarativeWebContainer::urlChanged, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::titleChanged,
+                    this, &DeclarativeWebContainer::titleChanged, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::windowCloseRequested,
+                    this, &DeclarativeWebContainer::closeWindow, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::loadingChanged,
+                    this, &DeclarativeWebContainer::updateLoading, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::loadProgressChanged,
+                    this, &DeclarativeWebContainer::updateLoadProgress, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::contentOrientationChanged,
+                    this, &DeclarativeWebContainer::handleContentOrientationChanged, Qt::UniqueConnection);
 
             // NB: these signals are not disconnected upon setting current m_webPage.
-            connect(m_webPage, SIGNAL(urlChanged()), m_model, SLOT(onUrlChanged()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(titleChanged()), m_model, SLOT(onTitleChanged()), Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::urlChanged,
+                    m_model.data(), &DeclarativeTabModel::onUrlChanged, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::titleChanged,
+                    m_model.data(), &DeclarativeTabModel::onTitleChanged, Qt::UniqueConnection);
 
             // Wait for one frame to be rendered and schedule update if tab is ready to render.
-            connect(m_mozWindow.data(), SIGNAL(compositingFinished()), this, SLOT(updateActiveTabRendered()), Qt::UniqueConnection);
-            connect(m_webPage, SIGNAL(domContentLoadedChanged()), this, SLOT(updateActiveTabRendered()), Qt::UniqueConnection);
+            connect(m_mozWindow.data(), &QMozWindow::compositingFinished,
+                    this, &DeclarativeWebContainer::updateActiveTabRendered, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::domContentLoadedChanged,
+                    this, &DeclarativeWebContainer::updateActiveTabRendered, Qt::UniqueConnection);
 
             if (m_webPage->completed() && m_webPage->active() && m_webPage->domContentLoaded()) {
                 m_webPage->update();
@@ -194,11 +207,16 @@ void DeclarativeWebContainer::setTabModel(DeclarativeTabModel *model)
         m_model = model;
         int newCount = 0;
         if (m_model) {
-            connect(m_model, SIGNAL(activeTabChanged(int)), this, SLOT(onActiveTabChanged(int)));
-            connect(m_model, SIGNAL(activeTabChanged(int)), this, SIGNAL(tabIdChanged()));
-            connect(m_model, SIGNAL(loadedChanged()), this, SLOT(initialize()));
-            connect(m_model, SIGNAL(tabClosed(int)), this, SLOT(releasePage(int)));
-            connect(m_model, SIGNAL(newTabRequested(QString,QString,int)), this, SLOT(onNewTabRequested(QString,QString,int)));
+            connect(m_model.data(), &DeclarativeTabModel::activeTabChanged,
+                    this, &DeclarativeWebContainer::onActiveTabChanged);
+            connect(m_model.data(), &DeclarativeTabModel::activeTabChanged,
+                    this, &DeclarativeWebContainer::tabIdChanged);
+            connect(m_model.data(), &DeclarativeTabModel::loadedChanged,
+                    this, &DeclarativeWebContainer::initialize);
+            connect(m_model.data(), &DeclarativeTabModel::tabClosed,
+                    this, &DeclarativeWebContainer::releasePage);
+            connect(m_model.data(), &DeclarativeTabModel::newTabRequested,
+                    this, &DeclarativeWebContainer::onNewTabRequested);
             newCount = m_model->count();
         }
         emit tabModelChanged();
@@ -889,8 +907,8 @@ void DeclarativeWebContainer::updateActiveTabRendered()
 
     setActiveTabRendered(true);
     // One frame rendered so let's disconnect.
-    disconnect(m_mozWindow.data(), SIGNAL(compositingFinished()),
-               this, SLOT(updateActiveTabRendered()));
+    disconnect(m_mozWindow.data(), &QMozWindow::compositingFinished,
+               this, &DeclarativeWebContainer::updateActiveTabRendered);
 }
 
 void DeclarativeWebContainer::onLastViewDestroyed()

--- a/src/core/settingmanager.cpp
+++ b/src/core/settingmanager.cpp
@@ -38,10 +38,10 @@ SettingManager::SettingManager(QObject *parent)
     // Look and feel related settings
     m_toolbarSmall = new MGConfItem("/apps/sailfish-browser/settings/toolbar_small", this);
     m_toolbarLarge = new MGConfItem("/apps/sailfish-browser/settings/toolbar_large", this);
-    connect(m_toolbarSmall, SIGNAL(valueChanged()), this, SIGNAL(toolbarSmallChanged()));
-    connect(m_toolbarLarge, SIGNAL(valueChanged()), this, SIGNAL(toolbarLargeChanged()));
-    connect(SailfishOS::WebEngine::instance(), SIGNAL(recvObserve(QString, QVariant)),
-            this, SLOT(handleObserve(QString, QVariant)));
+    connect(m_toolbarSmall, &MGConfItem::valueChanged, this, &SettingManager::toolbarSmallChanged);
+    connect(m_toolbarLarge, &MGConfItem::valueChanged, this, &SettingManager::toolbarLargeChanged);
+    connect(SailfishOS::WebEngine::instance(), &SailfishOS::WebEngine::recvObserve,
+            this, &SettingManager::handleObserve);
 }
 
 bool SettingManager::clearHistoryRequested() const
@@ -63,18 +63,18 @@ bool SettingManager::initialize()
     setSearchEngine();
     doNotTrack();
 
-    connect(m_clearHistoryConfItem, SIGNAL(valueChanged()),
-            this, SLOT(clearHistory()));
-    connect(m_clearCookiesConfItem, SIGNAL(valueChanged()),
-            this, SLOT(clearCookies()));
-    connect(m_clearPasswordsConfItem, SIGNAL(valueChanged()),
-            this, SLOT(clearPasswords()));
-    connect(m_clearCacheConfItem, SIGNAL(valueChanged()),
-            this, SLOT(clearCache()));
-    connect(m_searchEngineConfItem, SIGNAL(valueChanged()),
-            this, SLOT(setSearchEngine()));
-    connect(m_doNotTrackConfItem, SIGNAL(valueChanged()),
-            this, SLOT(doNotTrack()));
+    connect(m_clearHistoryConfItem, &MGConfItem::valueChanged,
+            this, &SettingManager::clearHistory);
+    connect(m_clearCookiesConfItem, &MGConfItem::valueChanged,
+            this, &SettingManager::clearCookies);
+    connect(m_clearPasswordsConfItem, &MGConfItem::valueChanged,
+            this, &SettingManager::clearPasswords);
+    connect(m_clearCacheConfItem, &MGConfItem::valueChanged,
+            this, &SettingManager::clearCache);
+    connect(m_searchEngineConfItem, &MGConfItem::valueChanged,
+            this, &SettingManager::setSearchEngine);
+    connect(m_doNotTrackConfItem, &MGConfItem::valueChanged,
+            this, &SettingManager::doNotTrack);
 
     m_initialized = true;
     return clearedData;

--- a/src/core/webpagequeue.cpp
+++ b/src/core/webpagequeue.cpp
@@ -94,7 +94,8 @@ void WebPageQueue::release(int tabId,  bool virtualize)
                 pageEntry->webPage->setParent(0);
                 delete pageEntry->webPage;
             } else {
-                QObject::connect(pageEntry->webPage, SIGNAL(completedChanged()), pageEntry->webPage, SLOT(deleteLater()));
+                QObject::connect(pageEntry->webPage.data(), &DeclarativeWebPage::completedChanged,
+                                 pageEntry->webPage.data(), &QObject::deleteLater);
             }
         }
 

--- a/src/core/webpages.cpp
+++ b/src/core/webpages.cpp
@@ -20,11 +20,11 @@
 #include <QQmlContext>
 #include <QMapIterator>
 #include <QRectF>
+#include <webengine.h>
 
 #include "webpages.h"
 #include "declarativewebcontainer.h"
 #include "declarativewebpage.h"
-#include "qmozcontext.h"
 #include "tab.h"
 #include "webpagefactory.h"
 
@@ -233,11 +233,12 @@ void WebPages::handleMemNotify(const QString &memoryLevel)
             connect(m_activePages.activeWebPage(), SIGNAL(completedChanged()), this, SLOT(delayVirtualization()), Qt::UniqueConnection);
         }
 
-        QMozContext::instance()->notifyObservers(QString("memory-pressure"), QString("low-memory"));
+        SailfishOS::WebEngine *webEngine = SailfishOS::WebEngine::instance();
+        webEngine->notifyObservers(QString("memory-pressure"), QString("low-memory"));
         if (!m_webContainer->foreground() &&
                 (QDateTime::currentMSecsSinceEpoch() - m_backgroundTimestamp) > gMemoryPressureTimeout) {
             m_backgroundTimestamp = QDateTime::currentMSecsSinceEpoch();
-            QMozContext::instance()->notifyObservers(QString("memory-pressure"), QString("heap-minimize"));
+            webEngine->notifyObservers(QString("memory-pressure"), QString("heap-minimize"));
         }
     }
 }

--- a/src/history/declarativehistorymodel.cpp
+++ b/src/history/declarativehistorymodel.cpp
@@ -16,10 +16,10 @@
 DeclarativeHistoryModel::DeclarativeHistoryModel(QObject *parent)
     : QAbstractListModel(parent)
 {
-    connect(DBManager::instance(), SIGNAL(historyAvailable(QList<Link>)),
-            this, SLOT(historyAvailable(QList<Link>)));
-    connect(DBManager::instance(), SIGNAL(titleChanged(QString,QString)),
-            this, SLOT(updateTitle(QString,QString)));
+    connect(DBManager::instance(), &DBManager::historyAvailable,
+            this, &DeclarativeHistoryModel::historyAvailable);
+    connect(DBManager::instance(), &DBManager::titleChanged,
+            this, &DeclarativeHistoryModel::updateTitle);
 }
 
 QHash<int, QByteArray> DeclarativeHistoryModel::roleNames() const

--- a/src/history/persistenttabmodel.cpp
+++ b/src/history/persistenttabmodel.cpp
@@ -18,8 +18,8 @@
 PersistentTabModel::PersistentTabModel(int nextTabId, DeclarativeWebContainer *webContainer)
     : DeclarativeTabModel(nextTabId, webContainer)
 {
-    connect(DBManager::instance(), SIGNAL(tabsAvailable(QList<Tab>)),
-            this, SLOT(tabsAvailable(QList<Tab>)));
+    connect(DBManager::instance(), &DBManager::tabsAvailable,
+            this, &PersistentTabModel::tabsAvailable);
 
     DBManager::instance()->getAllTabs();
 }
@@ -74,8 +74,8 @@ void PersistentTabModel::tabsAvailable(const QList<Tab> &tabs)
         emit loadedChanged();
     }
 
-    connect(this, SIGNAL(activeTabIndexChanged()),
-            this, SLOT(saveActiveTab()), Qt::UniqueConnection);
+    connect(this, &PersistentTabModel::activeTabIndexChanged,
+            this, &PersistentTabModel::saveActiveTab, Qt::UniqueConnection);
 }
 
 void PersistentTabModel::createTab(const Tab &tab) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,22 +130,22 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterType<InputRegion>(uri, 1, 0, "InputRegion");
 
     Browser *browser = new Browser(view.data(), app.data());
-    browser->connect(service, SIGNAL(openUrlRequested(QString)),
-                     browser, SLOT(openUrl(QString)));
-    browser->connect(service, SIGNAL(activateNewTabViewRequested()),
-                     browser, SLOT(openNewTabView()));
-    browser->connect(service, SIGNAL(dumpMemoryInfoRequested(QString)),
-                     browser, SLOT(dumpMemoryInfo(QString)));
+    browser->connect(service, &BrowserService::openUrlRequested,
+                     browser, &Browser::openUrl);
+    browser->connect(service, &BrowserService::activateNewTabViewRequested,
+                     browser, &Browser::openNewTabView);
+    browser->connect(service, &BrowserService::dumpMemoryInfoRequested,
+                     browser, &Browser::dumpMemoryInfo);
 
-    browser->connect(uiService, SIGNAL(openUrlRequested(QString)),
-                     browser, SLOT(openUrl(QString)));
-    browser->connect(uiService, SIGNAL(activateNewTabViewRequested()),
-                     browser, SLOT(openNewTabView()));
+    browser->connect(uiService, &BrowserUIService::openUrlRequested,
+                     browser, &Browser::openUrl);
+    browser->connect(uiService, &BrowserUIService::activateNewTabViewRequested,
+                     browser, &Browser::openNewTabView);
 
-    browser->connect(service, SIGNAL(cancelTransferRequested(int)),
-                     browser, SLOT(cancelDownload(int)));
-    browser->connect(service, SIGNAL(restartTransferRequested(int)),
-                     browser, SLOT(restartDownload(int)));
+    browser->connect(service, &BrowserService::cancelTransferRequested,
+                     browser, &Browser::cancelDownload);
+    browser->connect(service, &BrowserService::restartTransferRequested,
+                     browser, &Browser::restartDownload);
     browser->load();
     return app->exec();
 }

--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -14,6 +14,7 @@
 #include "dbmanager.h"
 #include "browserpaths.h"
 
+#include <webenginesettings.h>
 #include <qmozwindow.h>
 #include <QGuiApplication>
 #include <QtConcurrent>
@@ -417,7 +418,7 @@ void DeclarativeWebPage::sendVkbOpenCompositionMetrics()
 
     QVariantMap map;
     map.insert("imOpen", m_virtualKeyboardMargin > 0);
-    map.insert("pixelRatio", QMozContext::instance()->pixelRatio());
+    map.insert("pixelRatio", SailfishOS::WebEngineSettings::instance()->pixelRatio());
     map.insert("bottomMargin", m_virtualKeyboardMargin);
     map.insert("screenWidth", winWidth);
     map.insert("screenHeight", winHeight);

--- a/src/qtmozembed/declarativewebpagecreator.cpp
+++ b/src/qtmozembed/declarativewebpagecreator.cpp
@@ -9,7 +9,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <qmozcontext.h>
+#include <webengine.h>
 #include "declarativewebpage.h"
 #include "declarativewebpagecreator.h"
 
@@ -17,12 +17,12 @@ DeclarativeWebPageCreator::DeclarativeWebPageCreator(QObject *parent)
     : QMozViewCreator(parent)
     , m_activeWebPage(0)
 {
-    QMozContext::instance()->setViewCreator(this);
+    SailfishOS::WebEngine::instance()->setViewCreator(this);
 }
 
 DeclarativeWebPageCreator::~DeclarativeWebPageCreator()
 {
-    QMozContext::instance()->setViewCreator(0);
+    SailfishOS::WebEngine::instance()->setViewCreator(0);
 }
 
 DeclarativeWebPage *DeclarativeWebPageCreator::activeWebPage() const

--- a/src/qtmozembed/qtmozembed.pri
+++ b/src/qtmozembed/qtmozembed.pri
@@ -1,12 +1,5 @@
 INCLUDEPATH += $$PWD
 
-# Include qtmozembed lib
-isEmpty(QTEMBED_LIB) {
-  PKGCONFIG += qt5embedwidget
-} else {
-  LIBS+=$$QTEMBED_LIB
-}
-
 # C++ sources
 SOURCES += \
     $$PWD/declarativewebpage.cpp \

--- a/src/storage/dbmanager.cpp
+++ b/src/storage/dbmanager.cpp
@@ -35,12 +35,12 @@ DBManager::DBManager(QObject *parent)
     worker = new DBWorker();
     worker->moveToThread(&workerThread);
 
-    connect(&workerThread, SIGNAL(finished()), worker, SLOT(deleteLater()));
-    connect(worker, SIGNAL(tabsAvailable(QList<Tab>)), this, SIGNAL(tabsAvailable(QList<Tab>)));
-    connect(worker, SIGNAL(historyAvailable(QList<Link>)), this, SIGNAL(historyAvailable(QList<Link>)));
-    connect(worker, SIGNAL(tabHistoryAvailable(int,QList<Link>,int)), this, SIGNAL(tabHistoryAvailable(int,QList<Link>,int)));
-    connect(worker, SIGNAL(titleChanged(QString,QString)), this, SIGNAL(titleChanged(QString,QString)));
-    connect(worker, SIGNAL(thumbPathChanged(int,QString)), this, SIGNAL(thumbPathChanged(int,QString)));
+    connect(&workerThread, &QThread::finished, worker, &DBWorker::deleteLater);
+    connect(worker, &DBWorker::tabsAvailable, this, &DBManager::tabsAvailable);
+    connect(worker, &DBWorker::historyAvailable, this, &DBManager::historyAvailable);
+    connect(worker, &DBWorker::tabHistoryAvailable, this, &DBManager::tabHistoryAvailable);
+    connect(worker, &DBWorker::titleChanged, this, &DBManager::titleChanged);
+    connect(worker, &DBWorker::thumbPathChanged, this, &DBManager::thumbPathChanged);
     workerThread.start();
 
     QMetaObject::invokeMethod(worker, "init", Qt::BlockingQueuedConnection);

--- a/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
+++ b/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
@@ -29,6 +29,9 @@ public:
     int findParentTabId(int) const;
     MOCK_CONST_METHOD0(webPage, DeclarativeWebPage*());
     MOCK_CONST_METHOD0(privateMode, bool());
+
+signals:
+    void portraitChanged();
 };
 
 

--- a/tests/auto/mocks/declarativewebpage/declarativewebpage.h
+++ b/tests/auto/mocks/declarativewebpage/declarativewebpage.h
@@ -102,6 +102,7 @@ signals:
     void loadingChanged();
     void loadProgressChanged();
     void requestGLContext();
+    void completedChanged();
 
     void contentOrientationChanged(Qt::ScreenOrientation orientation);
     void containerChanged();

--- a/tests/auto/mocks/declarativewebutils/declarativewebutils.cpp
+++ b/tests/auto/mocks/declarativewebutils/declarativewebutils.cpp
@@ -11,7 +11,6 @@
 
 #include "declarativewebutils.h"
 
-#include <qmozcontext.h>
 #include <webenginesettings.h>
 
 static DeclarativeWebUtils *gSingleton = 0;
@@ -21,8 +20,8 @@ DeclarativeWebUtils::DeclarativeWebUtils(QObject *parent)
     , m_homePage("file:///opt/tests/sailfish-browser/manual/testpage.html")
     , m_firstUseDone(true)
 {
-    connect(QMozContext::instance(), SIGNAL(onInitialized()),
-            this, SLOT(updateWebEngineSettings()));
+    connect(SailfishOS::WebEngineSettings::instance(), &SailfishOS::WebEngineSettings::initialized,
+            this, &DeclarativeWebUtils::updateWebEngineSettings);
 }
 
 int DeclarativeWebUtils::getLightness(QColor color) const

--- a/tests/auto/mocks/webpagefactory/webpagefactory.h
+++ b/tests/auto/mocks/webpagefactory/webpagefactory.h
@@ -26,6 +26,9 @@ public:
 
     MOCK_METHOD3(createWebPage, DeclarativeWebPage*(DeclarativeWebContainer*, const Tab&, int));
 
+signals:
+    void aboutToInitialize(DeclarativeWebPage *webPage);
+
 public slots:
     void updateQmlComponent(QQmlComponent*) {};
 };

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.cpp
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.cpp
@@ -10,6 +10,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <QtTest/QtTest>
+#include <webengine.h>
 
 #include "declarativewebcontainer.h"
 #include "declarativewebpage.h"
@@ -56,7 +57,7 @@ void tst_declarativewebcontainer::initTestCase()
 
 void tst_declarativewebcontainer::cleanupTestCase()
 {
-    delete QMozContext::instance();
+    delete SailfishOS::WebEngine::instance();
 }
 
 void tst_declarativewebcontainer::init()
@@ -89,7 +90,6 @@ void tst_declarativewebcontainer::setWebPage()
     // Setting page
     EXPECT_CALL(page, setWindow(m_webContainer.data()));
     EXPECT_CALL(page, updateContentOrientation(_));
-    EXPECT_CALL(page, isPainted()).WillOnce(Return(true));
     EXPECT_CALL(page, loadProgress()).WillOnce(Return(0));
     m_webContainer->setWebPage(&page);
     QCOMPARE(m_webContainer->m_webPage.data(), &page);
@@ -229,8 +229,6 @@ void tst_declarativewebcontainer::loading()
     QCOMPARE(m_webContainer->loading(), false);
 
     // Page is not loading => false
-    EXPECT_CALL(page, setWindow(m_webContainer.data()));
-    EXPECT_CALL(page, isPainted());
     EXPECT_CALL(page, loadProgress());
     m_webContainer->setWebPage(&page);
     EXPECT_CALL(page, loading()).WillOnce(Return(false));
@@ -257,25 +255,23 @@ void tst_declarativewebcontainer::setChromeWindow()
 void tst_declarativewebcontainer::load()
 {
     // No page and no model set => set initial url
-    EXPECT_CALL(*QMozContext::instance(), initialized()).WillOnce(Return(false));
+    EXPECT_CALL(*SailfishOS::WebEngine::instance(), initialized()).WillOnce(Return(false));
     m_webContainer->load(QString(), QString(), true);
     QCOMPARE(m_webContainer->m_initialUrl, QString("about:blank"));
 
     // Test the path for uninitialized container => set initial url
     DeclarativeWebPage page;
-    EXPECT_CALL(page, setWindow(m_webContainer.data()));
-    EXPECT_CALL(page, isPainted());
     EXPECT_CALL(page, loadProgress());
     m_webContainer->setWebPage(&page);
     EXPECT_CALL(page, completed()).WillOnce(Return(false));
-    EXPECT_CALL(*QMozContext::instance(), initialized()).WillOnce(Return(false));
+    EXPECT_CALL(*SailfishOS::WebEngine::instance(), initialized()).WillOnce(Return(false));
     m_webContainer->load(QString("http://example1.com"), QString(), true);
     QCOMPARE(m_webContainer->m_initialUrl, QString("http://example1.com"));
 
     // Initialized container, empty model => add new tab to model
     PrivateTabModel model(NEXT_TAB_ID);
     m_webContainer->setTabModel(&model);
-    EXPECT_CALL(*QMozContext::instance(), initialized()).WillOnce(Return(true));
+    EXPECT_CALL(*SailfishOS::WebEngine::instance(), initialized()).WillOnce(Return(true));
     EXPECT_CALL(page, completed()).WillOnce(Return(false));
     m_webContainer->load(QString(), QString(), true);
 
@@ -317,7 +313,7 @@ void tst_declarativewebcontainer::activatePage()
 
 void tst_declarativewebcontainer::releasePage()
 {
-    EXPECT_CALL(*QMozContext::instance(), PostCompositorTask(_, m_webContainer.data()));
+    EXPECT_CALL(*SailfishOS::WebEngine::instance(), PostCompositorTask(_, m_webContainer.data()));
     m_webContainer->releasePage(1);
 }
 

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -483,7 +483,7 @@ void tst_persistenttabmodel::onUrlChanged()
     tabModel->addTab("http://example.com", "initial title", 0);
 
     DeclarativeWebPage mockPage;
-    connect(&mockPage, SIGNAL(urlChanged()), tabModel, SLOT(onUrlChanged()));
+    connect(&mockPage, &DeclarativeWebPage::urlChanged, tabModel, &PersistentTabModel::onUrlChanged);
 
     QSignalSpy dataChangedSpy(tabModel, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)));
     QSignalSpy tabAddedSpy(tabModel, SIGNAL(tabAdded(int)));
@@ -527,7 +527,7 @@ void tst_persistenttabmodel::onTitleChanged()
     tabModel->addTab("http://example.com", "initial title", 0);
 
     DeclarativeWebPage mockPage;
-    connect(&mockPage, SIGNAL(titleChanged()), tabModel, SLOT(onTitleChanged()));
+    connect(&mockPage, &DeclarativeWebPage::titleChanged, tabModel, &PersistentTabModel::onTitleChanged);
 
     QSignalSpy dataChangedSpy(tabModel, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)));
 

--- a/tests/auto/tst_webpages/tst_webpages.cpp
+++ b/tests/auto/tst_webpages/tst_webpages.cpp
@@ -10,6 +10,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <QtTest>
+#include <webengine.h>
 
 #include "webpagefactory.h"
 #include "declarativewebcontainer.h"
@@ -58,12 +59,12 @@ private:
 
 void tst_webpages::initTestCase()
 {
-    QMozContext::instance();
+    SailfishOS::WebEngine::instance();
 }
 
 void tst_webpages::cleanupTestCase()
 {
-    delete QMozContext::instance();
+    delete SailfishOS::WebEngine::instance();
 }
 
 void tst_webpages::init()

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -11,6 +11,7 @@
 
 #include <QtTest>
 #include <QQuickView>
+#include <webengine.h>
 #include <webenginesettings.h>
 
 #include "declarativehistorymodel.h"
@@ -766,7 +767,7 @@ void tst_webview::cleanupTestCase()
             .arg(QLatin1String(DB_NAME));
     QFile dbFile(dbFileName);
     QVERIFY(dbFile.remove());
-    QMozContext::instance()->stopEmbedding();
+    SailfishOS::WebEngine::instance()->stopEmbedding();
 }
 
 /*!
@@ -799,7 +800,6 @@ int main(int argc, char *argv[])
     app.setAttribute(Qt::AA_Use96Dpi, true);
     tst_webview testcase;
     testcase.setContextProperty("WebUtils", DeclarativeWebUtils::instance());
-    testcase.setContextProperty("MozContext", QMozContext::instance());
 
     qmlRegisterType<DeclarativeHistoryModel>("Sailfish.Browser", 1, 0, "HistoryModel");
     qmlRegisterUncreatableType<DeclarativeTabModel>("Sailfish.Browser", 1, 0, "TabModel", "TabModel is abstract!");
@@ -809,12 +809,12 @@ int main(int argc, char *argv[])
     qmlRegisterType<DeclarativeWebPageCreator>("Sailfish.Browser", 1, 0, "WebPageCreator");
 
     QString componentPath(DEFAULT_COMPONENTS_PATH);
-    QMozContext::instance()->addComponentManifest(componentPath + QString("/components/EmbedLiteBinComponents.manifest"));
-    QMozContext::instance()->addComponentManifest(componentPath + QString("/components/EmbedLiteJSComponents.manifest"));
-    QMozContext::instance()->addComponentManifest(componentPath + QString("/chrome/EmbedLiteJSScripts.manifest"));
-    QMozContext::instance()->addComponentManifest(componentPath + QString("/chrome/EmbedLiteOverrides.manifest"));
+    SailfishOS::WebEngine::instance()->addComponentManifest(componentPath + QString("/components/EmbedLiteBinComponents.manifest"));
+    SailfishOS::WebEngine::instance()->addComponentManifest(componentPath + QString("/components/EmbedLiteJSComponents.manifest"));
+    SailfishOS::WebEngine::instance()->addComponentManifest(componentPath + QString("/chrome/EmbedLiteJSScripts.manifest"));
+    SailfishOS::WebEngine::instance()->addComponentManifest(componentPath + QString("/chrome/EmbedLiteOverrides.manifest"));
 
-    QTimer::singleShot(0, QMozContext::instance(), SLOT(runEmbedding()));
+    QTimer::singleShot(0, SailfishOS::WebEngine::instance(), SLOT(runEmbedding()));
 
     return QTest::qExec(&testcase, argc, argv);
 }


### PR DESCRIPTION
Use WebEngine and WebEngineSettings when possible.

There's on include dependency in DeclarativeWebContainer to
QMozContext::TaskHandle. As posting tasks is rather low level API,
I don't see reason to duplicate that to WebEngine.
