### PR TITLE
[browser] Fix Qt 5.9 compatibility issues. Contributes to JB#42592

### DIFF
--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -598,10 +598,10 @@ bool DeclarativeWebContainer::eventFilter(QObject *obj, QEvent *event)
 
 bool DeclarativeWebContainer::event(QEvent *event)
 {
-    QPlatformWindow *windowHandle;
-    if (event->type() == QEvent::PlatformSurface
+    if (QPlatformWindow *windowHandle = event->type() == QEvent::PlatformSurface
                 && static_cast<QPlatformSurfaceEvent *>(event)->surfaceEventType() == QPlatformSurfaceEvent::SurfaceCreated
-                && (windowHandle = handle())) {
+            ? handle()
+            : nullptr) {
         QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
         native->setWindowProperty(windowHandle, QStringLiteral("BACKGROUND_VISIBLE"), false);
         native->setWindowProperty(windowHandle, QStringLiteral("HAS_CHILD_WINDOWS"), true);

--- a/src/core/inputregion.cpp
+++ b/src/core/inputregion.cpp
@@ -35,9 +35,13 @@ void InputRegionPrivate::update()
     q->killTimer(updateTimerId);
     updateTimerId = 0;
 
-    if (window && window->handle()) {
-        QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
-        native->setWindowProperty(window->handle(), QLatin1String("MOUSE_REGION"), QVariant(QRegion(x, y, width, height)));
+    if (window) {
+        QRegion mask(x, y, width, height);
+        window->setMask(mask);
+        if (window->handle()) {
+            QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
+            native->setWindowProperty(window->handle(), QLatin1String("MOUSE_REGION"), mask);
+        }
     }
 }
 


### PR DESCRIPTION
This might be take it or leave it stuff in the end. I was seeing a crash in the DeclarativeWebContainer code but I can't see anything actually wrong with the original version so its possible that despite having been rebuilt in OBS I was pulling a stale version and the fix was that I had a guaranteed build against Qt 5.9.

Likewise, the MOUSE_REGION window property would ideally be deprecated since its almost functionally identical to the window mask. The problem as it turns out is its not possible to create a QRegion from a rectangle with a 0 width or height and an empty QRegion is interpreted as an infinite region and all touch events to the web view are blocked when the crome is hidden. Ideally we'd hide the chrome surface too in that circumstance but that's likely to have knock on affects.