### PR TITLE
[browser] Improve local file handling when opening a local externally. Contributes to JB#40671

### DIFF
--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -68,9 +68,9 @@ void Browser::load()
     const QStringList arguments = qGuiApp->arguments();
     if (!arguments.contains(QStringLiteral("-prestart"))) {
         if (arguments.count() > 1 && (arguments.last() != QStringLiteral("-debugMode"))) {
-            emit DeclarativeWebUtils::instance()->openUrlRequested(arguments.last());
+            DeclarativeWebUtils::instance()->openUrl(arguments.last());
         } else if (!DeclarativeWebUtils::instance()->firstUseDone()) {
-            emit DeclarativeWebUtils::instance()->openUrlRequested("");
+            DeclarativeWebUtils::instance()->openUrl("");
         }
     }
 }
@@ -89,7 +89,7 @@ void Browser::openUrl(const QString &url)
 {
     Q_D(Browser);
     d->closeEventFilter->cancelStopApplication();
-    emit DeclarativeWebUtils::instance()->openUrlRequested(url);
+    DeclarativeWebUtils::instance()->openUrl(url);
 }
 
 void Browser::openNewTabView()

--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -92,6 +92,30 @@ void DeclarativeWebUtils::handleDumpMemoryInfoRequest(QString fileName)
     }
 }
 
+void DeclarativeWebUtils::openUrl(QString url)
+{
+
+    QFileInfo fileInfo(url);
+    QUrl targetUrl(url);
+
+    if (targetUrl.scheme().isEmpty()) {
+        QUrl tmpUrl;
+        if (fileInfo.isAbsolute()) {
+            tmpUrl = QUrl::fromLocalFile(url);
+        } else {
+            QUrl baseUrl = QUrl::fromLocalFile(QDir::currentPath() + QDir::separator());
+            tmpUrl = baseUrl.resolved(url);
+        }
+
+        if (QFileInfo::exists(tmpUrl.path())) {
+            targetUrl = tmpUrl;
+        }
+    }
+
+    url = targetUrl.toEncoded();
+    emit openUrlRequested(url);
+}
+
 void DeclarativeWebUtils::updateWebEngineSettings()
 {
     SailfishOS::WebEngineSettings *webEngineSettings = SailfishOS::WebEngineSettings::instance();

--- a/src/browser/declarativewebutils.h
+++ b/src/browser/declarativewebutils.h
@@ -42,6 +42,7 @@ public slots:
     QString homePage() const;
     void clearStartupCacheIfNeeded();
     void handleDumpMemoryInfoRequest(QString fileName);
+    void openUrl(QString url);
 
 signals:
     void homePageChanged();


### PR DESCRIPTION
Unknown mime type triggers still misleading download notification even though
the file is already in the file system.