### PR TITLE
Lazy load toolbar features to improve launch performance

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -28,7 +28,6 @@ Page {
     property Component tabPageComponent
 
     property alias tabs: webView.tabModel
-    property alias history: historyModel
     property alias viewLoading: webView.loading
     property alias url: webView.url
     property alias title: webView.title
@@ -108,10 +107,6 @@ Page {
                                    : "white"
 
         onApplyContentOrientation: webView.applyContentOrientation(browserPage.orientation)
-    }
-
-    HistoryModel {
-        id: historyModel
     }
 
     Private.VirtualKeyboardObserver {
@@ -270,7 +265,6 @@ Page {
 
         active: browserPage.status == PageStatus.Active
         webView: webView
-        historyModel: historyModel
         browserPage: browserPage
 
         onEnteringNewTabUrlChanged: window.opaqueBackground = webView.tabModel.waitingForNewTab || enteringNewTabUrl

--- a/src/pages/components/FavoriteGrid.qml
+++ b/src/pages/components/FavoriteGrid.qml
@@ -13,39 +13,32 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Browser 1.0
 
-SilicaGridView {
-    id: favoriteGrid
+Loader {
+    id: root
 
-    readonly property real pageHeight: Math.ceil(browserPage.height + pageStack.panelSize)
-
-    readonly property Item contextMenu: currentItem ? currentItem._menuItem : null
-    readonly property bool contextMenuActive: contextMenu && contextMenu.active
-
-    // Figure out which delegates need to be moved down to make room
-    // for the context menu when it's open.
-    readonly property int minOffsetIndex: contextMenu ? currentIndex - (currentIndex % columns) + columns : 0
-    readonly property int yOffset: contextMenu ? contextMenu.height : 0
-
-    readonly property int rows: Math.floor(pageHeight / minimumCellHeight)
-    readonly property int columns: Math.floor(browserPage.width / minimumCellWidth)
-
-    readonly property int horizontalMargin: largeScreen ? 6 * Theme.paddingLarge : Theme._homePageMargin
-    readonly property int initialCellWidth: (browserPage.width - 2*horizontalMargin) / columns
-
-    // The multipliers below for Large screens are magic. They look good on Jolla tablet.
-    readonly property real minimumCellWidth: largeScreen ? Theme.itemSizeExtraLarge * 1.6 : Theme.itemSizeExtraLarge
-    // phone reference row height: 960 / 6
-    readonly property real minimumCellHeight: largeScreen ? Theme.itemSizeExtraLarge * 1.6 : Theme.pixelRatio * 160
+    property Component header
+    property bool showFavorites
+    property QtObject model
+    readonly property real contentY: item ? item.contentY : 0
+    readonly property Item contextMenu: item ? item.contextMenu : null
+    readonly property bool moving: item && item.moving
+    readonly property int count: item ? item.count : 0
 
     signal load(string url, string title)
     signal newTab(string url, string title)
     signal share(string url, string title)
 
+    function positionViewAtBeginning() {
+        if (item) {
+            item.positionViewAtBeginning()
+        }
+    }
+
     function fetchAndSaveBookmark() {
         var webPage = webView && webView.contentItem
         if (webPage) {
             // Fetcher itself does async fetching. No need to create this asynchronously.
-            var fetcher = iconFetcher.createObject(favoriteGrid,
+            var fetcher = iconFetcher.createObject(root,
                                                    {
                                                        "url": webPage.url,
                                                        "title": webPage.title,
@@ -55,103 +48,159 @@ SilicaGridView {
         }
     }
 
-    width: cellWidth * columns
-    currentIndex: -1
-    anchors.horizontalCenter: parent.horizontalCenter
-    cellWidth: Math.floor(initialCellWidth + (initialCellWidth - Theme.iconSizeLauncher) / (columns - 1))
-    cellHeight: Math.round(pageHeight / rows)
+    onActiveChanged: if (active) active = true // remove binding
+    active: showFavorites
+    asynchronous: true
 
-    displaced: Transition { NumberAnimation { properties: "x,y"; easing.type: Easing.InOutQuad; duration: 200 } }
-    cacheBuffer: cellHeight * 2
+    sourceComponent: SilicaGridView {
+        id: favoriteGrid
 
-    onVisibleChanged: {
-        if (!visible && contextMenuActive) {
-            contextMenu.hide()
-        }
-    }
+        readonly property real pageHeight: Math.ceil(browserPage.height + pageStack.panelSize)
 
-    delegate: ListItem {
-        id: container
+        readonly property Item contextMenu: currentItem ? currentItem._menuItem : null
+        readonly property bool contextMenuActive: contextMenu && contextMenu.active
 
-        property real offsetY: largeScreen
-                 ? - (((-favoriteGrid.originY+container.contentHeight/2)%favoriteGrid.pageHeight)/favoriteGrid.pageHeight - 0.5) * (Theme.paddingLarge*4)
-                 : 0
+        // Figure out which delegates need to be moved down to make room
+        // for the context menu when it's open.
+        readonly property int minOffsetIndex: contextMenu ? currentIndex - (currentIndex % columns) + columns : 0
+        readonly property int yOffset: contextMenu ? contextMenu.height : 0
 
-        signal addToLauncher
-        signal editBookmark
+        readonly property int rows: Math.floor(pageHeight / minimumCellHeight)
+        readonly property int columns: Math.floor(browserPage.width / minimumCellWidth)
 
-        width: favoriteGrid.cellWidth
-        _showPress: false
-        contentHeight: favoriteGrid.cellHeight
-        menu: favoriteContextMenu
-        down: favoriteItem.down
-        openMenuOnPressAndHold: false
-        // Do not capture mouse events here. This ListItem only handles
-        // menu creation and destruction.
-        enabled: false
+        readonly property int horizontalMargin: largeScreen ? 6 * Theme.paddingLarge : Theme._homePageMargin
+        readonly property int initialCellWidth: (browserPage.width - 2*horizontalMargin) / columns
 
-        onAddToLauncher: {
-            // url, title, favicon
-            pageStack.push(addToLauncherDialog,
-                           {
-                               "url": url,
-                               "title": title,
-                               "icon": favicon
-                           })
-        }
+        // The multipliers below for Large screens are magic. They look good on Jolla tablet.
+        readonly property real minimumCellWidth: largeScreen ? Theme.itemSizeExtraLarge * 1.6 : Theme.itemSizeExtraLarge
+        // phone reference row height: 960 / 6
+        readonly property real minimumCellHeight: largeScreen ? Theme.itemSizeExtraLarge * 1.6 : Theme.pixelRatio * 160
 
-        onEditBookmark: {
-            // index, url, title
-            pageStack.push(editDialog,
-                           {
-                               "url": url,
-                               "title": title,
-                               "index": index,
-                           })
+        header: root.header
+        model: root.model
+        width: cellWidth * columns
+        currentIndex: -1
+        anchors.horizontalCenter: parent.horizontalCenter
+        _quickScrollRightMargin: -(browserPage.width - width) / 2
+        cellWidth: Math.floor(initialCellWidth + (initialCellWidth - Theme.iconSizeLauncher) / (columns - 1))
+        cellHeight: Math.round(pageHeight / rows)
+
+        displaced: Transition { NumberAnimation { properties: "x,y"; easing.type: Easing.InOutQuad; duration: 200 } }
+        cacheBuffer: cellHeight * 2
+
+        onVisibleChanged: {
+            if (!visible && contextMenuActive) {
+                contextMenu.hide()
+            }
         }
 
-        FavoriteItem {
-            id: favoriteItem
+        delegate: ListItem {
+            id: container
+
+            property real offsetY: largeScreen
+                                   ? - (((-favoriteGrid.originY+container.contentHeight/2)%favoriteGrid.pageHeight)/favoriteGrid.pageHeight - 0.5) * (Theme.paddingLarge*4)
+                                   : 0
+
+            signal addToLauncher
+            signal editBookmark
 
             width: favoriteGrid.cellWidth
-            height: favoriteGrid.cellHeight
-            y: index >= favoriteGrid.minOffsetIndex ? favoriteGrid.yOffset : 0.0
+            _showPress: false
+            contentHeight: favoriteGrid.cellHeight
+            menu: favoriteContextMenu
+            down: favoriteItem.down
+            openMenuOnPressAndHold: false
+            // Do not capture mouse events here. This ListItem only handles
+            // menu creation and destruction.
+            enabled: false
 
-            onClicked: favoriteGrid.load(model.url, model.title)
-            onShowContextMenuChanged: {
-                if (showContextMenu) {
-                    // Set currentIndex for grid to make minOffsetIndex calculation to work.
-                    favoriteGrid.currentIndex = model.index
-                    container.openMenu(
-                                {
-                                    "view": favoriteGrid,
-                                    "delegate": container,
-                                    "title": model.title,
-                                    "url": model.url,
-                                    "index": model.index
-                                })
-                }
+            onAddToLauncher: {
+                // url, title, favicon
+                pageStack.push(addToLauncherDialog,
+                               {
+                                   "url": url,
+                                   "title": title,
+                                   "icon": favicon
+                               })
             }
 
-            GridView.onAdd: AddAnimation { target: favoriteItem }
-            GridView.onRemove: animateRemoval()
+            onEditBookmark: {
+                // index, url, title
+                pageStack.push(editDialog,
+                               {
+                                   "url": url,
+                                   "title": title,
+                                   "index": index,
+                               })
+            }
+
+            FavoriteItem {
+                id: favoriteItem
+
+                width: favoriteGrid.cellWidth
+                height: favoriteGrid.cellHeight
+                y: index >= favoriteGrid.minOffsetIndex ? favoriteGrid.yOffset : 0.0
+
+                onClicked: root.load(model.url, model.title)
+                onShowContextMenuChanged: {
+                    if (showContextMenu) {
+                        // Set currentIndex for grid to make minOffsetIndex calculation to work.
+                        favoriteGrid.currentIndex = model.index
+                        container.openMenu(
+                                    {
+                                        "view": root,
+                                        "delegate": container,
+                                        "title": model.title,
+                                        "url": model.url,
+                                        "index": model.index
+                                    })
+                    }
+                }
+
+                GridView.onAdd: AddAnimation { target: favoriteItem }
+                GridView.onRemove: animateRemoval()
+            }
         }
-    }
 
-    FavoriteContextMenu {
-        id: favoriteContextMenu
-    }
+        FavoriteContextMenu {
+            id: favoriteContextMenu
+        }
 
-    VerticalScrollDecorator {
-        parent: favoriteGrid
-        anchors.rightMargin: -(browserPage.width - favoriteGrid.width) / 2
-        flickable: favoriteGrid
-    }
+        VerticalScrollDecorator {
+            parent: favoriteGrid
+            anchors.rightMargin: -(browserPage.width - favoriteGrid.width) / 2
+            flickable: favoriteGrid
+        }
 
-    Component {
-        id: desktopBookmarkWriter
-        DesktopBookmarkWriter {
-            onSaved: destroy()
+        Component {
+            id: desktopBookmarkWriter
+            DesktopBookmarkWriter {
+                onSaved: destroy()
+            }
+        }
+
+        Component {
+            id: editDialog
+            BookmarkEditDialog {
+                onAccepted: bookmarkModel.edit(index, editedUrl, editedTitle)
+            }
+        }
+
+        Component {
+            id: addToLauncherDialog
+            BookmarkEditDialog {
+                property string icon
+                property var bookmarkWriter
+
+                //: Title of the "Add to App Grid" dialog.
+                //% "Add to App Grid"
+                title: qsTrId("sailfish_browser-he-add_bookmark_to_launcher")
+                canAccept: editedUrl !== "" && editedTitle !== ""
+                onAccepted: {
+                    bookmarkWriter = desktopBookmarkWriter.createObject(favoriteGrid)
+                    bookmarkWriter.save(editedUrl, editedTitle, icon)
+                }
+            }
         }
     }
 
@@ -196,30 +245,6 @@ SilicaGridView {
                 // Add bookmark immediately with the defaultIcon. Update the favorite
                 // asynchronously.
                 bookmarkModel.add(url, title || url, defaultIcon, true)
-            }
-        }
-    }
-
-    Component {
-        id: editDialog
-        BookmarkEditDialog {
-            onAccepted: bookmarkModel.edit(index, editedUrl, editedTitle)
-        }
-    }
-
-    Component {
-        id: addToLauncherDialog
-        BookmarkEditDialog {
-            property string icon
-            property var bookmarkWriter
-
-            //: Title of the "Add to App Grid" dialog.
-            //% "Add to App Grid"
-            title: qsTrId("sailfish_browser-he-add_bookmark_to_launcher")
-            canAccept: editedUrl !== "" && editedTitle !== ""
-            onAccepted: {
-                bookmarkWriter = desktopBookmarkWriter.createObject(favoriteGrid)
-                bookmarkWriter.save(editedUrl, editedTitle, icon)
             }
         }
     }

--- a/src/pages/components/HistoryList.qml
+++ b/src/pages/components/HistoryList.qml
@@ -77,7 +77,7 @@ SilicaListView {
     ViewPlaceholder {
         x: (view.width - width) / 2
         y: view.originY + (view.height - height) / 2
-        enabled: !history.count
+        enabled: !view.count
 
         //: Shown as placeholder in history list when entered text or url did not match to history.
         //% "Press enter to open"

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -21,7 +21,6 @@ Background {
     property bool active
     property QtObject webView
     property Item browserPage
-    property alias historyModel: historyList.model
     property alias toolBar: toolBar
     property alias progressBar: progressBar
     property alias animator: overlayAnimator
@@ -462,16 +461,23 @@ Background {
                     height: searchField.height
                 }
 
-                search: searchField.text
+                model: historyModelLoader.item
+                search: !!model ? searchField.text : ""
                 opacity: historyContainer.showFavorites || toolBar.opacity > 0.9 ? 0.0 : 1.0
                 enabled: overlayAnimator.atTop
                 visible: !overlayAnimator.atBottom && !toolBar.findInPageActive && !historyContainer.showFavorites
 
                 onMovingChanged: if (moving) historyList.focus = true
-                onSearchChanged: if (search !== webView.url) historyModel.search(search)
+                onSearchChanged: if (search !== webView.url) model.search(search)
                 onLoad: overlay.loadPage(url, title)
 
                 Behavior on opacity { FadeAnimator {} }
+                Loader {
+                    id: historyModelLoader
+                    active: searchField.text.length > 0 && searchField.text !== webView.url
+                    onActiveChanged: if (active) active = true // remove binding
+                    sourceComponent: HistoryModel {}
+                }
             }
 
             Browser.FavoriteGrid {

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -477,11 +477,11 @@ Background {
             Browser.FavoriteGrid {
                 id: favoriteGrid
 
+                showFavorites: historyContainer.showFavorites
                 height: historyList.height
-                opacity: historyContainer.showFavorites && toolBar.opacity < 0.9 ? 1.0 : 0.0
+                opacity: showFavorites && toolBar.opacity < 0.9 && count > 0 ? 1.0 : 0.0
                 enabled: overlayAnimator.atTop
-                visible: !overlayAnimator.atBottom && !toolBar.findInPageActive && historyContainer.showFavorites
-                _quickScrollRightMargin: -(browserPage.width - width) / 2
+                visible: !overlayAnimator.atBottom && !toolBar.findInPageActive && showFavorites
 
                 header: Item {
                     width: parent.width

--- a/src/pages/components/ToolBar.qml
+++ b/src/pages/components/ToolBar.qml
@@ -79,13 +79,10 @@ Column {
 
     SecondaryBar {
         id: secondaryBar
-        visible: opacity > 0.0 || height > 0.0
-        opacity: secondaryToolsActive ? 1.0 : 0.0
-        height: secondaryToolsHeight
+        toolsActive: toolBarRow.secondaryToolsActive
         horizontalOffset: toolBarRow.horizontalOffset
         iconWidth: toolBarRow.iconWidth
-
-        Behavior on opacity { FadeAnimation {} }
+        height: secondaryToolsHeight
     }
 
     Row {


### PR DESCRIPTION
Most notable savings I would have gotten if I had postponed the component compilations too, but that is pointless since Qt 5.9 compile caching is coming.

Postpones few hundred of milliseconds of view delegate creations, which are already asynchronous so doesn't improve launch time that much (maybe 40-80ms), but also frees bandwidth for the initial page construction.

During system load introduces some flicker as you can sometimes see the favorite grid item icons appearing in steps, but the layout stays so I think it is ok.
