### PR TITLE
Display SSL/TLS security info to the user

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -1,7 +1,8 @@
 %global min_xulrunner_version 45.8.1.1
-%global min_qtmozembed_version 1.14.0
+%global min_qtmozembed_version 1.14.5
 %global min_embedlite_components_version 1.20.0
 %global min_sailfishwebengine_version 0.2.0
+%global min_systemsettings_version 0.5.25
 
 Name:       sailfish-browser
 
@@ -18,6 +19,7 @@ BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(qt5embedwidget) >= %{min_qtmozembed_version}
+BuildRequires:  pkgconfig(systemsettings) >= %{min_systemsettings_version}
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Concurrent)
 BuildRequires:  pkgconfig(Qt5Sql)
@@ -53,6 +55,7 @@ Requires: nemo-qml-plugin-policy-qt5 >= 0.0.4
 Requires: libkeepalive >= 1.7.0
 Requires: sailfish-components-pickers-qt5 >= 0.1.7
 Requires: nemo-qml-plugin-notifications-qt5 >= 1.0.12
+Requires: nemo-qml-plugin-systemsettings >= %{min_systemsettings_version}
 
 %{_oneshot_requires_post}
 

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -1,13 +1,11 @@
-/****************************************************************************
-**
-** Copyright (C) 2013 Jolla Ltd.
-** Contact: Raine Makelainen <raine.makelainen@jollamobile.com>
-**
-****************************************************************************/
-
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/*
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 #include "declarativewebpage.h"
 #include "declarativewebcontainer.h"
@@ -27,6 +25,7 @@
 #include <QOpenGLFunctions_ES2>
 #include <QGuiApplication>
 #include <qmozwindow.h>
+#include <qmozsecurity.h>
 
 #include <qpa/qplatformnativeinterface.h>
 
@@ -171,6 +170,8 @@ void DeclarativeWebContainer::setWebPage(DeclarativeWebPage *webPage, bool trigg
                     this, &DeclarativeWebContainer::updateLoadProgress, Qt::UniqueConnection);
             connect(m_webPage.data(), &DeclarativeWebPage::contentOrientationChanged,
                     this, &DeclarativeWebContainer::handleContentOrientationChanged, Qt::UniqueConnection);
+            connect(m_webPage.data(), &DeclarativeWebPage::securityChanged,
+                    this, &DeclarativeWebContainer::securityChanged, Qt::UniqueConnection);
 
             // NB: these signals are not disconnected upon setting current m_webPage.
             connect(m_webPage.data(), &DeclarativeWebPage::urlChanged,
@@ -197,6 +198,7 @@ void DeclarativeWebContainer::setWebPage(DeclarativeWebPage *webPage, bool trigg
         emit canGoForwardChanged();
         emit urlChanged();
         emit titleChanged();
+        emit securityChanged();
 
         setLoadProgress(m_webPage ? m_webPage->loadProgress() : 0);
     }
@@ -399,6 +401,11 @@ void DeclarativeWebContainer::setReadyToPaint(bool ready)
 Qt::ScreenOrientation DeclarativeWebContainer::pendingWebContentOrientation() const
 {
     return m_mozWindow ? m_mozWindow->pendingOrientation() : Qt::PortraitOrientation;
+}
+
+QMozSecurity *DeclarativeWebContainer::security() const
+{
+    return m_webPage ? m_webPage->security() : nullptr;
 }
 
 int DeclarativeWebContainer::tabId() const

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -1,13 +1,11 @@
-/****************************************************************************
-**
-** Copyright (C) 2013 Jolla Ltd.
-** Contact: Raine Makelainen <raine.makelainen@jollamobile.com>
-**
-****************************************************************************/
-
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/*
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 #ifndef DECLARATIVEWEBCONTAINER_H
 #define DECLARATIVEWEBCONTAINER_H
@@ -15,6 +13,7 @@
 #include "settingmanager.h"
 
 #include <qmozcontext.h>
+#include <qmozsecurity.h>
 #include <QtGui/QWindow>
 #include <QtGui/QOpenGLFunctions>
 #include <QPointer>
@@ -75,6 +74,8 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
 
     Q_PROPERTY(Qt::ScreenOrientation pendingWebContentOrientation READ pendingWebContentOrientation NOTIFY pendingWebContentOrientationChanged FINAL)
 
+    Q_PROPERTY(QMozSecurity *security READ security NOTIFY securityChanged)
+
 public:
     DeclarativeWebContainer(QWindow *parent = 0);
     ~DeclarativeWebContainer();
@@ -122,6 +123,8 @@ public:
     void setReadyToPaint(bool ready);
 
     Qt::ScreenOrientation pendingWebContentOrientation() const;
+
+    QMozSecurity *security() const;
 
     int tabId() const;
     QString title() const;
@@ -184,6 +187,7 @@ signals:
 
     void pendingWebContentOrientationChanged();
     void webContentOrientationChanged(Qt::ScreenOrientation orientation);
+    void securityChanged();
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);

--- a/src/pages/components/CertificateInfo.qml
+++ b/src/pages/components/CertificateInfo.qml
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import Sailfish.Silica.private 1.0 as Private
+import Sailfish.Browser 1.0
+import Qt5Mozilla 1.0
+import "." as Browser
+
+SilicaFlickable {
+    id: root
+    property QMozSecurity security
+    readonly property bool _validCert: security && security.subjectDisplayName.length > 0
+    contentHeight: certInfoColumn.height + certInfoColumn.y + showMore.height + calculatedHeight + 2 * Theme.paddingSmall
+    clip: contentHeight > height
+    property alias buttonHeight: showMore.height
+    readonly property bool _secure: security && security.allGood
+    property bool portrait
+    property bool initialized
+    property int implicitKeyWidth: Theme.itemSizeExtraLarge
+    property int keyWidth: implicitKeyWidth
+    property int maximumKeyWidth: width / 2
+    property int calculatedHeight
+
+    signal showCertDetail
+    signal closeCertInfo
+
+    function updateKeyWidth() {
+        if (!initialized) return
+
+        var width = implicitKeyWidth
+        for (var i in keyValuePairs.children) {
+            var child = keyValuePairs.children[i]
+            if (child.keyLabel !== undefined) {
+                var childWidth = Math.ceil(child.keyLabel.implicitWidth)
+                if (childWidth > maximumKeyWidth) continue
+                width = Math.max(width, childWidth)
+            }
+        }
+        keyWidth = width
+
+        // Column won't layout until the next frame, so we have to calculate the height ourselves
+        calculatedHeight = 0
+        for (var i in keyValuePairs.children) {
+            var child = keyValuePairs.children[i]
+            if ((child.keyLabel !== undefined) && (child.value.length > 0)) {
+                calculatedHeight += child.height + Theme.paddingSmall
+            }
+        }
+        if (calculatedHeight > 0) {
+            calculatedHeight -= Theme.paddingSmall
+        }
+    }
+
+    Component.onCompleted: {
+        initialized = true // avoid unnecessary re-layouting during initialization
+        updateKeyWidth()
+    }
+
+    onSecurityChanged: {
+        // Jump back to the top
+        contentY = originY
+    }
+
+    onMaximumKeyWidthChanged: updateKeyWidth()
+
+    VerticalScrollDecorator {}
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: closeCertInfo()
+    }
+
+    Column {
+        id: certInfoColumn
+        spacing: Theme.paddingSmall
+        width: parent.width
+        y: Theme.paddingMedium
+        bottomPadding: showMore.enabled ? 0 : Theme.paddingLarge
+
+        Label {
+            width: parent.width - 2 * Theme.horizontalPageMargin
+            x: Theme.horizontalPageMargin
+            wrapMode: Text.Wrap
+            font.pixelSize: Theme.fontSizeLarge
+            color: _secure ? (palette.colorScheme === Theme.LightOnDark ? "#22ff22" : "#007700")
+                           : Theme.errorColor
+            text: {
+                if (_secure) {
+                    //: The SSL/TLS connection is good
+                    //% "Connection is secure"
+                    return qsTrId("sailfish_browser-la-cert_connection_secure")
+                }
+                //: Either no SSL/TLS is in use, or the SSL/TLS connection is broken in some way
+                //% "Connection is not secure"
+                return qsTrId("sailfish_browser-la-cert_connection_insecure")
+            }
+        }
+
+        Label {
+            width: parent.width - 2 * Theme.horizontalPageMargin
+            x: Theme.horizontalPageMargin
+            wrapMode: Text.Wrap
+            visible: text.length > 0
+
+            text: {
+                if (security) {
+                    if (security.certIsNull) {
+                        //% "The page does't offer any security"
+                        return qsTrId("sailfish_browser-la-cert_none")
+                    } else if (security.domainMismatch) {
+                        // "The website doesn't match the name on the security certificate"
+                        //: The domain in the TLS certificate and the domain connected to are not the same
+                        //% "This site may not be legitimate and any information you enter could be stolen by attackers"
+                        return qsTrId("sailfish_browser-la-cert_domain_mismatch")
+                    } else if (security.notValidAtThisTime) {
+                        //: The TLS certificate has expired or is not yet valid
+                        //% "The security certificate has expired or isn't valid yet"
+                        return qsTrId("sailfish_browser-la-cert_not_valid_at_this_time")
+                    } else if (security.usesWeakCrypto) {
+                        //: The TLS certificate is insecure because it uses weak encryption or hashing methods
+                        //% "The conection only provides weak security"
+                        return qsTrId("sailfish_browser-la-cert_weak_crypto")
+                    } else if (security.loadedMixedActiveContent) {
+                        //% "Some content on the page is transmitted insecurely"
+                        return qsTrId("sailfish_browser-la-cert_insecure_content_loaded")
+                    } else if (security.loadedMixedDisplayContent) {
+                        // Display the same message as for mixed content
+                        return qsTrId("sailfish_browser-la-cert_insecure_content_loaded")
+                    } else if (security.blockedMixedActiveContent) {
+                        //% "Parts of the page that are not secure have been blocked"
+                        return qsTrId("sailfish_browser-la-cert_content_active_blocked")
+                    } else if (security.blockedMixedDisplayContent) {
+                        //% "Parts of the page that are not secure have been blocked"
+                        return qsTrId("sailfish_browser-la-cert_content_display_blocked")
+                    }
+                }
+                return ""
+            }
+            color: Theme.errorColor
+            opacity: Theme.opacityHigh
+        }
+
+        SectionHeader {
+            //: Header separating out the main security info from the details
+            //% "Certificate"
+            text: qsTrId("sailfish_browser-sh-cert_details")
+            visible: security && !security.certIsNull
+        }
+    }
+
+    Column {
+        id: keyValuePairs
+        width: parent.width
+        spacing: Theme.paddingSmall
+        anchors {
+            top: certInfoColumn.bottom
+            topMargin: Theme.paddingSmall
+        }
+
+        onHeightChanged: calculatedHeight = height
+
+        CertificateLabel {
+            //: Label for the owner field of a TLS certificate
+            //% "Owner"
+            key: qsTrId("sailfish_browser-la-cert_owner")
+            value: security ? security.subjectOrganization : ""
+            valueColor: _secure ? palette.colorScheme === Theme.LightOnDark
+                                  ? "#22ff22" : "#007700" : Theme.secondaryHighlightColor
+            keyWidth: root.keyWidth
+        }
+
+        CertificateLabel {
+            //: Label for the subject field of a TLS certificate
+            //% "Website"
+            key: qsTrId("sailfish_browser-la-cert_subject")
+            value: security ? security.subjectDisplayName : ""
+            keyWidth: root.keyWidth
+        }
+
+        CertificateLabel {
+            //: Label for the issuer field of a TLS certificate
+            //% "Issuer"
+            key: qsTrId("sailfish_browser-la-cert_issuer")
+            value: security ? security.issuerDisplayName : ""
+            keyWidth: root.keyWidth
+        }
+
+        CertificateLabel {
+            //: Label for the TLS certificate validity period (dates)
+            //% "Valid"
+            key: qsTrId("sailfish_browser-la-cert_valid_dates")
+            value: insecure ? Format.formatDate(security.effectiveDate, Formatter.DateMedium)
+                            + " — "
+                            + Format.formatDate(security.expiryDate, Formatter.DateMedium)
+                          : ""
+            insecure: security && !security.certIsNull && security.notValidAtThisTime
+            keyWidth: root.keyWidth
+        }
+
+        CertificateLabel {
+            //: Label prefixing the status of whether tracking tech is being used on a page
+            //% "Tracking"
+            key: qsTrId("sailfish_browser-la-cert_tracking")
+            value: {
+                if (security) {
+                    if (security.loadedTrackingContent) {
+                        //% "The page includes items used to track your behaviour"
+                        return qsTrId("sailfish_browser-la-cert_tracking_content_loaded")
+                    } else if (security.blockedTrackingContent) {
+                        //% "Items used to track your behaviour have been blocked"
+                        return qsTrId("sailfish_browser-la-cert_tracking_content_blocked")
+                    }
+                }
+                return ""
+            }
+            insecure: security && security.loadedTrackingContent
+            keyWidth: root.keyWidth
+        }
+    }
+
+    BackgroundItem {
+        id: showMore
+        height: enabled ? portrait ? Theme.itemSizeSmall : Theme.itemSizeExtraSmall : 0
+        enabled: security && !security.certIsNull
+        visible: enabled
+        anchors {
+            top: keyValuePairs.bottom
+            topMargin: Theme.paddingSmall
+        }
+
+        onClicked: showCertDetail()
+
+        Private.ShowMoreButton {
+            x: Theme.horizontalPageMargin
+            width: parent.width - 2 * x
+            anchors.verticalCenter: parent.verticalCenter
+            highlighted: showMore.highlighted
+            enabled: false
+        }
+    }
+}

--- a/src/pages/components/CertificateLabel.qml
+++ b/src/pages/components/CertificateLabel.qml
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+
+Item {
+    property alias key: keyLabel.text
+    property alias value: valueLabel.text
+    property alias valueColor: valueLabel.color
+    property alias keyLabel: keyLabel
+    property int keyWidth
+    property bool _wrap: keyLabel.implicitWidth > keyWidth
+
+    property bool insecure
+    visible: value && value.length > 0
+    width: parent.width - 2 * Theme.horizontalPageMargin
+    x: Theme.horizontalPageMargin
+    height: _wrap ? keyLabel.height + valueLabel.height : Math.max(keyLabel.height, valueLabel.height)
+
+    Label {
+        id: keyLabel
+        color: Theme.highlightColor
+        width: keyWidth
+    }
+
+    Label {
+        id: valueLabel
+        anchors {
+            left: _wrap ? keyLabel.left : keyLabel.right
+            leftMargin: _wrap ? 0 : Theme.paddingMedium
+            top: _wrap ? keyLabel.bottom : keyLabel.top
+        }
+
+        width: _wrap ? parent.width : parent.width - keyLabel.width - Theme.paddingMedium
+        wrapMode: Text.Wrap
+        color: insecure ? Theme.errorColor : Theme.secondaryHighlightColor
+        opacity: insecure ? Theme.opacityHigh : 1.0
+    }
+}

--- a/src/pages/components/OverlayAnimator.qml
+++ b/src/pages/components/OverlayAnimator.qml
@@ -1,13 +1,11 @@
-/****************************************************************************
-**
-** Copyright (C) 2014 Jolla Ltd.
-** Contact: Raine Makelainen <raine.makelainen@jolla.com>
-**
-****************************************************************************/
-
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/*
+ * Copyright (c) 2014 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 import QtQuick 2.2
 
@@ -20,21 +18,25 @@ Item {
     property bool portrait
     property bool atTop
     property bool atBottom: true
-    property int transitionDuration: !_immediate ? 400 : 0
+    property int transitionDuration: !_immediate ? (state === _certOverlay ? proportionalDuration : 400) : 0
     property real openYPosition: portrait ? overlay.toolBar.toolsHeight : 0
 
     readonly property bool allowContentUse: state === _chromeVisible || state === _fullscreenWebPage || state === _doubleToolBar
     readonly property bool dragging: state === _draggingOverlay
     readonly property bool secondaryTools: state === _doubleToolBar
+    readonly property bool certOverlay: state === _certOverlay
 
     property bool _immediate
+    property bool _midPos
 
     readonly property string _fullscreenOverlay: "fullscreenOverlay"
     readonly property string _doubleToolBar: "doubleToolBar"
     readonly property string _chromeVisible: "chromeVisible"
     readonly property string _fullscreenWebPage: "fullscreenWebPage"
     readonly property string _draggingOverlay: "draggingOverlay"
+    readonly property string _certOverlay: "certOverlay"
     readonly property string _noOverlay: "noOverlay"
+    property int proportionalDuration: 400
 
     function showSecondaryTools() {
         updateState(_doubleToolBar)
@@ -46,6 +48,10 @@ Item {
 
     function showOverlay(immediate) {
         updateState(_fullscreenOverlay, immediate || false)
+    }
+
+    function showInfoOverlay(immediate) {
+        updateState(_certOverlay, immediate || false)
     }
 
     function drag() {
@@ -62,6 +68,18 @@ Item {
         if (newState !== _fullscreenWebPage) {
             overlay.visible = true
         }
+        if (state === _certOverlay) {
+            _midPos = true
+        }
+
+        // Update the animation time to suit the type of overlay
+        if ((newState !== _noOverlay) && (newState !== _chromeVisible)) {
+            if (newState === _certOverlay) {
+                proportionalDuration = 600 * (1.0 - (_infoHeight / webView.fullscreenHeight))
+            } else {
+                proportionalDuration = 400
+            }
+        }
 
         state = newState
     }
@@ -69,15 +87,17 @@ Item {
     state: _chromeVisible
     onStateChanged: {
         // Animation end changes to true state. Hence not like atTop = state !== _fullscreenOverlay
-        var wasAtMiddle = !atBottom && !atTop
+        var wasAtMiddle = (!atBottom && !atTop) || _midPos
         var goingUp = (atBottom || wasAtMiddle) && state === _fullscreenOverlay
-        var goingDown = (atTop || wasAtMiddle) && (state === _chromeVisible || state === _fullscreenWebPage || state === _doubleToolBar || state === _noOverlay || state == _draggingOverlay)
+        var goingDown = (atTop || wasAtMiddle) && (state === _chromeVisible || state === _fullscreenWebPage || state === _doubleToolBar || state === _noOverlay || state === _draggingOverlay || state === _certOverlay)
 
-        if (state !== _fullscreenOverlay) {
+        if ((state !== _fullscreenOverlay && state !== _certOverlay) || _midPos) {
             atTop = false
-        } if (state !== _chromeVisible && state !== _fullscreenWebPage && state !== _doubleToolBar) {
+        }
+        if ((state !== _chromeVisible && state !== _fullscreenWebPage && state !== _doubleToolBar) || _midPos) {
             atBottom = false
         }
+        _midPos = false
 
         direction = goingUp ? "upwards" : (goingDown ? "downwards" : "")
     }
@@ -137,7 +157,7 @@ Item {
             changes: [
                 PropertyChanges {
                     target: overlay
-                    y: openYPosition
+                    y: _fullHeight
                 }
             ]
         },
@@ -154,13 +174,23 @@ Item {
                     secondaryToolsHeight: overlay.toolBar.toolsHeight
                 }
             ]
+        },
+
+        State {
+            name: _certOverlay
+            changes: [
+                PropertyChanges {
+                    target: overlay
+                    y: _infoHeight
+                }
+            ]
         }
     ]
 
     transitions: [
         Transition {
             id: overlayTransition
-            to: "fullscreenWebPage,chromeVisible,loadProgressOverlay,fullscreenOverlay,noOverlay,doubleToolBar"
+            to: "fullscreenWebPage,chromeVisible,loadProgressOverlay,fullscreenOverlay,noOverlay,doubleToolBar,certOverlay"
 
             SequentialAnimation {
                 NumberAnimation { target: webView; property: "height"; duration: transitionDuration; easing.type: Easing.InOutQuad }
@@ -168,7 +198,7 @@ Item {
                     script: {
                         if (animator.state === _chromeVisible || animator.state === _fullscreenWebPage || animator.state === _doubleToolBar) {
                             atBottom = true
-                        } else if (animator.state === _fullscreenOverlay) {
+                        } else if (animator.state === _fullscreenOverlay || animator.state === _certOverlay) {
                             atTop = true
                         }
 
@@ -186,7 +216,7 @@ Item {
                 }
             }
             NumberAnimation { target: overlay; property: "y"; duration: transitionDuration; easing.type: Easing.InOutQuad }
-            NumberAnimation { target: overlay.toolBar; property: "secondaryToolsHeight"; duration: transitionDuration; easing.type: Easing.InOutQuad }
+            NumberAnimation { target: overlay.toolBar; property: "secondaryToolsHeight"; duration: transitionDuration; easing.type: Easing.InOutQuad }        
         }
         ,
         Transition {

--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -1,13 +1,11 @@
-/****************************************************************************
-**
-** Copyright (C) 2014 Jolla Ltd.
-** Contact: Raine Makelainen <raine.makelainen@jollamobile.com>
-**
-****************************************************************************/
-
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/*
+ * Copyright (c) 2014 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 #include "declarativewebpage.h"
 #include "declarativewebcontainer.h"
@@ -19,6 +17,7 @@
 #include <qmozwindow.h>
 #include <QGuiApplication>
 #include <QtConcurrent>
+#include <qmozsecurity.h>
 
 static const QString gFullScreenMessage("embed:fullscreenchanged");
 static const QString gDomContentLoadedMessage("chrome:contentloaded");
@@ -522,3 +521,4 @@ QDebug operator<<(QDebug dbg, const DeclarativeWebPage *page)
                   << ", active = " << page->active() << ", enabled = " << page->enabled() << ")";
     return dbg.space();
 }
+

--- a/src/qtmozembed/declarativewebpage.h
+++ b/src/qtmozembed/declarativewebpage.h
@@ -1,13 +1,11 @@
-/****************************************************************************
-**
-** Copyright (C) 2014 Jolla Ltd.
-** Contact: Raine Makelainen <raine.makelainen@jollamobile.com>
-**
-****************************************************************************/
-
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/*
+ * Copyright (c) 2014 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 #ifndef DECLARATIVEWEBPAGE_H
 #define DECLARATIVEWEBPAGE_H
@@ -18,6 +16,7 @@
 #include <QRgb>
 #include <qopenglwebpage.h>
 #include <qmozgrabresult.h>
+#include <qmozsecurity.h>
 
 #include "tab.h"
 
@@ -88,6 +87,7 @@ signals:
     void fullscreenHeightChanged();
     void toolbarHeightChanged();
     void virtualKeyboardMarginChanged();
+    void securityChanged();
 
 private slots:
     void setFullscreen(const bool fullscreen);
@@ -132,6 +132,7 @@ private:
     qreal m_virtualKeyboardMargin;
 
     int m_marginChangeThrottleTimer;
+    QMozSecurity m_security;
 };
 
 QDebug operator<<(QDebug, const DeclarativeWebPage *);

--- a/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
+++ b/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
@@ -1,18 +1,17 @@
-/****************************************************************************
-**
-** Copyright (C) 2015 Jolla Ltd.
-** Contact: Raine Makelainen <raine.makelainen@jolla.com>
-**
-****************************************************************************/
-
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/*
+ * Copyright (c) 2015 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 #ifndef DECLARATIVEWEBCONTAINER_H
 #define DECLARATIVEWEBCONTAINER_H
 
 #include <QObject>
+#include <qmozsecurity.h>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"

--- a/tests/auto/mocks/declarativewebpage/declarativewebpage.h
+++ b/tests/auto/mocks/declarativewebpage/declarativewebpage.h
@@ -1,13 +1,11 @@
-/****************************************************************************
-**
-** Copyright (C) 2015 Jolla Ltd.
-** Contact: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
-**
-****************************************************************************/
-
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/*
+ * Copyright (c) 2015 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 #ifndef DECLARATIVEWEBPAGE_H
 #define DECLARATIVEWEBPAGE_H
@@ -27,6 +25,7 @@
 #include "tab.h"
 
 class DeclarativeWebContainer;
+class QMozSecurity;
 
 class DeclarativeWebPage : public QObject
 {
@@ -94,6 +93,10 @@ public:
 
     MOCK_METHOD2(Q_INVOKABLE loadTab, void(const QString &newUrl, bool force));
 
+    MOCK_CONST_METHOD0(securityState, uint());
+    MOCK_CONST_METHOD0(securityStatus, QString());
+    MOCK_CONST_METHOD0(security, QMozSecurity *());
+
 signals:
     void canGoBackChanged();
     void canGoForwardChanged();
@@ -109,6 +112,7 @@ signals:
     void tabIdChanged();
     void urlChanged();
     void titleChanged();
+    void securityChanged(QString status, uint state);
     void forcedChromeChanged();
     void fullscreenChanged();
     void domContentLoadedChanged();

--- a/tests/auto/mocks/qmozsecurity/qmozsecurity.h
+++ b/tests/auto/mocks/qmozsecurity/qmozsecurity.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef qmozsecurity_h
+#define qmozsecurity_h
+
+#include <QObject>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+class QMozSecurity : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit QMozSecurity(QObject *parent = 0) : QObject(parent) {
+    }
+
+};
+
+#endif /* qmozsecurity_h */
+

--- a/tests/auto/mocks/qmozsecurity/qmozsecurity.pri
+++ b/tests/auto/mocks/qmozsecurity/qmozsecurity.pri
@@ -1,0 +1,3 @@
+INCLUDEPATH += $$PWD
+
+HEADERS += $$PWD/qmozsecurity.h

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
@@ -14,6 +14,7 @@ include(../mocks/declarativewebpage/declarativewebpage_mock.pri)
 include(../mocks/declarativewebutils/declarativewebutils_mock.pri)
 include(../mocks/downloadmanager/downloadmanager_mock.pri)
 include(../mocks/opensearchconfigs/opensearchconfigs_mock.pri)
+include(../mocks/qmozsecurity/qmozsecurity.pri)
 
 include(../test_common.pri)
 include(../../../common/paths.pri)

--- a/tests/auto/tst_webpages/tst_webpages.pro
+++ b/tests/auto/tst_webpages/tst_webpages.pro
@@ -14,6 +14,7 @@ include(../mocks/declarativewebpage/declarativewebpage_mock.pri)
 include(../mocks/declarativewebutils/declarativewebutils_mock.pri)
 include(../mocks/downloadmanager/downloadmanager_mock.pri)
 include(../mocks/opensearchconfigs/opensearchconfigs_mock.pri)
+include(../mocks/qmozsecurity/qmozsecurity.pri)
 
 include(../test_common.pri)
 include(../../../common/paths.pri)

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -2,7 +2,7 @@ TARGET = tst_webview
 
 CONFIG += link_pkgconfig
 
-PKGCONFIG += nemotransferengine-qt5 mlite5 sailfishwebengine
+PKGCONFIG += nemotransferengine-qt5 mlite5 sailfishwebengine systemsettings
 INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
 
 QT += quick concurrent sql gui-private


### PR DESCRIPTION
Adds a new button to the toolbar that gives immediate feedback on the
SSL/TLS security status. Clicking on the button displays on overlay with
more info about the TLS certificate and security of the page being
viewed, as provided by gecko (via qtmozembed).