### PR TITLE
[sailfish-browser] Do not change chrome state before dom content is loaded. Contributes to JB#14628

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -125,14 +125,14 @@ WebContainer {
             onThumbnailResult: tabModel.updateThumbnailPath(tabId, data)
 
             onAtYBeginningChanged: {
-                if (atYBeginning && activeWebPage) {
+                if (atYBeginning && activeWebPage && domContentLoaded) {
                     chrome = true
                 }
             }
 
             onAtYEndChanged: {
                 // Don't hide chrome if content lenght is short e.i. forcedChrome is enabled.
-                if (atYEnd && !forcedChrome && chrome && activeWebPage) {
+                if (atYEnd && !forcedChrome && chrome && activeWebPage && domContentLoaded) {
                     chrome = false
                 }
             }


### PR DESCRIPTION
When we are loading a web page, atYBeginning and/or atYEnd might change
so that content reaches beginning/end while in reality content loading is
about to start. Thus, guard statements with domContentLoaded property.