### PR TITLE
Revert background colour match to ambience

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -27,7 +27,6 @@ BuildRequires:  pkgconfig(nemotransferengine-qt5)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(qdeclarative5-boostable)
 BuildRequires:  pkgconfig(sailfishwebengine) >= %{min_sailfishwebengine_version}
-BuildRequires:  pkgconfig(sailfishsilica)
 BuildRequires:  pkgconfig(sailfishpolicy)
 BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist

--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -1,7 +1,7 @@
 INCLUDEPATH += $$PWD
 
 CONFIG += link_pkgconfig
-PKGCONFIG += sailfishsilica sailfishpolicy
+PKGCONFIG += sailfishpolicy
 
 # C++ sources
 SOURCES += \

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -26,7 +26,6 @@
 #include <QGuiApplication>
 #include <qmozwindow.h>
 #include <qmozsecurity.h>
-#include <silicatheme.h>
 
 #include <qpa/qplatformnativeinterface.h>
 #include <libsailfishpolicy/policyvalue.h>
@@ -66,7 +65,6 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     , m_activeTabRendered(false)
     , m_clearSurfaceTask(0)
     , m_closing(false)
-    , m_silicaTheme(new Silica::Theme(this))
 {
     Q_ASSERT(!s_instance);
 
@@ -602,8 +600,7 @@ void DeclarativeWebContainer::clearWindowSurface()
     QOpenGLFunctions_ES2* funcs = m_context->versionFunctions<QOpenGLFunctions_ES2>();
     Q_ASSERT(funcs);
 
-    QColor bgColor = m_silicaTheme->overlayBackgroundColor();
-    funcs->glClearColor(bgColor.redF(), bgColor.greenF(), bgColor.blueF(), 0.0);
+    funcs->glClearColor(1.0, 1.0, 1.0, 0.0);
     funcs->glClear(GL_COLOR_BUFFER_BIT);
     m_context->swapBuffers(this);
 }
@@ -1064,7 +1061,7 @@ void DeclarativeWebContainer::drawUnderlay()
 {
     Q_ASSERT(m_context);
 
-    QColor bgColor = m_webPage ? m_webPage->bgcolor() : m_silicaTheme->overlayBackgroundColor();
+    QColor bgColor = m_webPage ? m_webPage->bgcolor() : QColor(Qt::white);
     m_context->makeCurrent(this);
     QOpenGLFunctions_ES2* funcs = m_context->versionFunctions<QOpenGLFunctions_ES2>();
     if (funcs) {

--- a/src/core/declarativewebcontainer.h
+++ b/src/core/declarativewebcontainer.h
@@ -31,9 +31,6 @@ class DeclarativeTabModel;
 class DeclarativeWebPage;
 class WebPages;
 class Tab;
-namespace Silica {
-    class Theme;
-}
 
 class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protected QOpenGLFunctions {
     Q_OBJECT
@@ -294,8 +291,6 @@ private:
     QMozContext::TaskHandle m_clearSurfaceTask;
 
     bool m_closing;
-
-    const Silica::Theme *m_silicaTheme;
 
     friend class tst_webview;
     friend class tst_declarativewebcontainer;


### PR DESCRIPTION
This reverts some of the changes made in commit
3b56be95b265854cc77d96022bf825b084bac22d

Originally the browser background colour was always cleared to white. On
first opening there's a slight delay between the browser opening with a
cleared canvas and the URL panel opening, resulting in an abrupt colour
switch. The background was therefore changed to match the panel colour
of the current ambience.

As a result of this change, in in the more common case of opening a new
tab, the canvas opens dark and then later renders the web page. On the
basis that most web pages are a light colour, this PR reverts the canvas
colour to always be white to avoid an abrupt switch in this case.