### PR TITLE
[browser] Color tab item controls always light on dark. Fixes JB#43267

### DIFF
--- a/src/pages/components/TabItem.qml
+++ b/src/pages/components/TabItem.qml
@@ -73,7 +73,8 @@ BackgroundItem {
                 left: parent.left
                 bottom: parent.bottom
             }
-            highlighted: down || activeTab
+            highlighted: true
+            icon.color: down || activeTab ? Theme.highlightColor : Theme.lightPrimaryColor
             icon.source: "image://theme/icon-m-tab-close"
             onClicked: {
                 // Break binding, so that texture size would not change when
@@ -102,7 +103,7 @@ BackgroundItem {
 
             text: title || WebUtils.displayableUrl(url)
             truncationMode: TruncationMode.Fade
-            color: down || activeTab ? Theme.highlightColor : Theme.primaryColor
+            color: down || activeTab ? Theme.highlightColor : Theme.lightPrimaryColor
         }
     ]
 }


### PR DESCRIPTION
Web pages are more commonly light than dark so always dark controls
suit these better. Alternative whitening gradient on top would
also act quite differently.

@rainemak  @jpetrell 