### PR TITLE
Clean startupCache only using a oneshot

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -117,6 +117,7 @@ install -m 644 -p %{SOURCE1} %{buildroot}%{_datadir}/mapplauncherd/privileges.d/
 
 # Upgrade, count is 2 or higher (depending on the number of versions installed)
 if [ "$1" -ge 2 ]; then
+# Script insalled by xulrunner-qt5
 %{_bindir}/add-oneshot --all-users --now browser-cleanup-startup-cache || :
 fi
 

--- a/sailfish-browser.pro
+++ b/sailfish-browser.pro
@@ -12,8 +12,7 @@ dbus_service.path = /usr/share/dbus-1/services
 chrome_scripts.files = chrome/*.js
 chrome_scripts.path = $$[QT_INSTALL_LIBS]/mozembedlite/chrome/embedlite/content
 
-oneshots.files = oneshot.d/browser-cleanup-startup-cache \
-                 oneshot.d/browser-update-default-data
+oneshots.files = oneshot.d/browser-update-default-data
 oneshots.path  = /usr/lib/oneshot.d
 
 data.files = data/prefs.js \

--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -46,8 +46,6 @@ Browser::Browser(QQuickView *view, QObject *parent)
     DeclarativeWebUtils *utils = DeclarativeWebUtils::instance();
     DownloadManager *downloadManager = DownloadManager::instance();
 
-    utils->clearStartupCacheIfNeeded();
-
     d->view->rootContext()->setContextProperty("WebUtils", utils);
     d->view->rootContext()->setContextProperty("Settings", SettingManager::instance());
     d->view->rootContext()->setContextProperty("DownloadManager", downloadManager);

--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -71,21 +71,6 @@ int DeclarativeWebUtils::getLightness(const QColor &color) const
     return color.lightness();
 }
 
-void DeclarativeWebUtils::clearStartupCacheIfNeeded()
-{
-    QFileInfo systemStamp(gSystemComponentsTimeStamp);
-    if (systemStamp.exists()) {
-        QString mostProfilePath = QDir::homePath() + gProfilePath;
-        QString localStampString(mostProfilePath + QString("/_CACHE_CLEAN_"));
-        QFileInfo localStamp(localStampString);
-        if (localStamp.exists() && systemStamp.lastModified() > localStamp.lastModified()) {
-            QDir cacheDir(mostProfilePath + "/startupCache");
-            cacheDir.removeRecursively();
-            QFile(localStampString).remove();
-        }
-    }
-}
-
 void DeclarativeWebUtils::handleDumpMemoryInfoRequest(const QString &fileName)
 {
     if (qApp->arguments().contains("-debugMode")) {

--- a/src/browser/declarativewebutils.h
+++ b/src/browser/declarativewebutils.h
@@ -40,7 +40,6 @@ public:
 
 public slots:
     QString homePage() const;
-    void clearStartupCacheIfNeeded();
     void handleDumpMemoryInfoRequest(const QString &fileName);
     void openUrl(const QString &url);
 


### PR DESCRIPTION
The startupCache needs rebuilding if any of the components change, which
could happen if any one of xulrunner-qt5, embedlite-components-qt5 or
sailfish-browser is reinstalled.

Previously, the file `/var/lib/_MOZEMBED_CACHE_CLEAN_` was touched on
installation and the modified date/time compared against the cache. This
change uses a oneshot, added by each of the components, instead.

These three PRs go together:
1. https://git.sailfishos.org/mer-core/gecko-dev/merge_requests/121
2. https://git.sailfishos.org/mer-core/embedlite-components/merge_requests/62
3. https://github.com/sailfishos/sailfish-browser/pull/691
