### PR TITLE
[sailfish-browser] Use remorse delete for favorites. JB#48357

### DIFF
--- a/src/pages/components/FavoriteContextMenu.qml
+++ b/src/pages/components/FavoriteContextMenu.qml
@@ -54,7 +54,14 @@ Component {
             //: "Remove favorited / bookmarked web page"
             //% "Remove favorite"
             text: qsTrId("sailfish_browser-me-remove_favorite")
-            onClicked: bookmarkModel.remove(index)
+            onClicked: {
+                var d = delegate
+                var i = index
+                var model = bookmarkModel
+                d.remorseDelete(function() {
+                    model.remove(i)
+                })
+            }
         }
     }
 }

--- a/src/pages/components/FavoriteGrid.qml
+++ b/src/pages/components/FavoriteGrid.qml
@@ -89,7 +89,6 @@ IconGridViewBase {
         }
 
         GridView.onAdd: AddAnimation { target: favoriteItem }
-        GridView.onRemove: animateRemoval()
     }
 
 


### PR DESCRIPTION
This commit also removes obsoleted animated removal call.