### PR TITLE
[oneshot] Do not use perl regex. Contributes to JB#40843

### DIFF
--- a/oneshot.d/browser-update-default-data
+++ b/oneshot.d/browser-update-default-data
@@ -8,8 +8,7 @@ fi
 
 if [ ! -f "$MOZEMBED_DIR/ua-update.json" -o ! -s "$MOZEMBED_DIR/ua-update.json" ]; then
     # Remove lines starting with a comment.
-    # Using Perl regexp so that this works on device.
-    grep -vP  ^\\s*// $BROWSER_DATA_DIR/ua-update.json.in > "$MOZEMBED_DIR/ua-update.json"
+    sed  '\|^\s*//|d' $BROWSER_DATA_DIR/ua-update.json.in > "$MOZEMBED_DIR/ua-update.json"
 fi
 
 if [ ! -f "$MOZEMBED_DIR/prefs.js" ]; then


### PR DESCRIPTION
Busybox does not support perl regex on grep. We want to be compatible
with busybox as well as GNU grep.