### PR TITLE
[browser] Add baseXOffset for FavoriteGrid's context menu. Fixes JB#43519

### DIFF
--- a/src/pages/components/FavoriteContextMenu.qml
+++ b/src/pages/components/FavoriteContextMenu.qml
@@ -21,6 +21,8 @@ Component {
         property string url
         property int index
 
+        baseXOffset: _flickable ? (width - _flickable.width) / 2 : 0
+
         // FavoriteGrid doesn't fill the entire page thus set width to FavoriteGrid's parent
         width: _flickable !== null ? _flickable.parent.width : (parent ? parent.width : 0)
 


### PR DESCRIPTION
On full hd portrait difference is 1048 vs 1080 and now the context
menu on favorite grid covers the full screen width.