### PR TITLE
[sailfish-browser] Use keepalive directly. Contributes to JB#47022

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -50,7 +50,7 @@ Requires: qt5-qtgraphicaleffects
 Requires: nemo-qml-plugin-contextkit-qt5
 Requires: nemo-qml-plugin-connectivity
 Requires: nemo-qml-plugin-policy-qt5 >= 0.0.4
-Requires: sailfish-components-media-qt5
+Requires: libkeepalive >= 1.7.0
 Requires: sailfish-components-pickers-qt5 >= 0.1.7
 Requires: nemo-qml-plugin-notifications-qt5 >= 1.0.12
 

--- a/src/pages/components/ResourceController.qml
+++ b/src/pages/components/ResourceController.qml
@@ -11,7 +11,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import QtQuick 2.0
-import Sailfish.Media 1.0
+import Nemo.KeepAlive 1.2
 import Sailfish.WebEngine 1.0
 import org.freedesktop.contextkit 1.0
 import org.nemomobile.policy 1.0
@@ -112,9 +112,9 @@ Item {
         }
     }
 
-    ScreenBlank {
-        // This is stopping ScreenBlank timer.
-        suspend: videoActive
+    DisplayBlanking {
+        // This is stopping screen blank timer.
+        preventBlanking: videoActive
     }
 
     Timer {


### PR DESCRIPTION
Better api now, no need for ScreenBlank wrapper anymore.

@rainemak @spiiroin