### PR TITLE
[sailfish-browser] Don't foreground browser when unlocking to another screen. Fixes JB#45096

### DIFF
--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -96,7 +96,7 @@ WebContainer {
         }
     }
 
-    foreground: visibility >= QuickWindow.Window.Maximized
+    foreground: visibility >= QuickWindow.Window.Maximized && Qt.application.state === Qt.ApplicationActive
     readyToPaint: resourceController.videoActive ? webView.visible && !resourceController.displayOff : webView.visible && webView.contentItem && webView.contentItem.domContentLoaded
     allowHiding: !resourceController.videoActive && !resourceController.audioActive
     fullscreenMode: (contentItem && !contentItem.chrome) ||


### PR DESCRIPTION
screen. Fixes JB#45096

When the device unlocks and moves to the Events screen, the home
screen is briefly active before lipstick moves to the Events screen,
and at this point the browser window visibility is still
QWindow::FullScreen, so the WebView foreground binding is true.
However the BrowserPage raises the window whenever foreground=true, so
this causes the window to be raised when lipstick is actually moving
to another screen.

To prevent the unnecessary raise(), don't set foreground=true when the
application is not active.