### PR TITLE
[UA] Workaround user-agent for twitter.com load failure. JB#46293

### DIFF
--- a/data/ua/45.9.1/ua-update.json
+++ b/data/ua/45.9.1/ua-update.json
@@ -62,5 +62,6 @@
   "google.cz": "Linux#Maemo",
   "google.sk": "Linux#Maemo",
   "google.ch": "Linux#Maemo",
-  "google.at": "Linux#Maemo"
+  "google.at": "Linux#Maemo",
+  "twitter.com": "Mozilla/5.0 (Android 8.1.0; U; Sailfish 3.0; Mobile; rv:45.0) Gecko/45.0 SailfishBrowser/1.0"
 }


### PR DESCRIPTION
The Firefox version of Twitter is currently failing to load with a 'Sorry, We did something wrong' error. This change drops back to the old mobile site, and gives a warning, but at least shows the content.