### PR TITLE
[sailfish-browser] Add sailfish-silica as a build requirement. Contributes to JB#47875

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -27,6 +27,7 @@ BuildRequires:  pkgconfig(nemotransferengine-qt5)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(qdeclarative5-boostable)
 BuildRequires:  pkgconfig(sailfishwebengine) >= %{min_sailfishwebengine_version}
+BuildRequires:  pkgconfig(sailfishsilica)
 BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  oneshot


### PR DESCRIPTION
…butes to JB#47875

To allow the overlayBackgroundColor to be queried from within the C++
code. This should have been included in the previous commits as it's
needed to allow the packages to build.