### PR TITLE
[sailfish-browser] Close vkb when opening context menu. Contributes to JB#36163

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -105,6 +105,11 @@ WebContainer {
                 tabModel: webView.tabModel
 
                 onAboutToOpenContextMenu: {
+                    if (Qt.inputMethod.visible) {
+                        browserPage.focus = true
+                        Qt.inputMethod.hide()
+                    }
+
                     // Possible path that leads to a new tab. Thus, capturing current
                     // view before opening context menu.
                     webView.grabActivePage()


### PR DESCRIPTION
Give focus to the other window and hide virtual keyboard.

See also: https://github.com/sailfishos/sailfish-components-webview/pull/18