### PR TITLE
[browser] Identify the chrome window as not being opaque. Contributes to JB#49482

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -35,7 +35,7 @@ BuildRequires:  gtest-devel
 BuildRequires:  libgmock-devel
 BuildRequires:  pkgconfig(vault) >= 1.0.1
 
-Requires: sailfishsilica-qt5 >= 1.1.79
+Requires: sailfishsilica-qt5 >= 1.1.107
 Requires: sailfish-content-graphics
 Requires: xulrunner-qt5 >= %{min_xulrunner_version}
 Requires: embedlite-components-qt5 >= %{min_embedlite_components_version}

--- a/src/browser.qml
+++ b/src/browser.qml
@@ -1,7 +1,7 @@
 /****************************************************************************
 **
-** Copyright (C) 2013 - 2019 Jolla Ltd.
-** Copyright (C) 2019 Open Mobile Platform LLC.
+** Copyright (c) 2013 - 2019 Jolla Ltd.
+** Copyright (c) 2019 - 2020 Open Mobile Platform LLC.
 ** Contact: Vesa-Matti Hartikainen <vesa-matti.hartikainen@jollamobile.com>
 ** Contact: Raine Makelainen <raine.makelainen@jolla.com>
 **
@@ -52,6 +52,7 @@ ApplicationWindow {
     _resizeContent: !window.rootPage.active
     _mainWindow: webView
     _backgroundVisible: false
+    _opaque: false
 
     cover: null
     initialPage: Component {


### PR DESCRIPTION
Normally application windows which hide the application background are
considered opaque, overwrite this default for the chrome window which is
stacked above the browser window.