### PR TITLE
[sailfish-browser] Move libraries from QMAKE_LFAGS to LIBS. Contributes to JB#38751

### DIFF
--- a/tests/auto/test_common.pri
+++ b/tests/auto/test_common.pri
@@ -12,7 +12,7 @@ BROWSERSRCDIR = $$SRCDIR/browser
 CONFIG(gcov) {
     message("GCOV instrumentalization enabled")
     QMAKE_CXXFLAGS += -fprofile-arcs -ftest-coverage -O0
-    QMAKE_LFLAGS += -lgcov -coverage
+    LIBS += -lgcov -coverage
 }
 
 # install the test

--- a/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.pro
+++ b/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.pro
@@ -1,7 +1,5 @@
 TARGET = tst_declarativehistorymodel
 
-QMAKE_LFLAGS += -lgtest -lgmock
-
 QT += quick sql
 
 include(../test_common.pri)
@@ -12,3 +10,5 @@ include(../../../common/paths.pri)
 include(../../../src/history/history.pri)
 
 SOURCES += tst_declarativehistorymodel.cpp
+
+LIBS += -lgtest -lgmock

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
@@ -2,8 +2,6 @@ TARGET = tst_declarativewebcontainer
 
 CONFIG += link_pkgconfig
 
-QMAKE_LFLAGS += -lgtest -lgmock
-
 PKGCONFIG += mlite5 nemotransferengine-qt5
 
 QT += quick qml concurrent sql gui-private
@@ -26,3 +24,5 @@ SOURCES += tst_declarativewebcontainer.cpp
 
 # Avoid inclusion of qtmozembed headers in devel environment
 INCLUDEPATH -= $$absolute_path(../../../../qtmozembed/src)
+
+LIBS += -lgtest -lgmock

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.pro
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.pro
@@ -1,7 +1,5 @@
 TARGET = tst_persistenttabmodel
 
-QMAKE_LFLAGS += -lgtest -lgmock
-
 QT += qml sql
 
 include(../test_common.pri)
@@ -12,3 +10,5 @@ include(../../../common/paths.pri)
 include(../../../src/history/history.pri)
 
 SOURCES += tst_persistenttabmodel.cpp
+
+LIBS += -lgtest -lgmock

--- a/tests/auto/tst_webpagefactory/tst_webpagefactory.pro
+++ b/tests/auto/tst_webpagefactory/tst_webpagefactory.pro
@@ -2,8 +2,6 @@ TARGET = tst_webpagefactory
 
 QT += qml quick sql concurrent
 
-QMAKE_LFLAGS += -lgtest -lgmock
-
 include(../mocks/declarativewebcontainer/declarativewebcontainer_mock.pri)
 include(../mocks/declarativewebpage/declarativewebpage_mock.pri)
 
@@ -13,3 +11,5 @@ include(../../../src/storage/storage.pri)
 include(../../../src/factories/factories.pri)
 
 SOURCES += tst_webpagefactory.cpp
+
+LIBS += -lgtest -lgmock

--- a/tests/auto/tst_webpages/tst_webpages.pro
+++ b/tests/auto/tst_webpages/tst_webpages.pro
@@ -6,8 +6,6 @@ PKGCONFIG += mlite5
 
 QT += qml quick concurrent sql gui-private
 
-QMAKE_LFLAGS += -lgtest -lgmock
-
 include(../mocks/webengine/webengine.pri)
 include(../mocks/qmozcontext/qmozcontext.pri)
 include(../mocks/qmozwindow/qmozwindow.pri)
@@ -21,6 +19,8 @@ include(../test_common.pri)
 include(../../../common/paths.pri)
 include(../../../src/core/core.pri)
 include(../../../src/history/history.pri)
+
+LIBS += -lgtest -lgmock
 
 SOURCES += tst_webpages.cpp
 

--- a/tests/auto/tst_webutils/tst_webutils.pro
+++ b/tests/auto/tst_webutils/tst_webutils.pro
@@ -1,12 +1,14 @@
 TARGET = tst_webutils
 CONFIG += link_pkgconfig
-QMAKE_LFLAGS += -lgtest -lgmock
+
 PKGCONFIG += mlite5
 
 include(../mocks/webengine/webengine.pri)
 include(../test_common.pri)
 include(../../../common/opensearchconfigs.pri)
 include(../../../common/paths.pri)
+
+LIBS += -lgtest -lgmock
 
 INCLUDEPATH += $$SRCDIR \
     $$BROWSERSRCDIR


### PR DESCRIPTION
I couldn't determine from the git history why there would be libraries in LFLAGS. As is a strict left-to-right resolving linker fails with:

    [  344s] g++ -lgtest -lgmock -Wl,-O1 -o tst_declarativehistorymodel testobject.o declarativewebpage.o declarativewebcontainer.o browserpaths.o dbmanager.o dbworker.o link.o tab.o declarativetabmodel.o persistenttabmodel.o privatetabmodel.o linkvalidator.o declarativehistorymodel.o tst_declarativehistorymodel.o moc_testobject.o moc_declarativewebpage.o moc_declarativewebcontainer.o moc_dbmanager.o moc_dbworker.o moc_declarativetabmodel.o moc_persistenttabmodel.o moc_privatetabmodel.o moc_declarativehistorymodel.o   -lQt5Quick -lQt5Gui -lQt5Qml -lQt5Network -lQt5Sql -lQt5Test -lQt5Core -lGLESv2 -lpthread 
    [  345s] declarativewebcontainer.o: In function `FunctionMockerBase':
    [  345s] /usr/include/gmock/gmock-spec-builders.h:1407: undefined reference to `testing::internal::UntypedFunctionMockerBase::UntypedFunctionMockerBase()'
    [  345s] /usr/include/gmock/gmock-spec-builders.h:1407: undefined reference to `testing::internal::UntypedFunctionMockerBase::UntypedFunctionMockerBase()'
    [  345s] declarativewebcontainer.o: In function `DefaultPrintTo<DeclarativeWebPage>':
    [  345s] /usr/include/gtest/gtest-printers.h:314: undefined reference to `testing::internal::IsTrue(bool)'
    [  345s] declarativewebcontainer.o: In function `testing::internal::MutexBase::Unlock()':
    [  345s] /usr/include/gtest/internal/gtest-port.h:1352: undefined reference to `testing::internal::GTestLog::GTestLog(testing::internal::GTestLogSeverity, char const*, int)'
    [  345s] /usr/include/gtest/internal/gtest-port.h:1352: undefined reference to `testing::internal::GTestLog::~GTestLog()'

Note how `-lgtest -lgmock` is inserted inbetween g++ and the -Wl,-O1 linker flag, rather than grouped with the other libraries.
If there is a good reason for this I don't see it, it looks just plain wrong.
