### PR TITLE
[sailfish-browser] Show frequently visited web pages at top of history search. Fixes JB#36478

### DIFF
--- a/src/storage/dbworker.cpp
+++ b/src/storage/dbworker.cpp
@@ -550,7 +550,7 @@ void DBWorker::getHistory(const QString &filter)
 
     if (!filter.isEmpty()) {
         filterQuery = filterQuery.arg(QString("(url LIKE :search OR title LIKE :search)"));
-        order = QString("LENGTH(url), title, date ASC");
+        order = QString("visited_count DESC, date ASC, LENGTH(url), title");
     } else {
         filterQuery = filterQuery.arg(1);
         order = QString("date DESC");


### PR DESCRIPTION
This commit adds visited count to the history search. It should have been there from day one.

@jpetrell @chriadam review ?