### PR TITLE
Ensure empty browser opens with URL entry

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -1,5 +1,8 @@
 INCLUDEPATH += $$PWD
 
+PKGCONFIG += \
+        sailfishsilica
+
 # C++ sources
 SOURCES += \
     $$PWD/declarativewebcontainer.cpp \

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -26,6 +26,7 @@
 #include <QGuiApplication>
 #include <qmozwindow.h>
 #include <qmozsecurity.h>
+#include <silicatheme.h>
 
 #include <qpa/qplatformnativeinterface.h>
 
@@ -63,6 +64,7 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     , m_activeTabRendered(false)
     , m_clearSurfaceTask(0)
     , m_closing(false)
+    , m_silicaTheme(new Silica::Theme(this))
 {
     Q_ASSERT(!s_instance);
 
@@ -593,7 +595,9 @@ void DeclarativeWebContainer::clearWindowSurface()
     m_context->makeCurrent(this);
     QOpenGLFunctions_ES2* funcs = m_context->versionFunctions<QOpenGLFunctions_ES2>();
     Q_ASSERT(funcs);
-    funcs->glClearColor(1.0, 1.0, 1.0, 0.0);
+
+    QColor bgColor = m_silicaTheme->overlayBackgroundColor();
+    funcs->glClearColor(bgColor.redF(), bgColor.greenF(), bgColor.blueF(), 0.0);
     funcs->glClear(GL_COLOR_BUFFER_BIT);
     m_context->swapBuffers(this);
 }
@@ -1041,7 +1045,7 @@ void DeclarativeWebContainer::drawUnderlay()
 {
     Q_ASSERT(m_context);
 
-    QColor bgColor = m_webPage ? m_webPage->bgcolor() : QColor(Qt::white);
+    QColor bgColor = m_webPage ? m_webPage->bgcolor() : m_silicaTheme->overlayBackgroundColor();
     m_context->makeCurrent(this);
     QOpenGLFunctions_ES2* funcs = m_context->versionFunctions<QOpenGLFunctions_ES2>();
     if (funcs) {

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -31,6 +31,9 @@ class DeclarativeTabModel;
 class DeclarativeWebPage;
 class WebPages;
 class Tab;
+namespace Silica {
+    class Theme;
+}
 
 class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protected QOpenGLFunctions {
     Q_OBJECT
@@ -290,6 +293,8 @@ private:
     QMozContext::TaskHandle m_clearSurfaceTask;
 
     bool m_closing;
+
+    const Silica::Theme *m_silicaTheme;
 
     friend class tst_webview;
     friend class tst_declarativewebcontainer;

--- a/src/pages/components/Overlay.qml
+++ b/src/pages/components/Overlay.qml
@@ -33,7 +33,7 @@ Background {
 
     property real _overlayHeight: browserPage.isPortrait ? toolBar.toolsHeight : 0
     property bool _showFindInPage
-    property bool _showUrlEntry
+    property bool _showUrlEntry: true
     property bool _showInfoOverlay
     readonly property bool _topGap: _showUrlEntry || _showFindInPage
 
@@ -103,8 +103,6 @@ Background {
         overlay: overlay
         portrait: browserPage.isPortrait
         webView: overlay.webView
-        // Favorite grid first row offset is negative. So, increase minumumY drag by that.
-        openYPosition: _overlayHeight
 
         readonly property real _fullHeight: isPortrait ? overlay.toolBar.toolsHeight : 0
         readonly property real _infoHeight: Math.max(webView.fullscreenHeight - overlay.toolBar.certOverlayPreferedHeight - overlay.toolBar.toolsHeight, 0)

--- a/src/pages/components/OverlayAnimator.qml
+++ b/src/pages/components/OverlayAnimator.qml
@@ -19,8 +19,6 @@ Item {
     property bool atTop
     property bool atBottom: true
     property int transitionDuration: !_immediate ? (state === _certOverlay ? proportionalDuration : 400) : 0
-    property real openYPosition: portrait ? overlay.toolBar.toolsHeight : 0
-
     readonly property bool allowContentUse: state === _chromeVisible || state === _fullscreenWebPage || state === _doubleToolBar
     readonly property bool dragging: state === _draggingOverlay
     readonly property bool secondaryTools: state === _doubleToolBar
@@ -93,6 +91,8 @@ Item {
 
         if ((state !== _fullscreenOverlay && state !== _certOverlay) || _midPos) {
             atTop = false
+        } else if (state == _fullscreenOverlay) {
+            atTop = true
         }
         if ((state !== _chromeVisible && state !== _fullscreenWebPage && state !== _doubleToolBar) || _midPos) {
             atBottom = false


### PR DESCRIPTION
When the browser opens for the first time there is no page to display,
and the user should be presented with the URL entry field open.

Previous changes which introduced the TLS panel broke this behaviour.
These changes fix the regression.

The problem seems to be twofold. First, the atTop/atBottom state
behaviour changed (because panels with multiple sizes were introduced,
meaning it was possible to change from a large panel size to a smaller
panel size and still be atTop). The initial URL entry field relies on a
switch from atTop = false to atTop = true in order to trigger a
searchField.requestingFocus change in Overlay.qml. Second, the
initial _showUrlEntry entry also has to be true in order to trigger this
requestingFocus state change. This will revert to false as soon as
atBottom becomes true (i.e. as soon as the URL entry field is closed).