### PR TITLE
[sailfish-browser] Write rendering preferences to prefs.js. Contributes to JB#39851

### DIFF
--- a/data/prefs.js
+++ b/data/prefs.js
@@ -1,1 +1,4 @@
 user_pref("general.useragent.updates.enabled", true);
+user_pref("gfx.compositor.external-window", true);
+user_pref("gfx.compositor.clear-context", false);
+user_pref("embedlite.compositor.external_gl_context", true);


### PR DESCRIPTION
This makes it sure that preferences are available for the Gecko compositor
thread when it requests gl context.