### PR TITLE
Remove startupCache removal code

### DIFF
--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -46,8 +46,6 @@ Browser::Browser(QQuickView *view, QObject *parent)
     DeclarativeWebUtils *utils = DeclarativeWebUtils::instance();
     DownloadManager *downloadManager = DownloadManager::instance();
 
-    utils->clearStartupCacheIfNeeded();
-
     d->view->rootContext()->setContextProperty("WebUtils", utils);
     d->view->rootContext()->setContextProperty("Settings", SettingManager::instance());
     d->view->rootContext()->setContextProperty("DownloadManager", downloadManager);

--- a/src/browser/declarativewebutils.cpp
+++ b/src/browser/declarativewebutils.cpp
@@ -34,8 +34,6 @@
 #include "declarativewebutils.h"
 #include "browserpaths.h"
 
-static const auto gSystemComponentsTimeStamp = QStringLiteral("/var/lib/_MOZEMBED_CACHE_CLEAN_");
-static const auto gProfilePath = QStringLiteral("/.mozilla/mozembed");
 static const auto defaultUserAgentUpdateUrl = QStringLiteral("https://browser.sailfishos.org/gecko/%APP_VERSION%/ua-update.json");
 
 static DeclarativeWebUtils *gSingleton = 0;
@@ -69,21 +67,6 @@ DeclarativeWebUtils::~DeclarativeWebUtils()
 int DeclarativeWebUtils::getLightness(const QColor &color) const
 {
     return color.lightness();
-}
-
-void DeclarativeWebUtils::clearStartupCacheIfNeeded()
-{
-    QFileInfo systemStamp(gSystemComponentsTimeStamp);
-    if (systemStamp.exists()) {
-        QString mostProfilePath = QDir::homePath() + gProfilePath;
-        QString localStampString(mostProfilePath + QString("/_CACHE_CLEAN_"));
-        QFileInfo localStamp(localStampString);
-        if (localStamp.exists() && systemStamp.lastModified() > localStamp.lastModified()) {
-            QDir cacheDir(mostProfilePath + "/startupCache");
-            cacheDir.removeRecursively();
-            QFile(localStampString).remove();
-        }
-    }
 }
 
 void DeclarativeWebUtils::handleDumpMemoryInfoRequest(const QString &fileName)

--- a/src/browser/declarativewebutils.h
+++ b/src/browser/declarativewebutils.h
@@ -40,7 +40,6 @@ public:
 
 public slots:
     QString homePage() const;
-    void clearStartupCacheIfNeeded();
     void handleDumpMemoryInfoRequest(const QString &fileName);
     void openUrl(const QString &url);
 


### PR DESCRIPTION
The startupCache needs to be removed if it's stale (e.g. after component
installation). The code to do this has been moved into xulrunner and so
is no longer needed here.

This change effectively reverts commit
469d6a7dfe43efacf866d7f28d32eda24f3a0a9d