### PR TITLE
[ua] Make apkpure.com to be identified as mobile. Fixes JB#47744

### DIFF
--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -98,5 +98,6 @@
   "google.sk": "Linux#Maemo",
   "google.ch": "Linux#Maemo",
   "google.at": "Linux#Maemo",
-  "twitter.com": "Mozilla/5.0 (Android 8.1.0; U; Sailfish 3.0; Mobile; rv:45.0) Gecko/45.0 SailfishBrowser/1.0"
+  "twitter.com": "Linux#Android 8.1.0",
+  "apkpure.com": "Linux#Android 8.1.0"
 }


### PR DESCRIPTION
This commit also simplifies twitter.com override.