### PR TITLE
[sailfish-browser] Clear text selection when receiving an external url. Fixes JB#37947

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -277,8 +277,8 @@ Page {
         onEnteringNewTabUrlChanged: window.opaqueBackground = webView.tabModel.waitingForNewTab || enteringNewTabUrl
 
         animator.onAtBottomChanged: {
-            if (!animator.atBottom && webView.contentItem) {
-                webView.contentItem.clearSelection()
+            if (!animator.atBottom) {
+                webView.clearSelection()
             }
         }
 
@@ -287,8 +287,11 @@ Page {
                 overlay.animator.showChrome()
             }
 
-            if (!active && webView.chromeWindow && webView.foreground) {
-                webView.chromeWindow.raise()
+            if (!active) {
+                webView.clearSelection()
+                if (webView.chromeWindow && webView.foreground) {
+                    webView.chromeWindow.raise()
+                }
             }
         }
     }
@@ -324,6 +327,7 @@ Page {
 
             webView.grabActivePage()
             if (!webView.tabModel.activateTab(url)) {
+                webView.clearSelection()
                 // Open new tab with empty title
                 webView.tabModel.newTab(url, "")
                 overlay.animator.showChrome(true)

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -63,6 +63,12 @@ WebContainer {
         }
     }
 
+    function clearSelection() {
+        if (contentItem) {
+            contentItem.clearSelection()
+        }
+    }
+
     function sendAsyncMessage(name, data) {
         if (!contentItem) {
             return


### PR DESCRIPTION
This commit adds a clearSelection wrapper to the WebView that can
called whenever text selection needs to be cleared.

Text selection is also cleared when BrowserPage becomes inactive.