### PR TITLE
[browser] Add a special mode for WLAN captive portals. Contributes to JB#40777

### DIFF
--- a/common/browserapp.cpp
+++ b/common/browserapp.cpp
@@ -1,0 +1,47 @@
+/****************************************************************************
+**
+** Copyright (c) 2020 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QCoreApplication>
+#include <QString>
+#include "browserapp.h"
+
+bool BrowserApp::captivePortal()
+{
+    static bool captivePortalMode = false;
+    static bool argsChecked = false;
+
+    if (!argsChecked) {
+        if (QCoreApplication::arguments().contains(QStringLiteral("-captiveportal")))
+            captivePortalMode = true;
+        argsChecked = true;
+    }
+
+    return captivePortalMode;
+}
+
+QString BrowserApp::profileName()
+{
+    static QString profileName = QStringLiteral("mozembed");
+    static bool argsChecked = false;
+
+    if (!argsChecked) {
+        const QStringList &arguments = QCoreApplication::arguments();
+
+        if (arguments.contains(QStringLiteral("-profile"))) {
+            int index = arguments.indexOf(QStringLiteral("-profile"));
+            if (index + 1 < arguments.size()) {
+                profileName = arguments.at(index + 1);
+            }
+        } else if (BrowserApp::captivePortal()) {
+            profileName = QStringLiteral("captiveportal");
+        }
+    }
+    return profileName;
+}

--- a/common/browserapp.h
+++ b/common/browserapp.h
@@ -1,0 +1,22 @@
+/****************************************************************************
+**
+** Copyright (c) 2020 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BROWSERAPP_H
+#define BROWSERAPP_H
+
+class QString;
+
+struct BrowserApp
+{
+    static bool captivePortal();
+    static QString profileName();
+};
+
+#endif // BROWSERAPP_H

--- a/common/browserapp.pri
+++ b/common/browserapp.pri
@@ -1,0 +1,9 @@
+INCLUDEPATH += $$PWD
+
+# C++ sources
+SOURCES += \
+    $$PWD/browserapp.cpp \
+
+# C++ headers
+HEADERS += \
+    $$PWD/browserapp.h \

--- a/oneshot.d/browser-cleanup-startup-cache
+++ b/oneshot.d/browser-cleanup-startup-cache
@@ -1,2 +1,3 @@
 #!/bin/sh
 rm -rf ~/.mozilla/mozembed/startupCache
+rm -rf ~/.mozilla/captiveportal/startupCache

--- a/oneshot.d/browser-update-default-data
+++ b/oneshot.d/browser-update-default-data
@@ -1,24 +1,27 @@
 #!/bin/sh
 MOZEMBED_DIR=~/.mozilla/mozembed
+CAPTIVE_PORTAL_DIR=~/.mozilla/captiveportal
 BROWSER_DATA_DIR=/usr/share/sailfish-browser/data
 
-if [ ! -d "$MOZEMBED_DIR" ]; then
-    mkdir -p $MOZEMBED_DIR
-fi
+for PROFILE_DIR in $MOZEMBED_DIR $CAPTIVE_PORTAL_DIR; do
+    if [ ! -d "$PROFILE_DIR" ]; then
+        mkdir -p $PROFILE_DIR
+    fi
 
-if [ ! -f "$MOZEMBED_DIR/ua-update.json" -o ! -s "$MOZEMBED_DIR/ua-update.json" ]; then
-    # Remove lines starting with a comment.
-    sed  '\|^\s*//|d' $BROWSER_DATA_DIR/ua-update.json.in > "$MOZEMBED_DIR/ua-update.json"
-fi
+    if [ ! -f "$PROFILE_DIR/ua-update.json" -o ! -s "$PROFILE_DIR/ua-update.json" ]; then
+        # Remove lines starting with a comment.
+        sed  '\|^\s*//|d' $BROWSER_DATA_DIR/ua-update.json.in > "$PROFILE_DIR/ua-update.json"
+    fi
 
-if [ ! -f "$MOZEMBED_DIR/prefs.js" ]; then
-    cp $BROWSER_DATA_DIR/prefs.js $MOZEMBED_DIR
-else
-    while IFS='' read -r line || [[ -n "$line" ]]; do
-        prefKey=$(echo "$line" | cut -d "," -f1)
-        foundKey=$(grep "$prefKey" $MOZEMBED_DIR/prefs.js | wc -l)
-        if [ $foundKey -eq 0 ]; then
-            echo "$line" >> $MOZEMBED_DIR/prefs.js
-        fi
-    done < "$BROWSER_DATA_DIR/prefs.js"
-fi
+    if [ ! -f "$PROFILE_DIR/prefs.js" ]; then
+        cp $BROWSER_DATA_DIR/prefs.js $PROFILE_DIR
+    else
+        while IFS='' read -r line || [[ -n "$line" ]]; do
+            prefKey=$(echo "$line" | cut -d "," -f1)
+            foundKey=$(grep "$prefKey" $PROFILE_DIR/prefs.js | wc -l)
+            if [ $foundKey -eq 0 ]; then
+                echo "$line" >> $PROFILE_DIR/prefs.js
+            fi
+        done < "$BROWSER_DATA_DIR/prefs.js"
+    fi
+done

--- a/org.sailfishos.browser.captiveportal.service
+++ b/org.sailfishos.browser.captiveportal.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.sailfishos.browser.captiveportal
+Exec=/usr/bin/invoker -s --type=browser -G /usr/bin/sailfish-browser-captiveportal -prestart -captiveportal

--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -111,6 +111,7 @@ cp -f data/70-browser.conf %{buildroot}/%{_sharedstatedir}/environment/nemo/
 
 mkdir -p %{buildroot}%{_datadir}/mapplauncherd/privileges.d
 install -m 644 -p %{SOURCE1} %{buildroot}%{_datadir}/mapplauncherd/privileges.d/
+ln -s %{name} %{buildroot}%{_bindir}/%{name}-captiveportal
 
 %post
 /usr/bin/update-desktop-database -q || :
@@ -124,7 +125,9 @@ fi
 %files
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
+%{_bindir}/%{name}-captiveportal
 %{_datadir}/applications/%{name}.desktop
+%{_datadir}/applications/%{name}-captiveportal.desktop
 %{_datadir}/applications/open-url.desktop
 %{_datadir}/%{name}
 %{_datadir}/translations/%{name}*.qm

--- a/sailfish-browser-captiveportal.desktop
+++ b/sailfish-browser-captiveportal.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Captive Portal Browser
+X-MeeGo-Logical-Id=sailfish-browser-ap-name
+X-MeeGo-Translation-Catalog=sailfish-browser-captiveportal
+Icon=icon-launcher-browser
+Exec=invoker -s --type=browser -G /usr/bin/sailfish-browser-captiveportal -captiveportal %U
+Comment=Sailfish UI application

--- a/sailfish-browser.pro
+++ b/sailfish-browser.pro
@@ -2,11 +2,12 @@ TEMPLATE = subdirs
 SUBDIRS += src tests settings backup-unit
 
 # The .desktop file
-desktop.files = sailfish-browser.desktop open-url.desktop
+desktop.files = sailfish-browser.desktop sailfish-browser-captiveportal.desktop open-url.desktop
 desktop.path = /usr/share/applications
 
 dbus_service.files = org.sailfishos.browser.service \
-                     org.sailfishos.browser.ui.service
+                     org.sailfishos.browser.ui.service \
+                     org.sailfishos.browser.captiveportal.service
 dbus_service.path = /usr/share/dbus-1/services
 
 chrome_scripts.files = chrome/*.js

--- a/src/BrowserWindow.qml
+++ b/src/BrowserWindow.qml
@@ -1,0 +1,104 @@
+/****************************************************************************
+**
+** Copyright (c) 2013 - 2019 Jolla Ltd.
+** Copyright (c) 2020 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+import QtQuick 2.2
+import QtQuick.Window 2.2 as QuickWindow
+import Sailfish.Silica 1.0
+import Sailfish.Browser 1.0
+import Sailfish.Policy 1.0
+import com.jolla.settings.system 1.0
+import "pages"
+import "pages/components" as Browser
+
+ApplicationWindow {
+    id: window
+
+    readonly property bool largeScreen: Screen.sizeCategory > Screen.Medium
+    readonly property int browserVisibility: _mainWindow ? _mainWindow.visibility : QuickWindow.Window.Hidden
+    property bool coverMode: browserVisibility === QuickWindow.Window.Hidden ||
+                             browserVisibility === QuickWindow.Window.Minimized ||
+                             browserVisibility === QuickWindow.Window.Windowed
+
+    property bool opaqueBackground
+    property var rootPage
+    property QtObject webView
+
+    function setBrowserCover(model) {
+        if (!model || model.count === 0) {
+            cover = Qt.resolvedUrl("cover/NoTabsCover.qml")
+        } else {
+            if (cover != null && window.webView) {
+              window.webView.clearSurface();
+            }
+            cover = null
+        }
+    }
+
+    allowedOrientations: defaultAllowedOrientations
+    // For non large screen fix cover to portrait.
+    _defaultPageOrientations: !largeScreen && coverMode ? Orientation.Portrait : Orientation.LandscapeMask | Orientation.Portrait
+    _defaultLabelFormat: Text.PlainText
+    _clippingItem.opacity: 1.0
+    _resizeContent: !window.rootPage.active
+    _mainWindow: webView
+    _backgroundVisible: false
+    _opaque: false
+
+    cover: null
+
+    Browser.Background {
+        id: pushBackground
+        parent: null
+        anchors.fill: parent
+        z: -1
+    }
+
+    pageStack.onCurrentPageChanged: {
+        var currentContainer = pageStack._currentContainer
+
+        // synchronous x binding does not work with the new animator-based page pushes
+        // the push is performed using placeholder page, the background is handled with pushBackground above
+        var isPlaceholderPage = pageStack.currentPage && pageStack.currentPage.hasOwnProperty("__placeholder")
+        var newBackground = pageStack.currentPage && !pageStack.currentPage.hasOwnProperty("__hasBackground")
+        if (isPlaceholderPage) {
+            pushBackground.parent = pageStack.currentPage
+        } else if (newBackground) {
+            var background = pushBackgroundComponent.createObject(pageStack.currentPage)
+            background.parent = pageStack.currentPage
+        }
+    }
+
+    Component {
+        id: pushBackgroundComponent
+        Browser.Background {
+            parent: null
+            anchors.fill: parent
+            z: -1
+        }
+    }
+
+    DisabledByMdmView {
+        enabled: !AccessPolicy.browserEnabled
+        //% "Web browsing"
+        activity: qsTrId("sailfish_browser-la-web_browsing");
+        onEnabledChanged: {
+            if (enabled) {
+                webView.tabModel.clear()
+                webView.privateMode = true
+                pageStack.pop(null, PageStackAction.Immediate)
+                rootPage.overlay.toolBar.showOverlay()
+            } else {
+                webView.privateMode = false
+            }
+        }
+    }
+}

--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -15,6 +15,7 @@
 #include "declarativewebutils.h"
 #include "downloadmanager.h"
 #include "settingmanager.h"
+#include "browserapp.h"
 
 #include <QDir>
 #include <QGuiApplication>
@@ -77,7 +78,7 @@ Browser::Browser(QQuickView *view, QObject *parent)
     Q_ASSERT(view);
     Q_ASSERT(qGuiApp);
 
-    SailfishOS::WebEngine::initialize("mozembed");
+    SailfishOS::WebEngine::initialize(BrowserApp::profileName());
     SailfishOS::WebEngineSettings::initialize();
 
     DeclarativeWebUtils *utils = DeclarativeWebUtils::instance();

--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -91,10 +91,12 @@ Browser::Browser(QQuickView *view, QObject *parent)
     d->closeEventFilter = new CloseEventFilter(downloadManager, this);
     d->view->installEventFilter(d->closeEventFilter);
 
+    QString mainQml = BrowserApp::captivePortal() ? "captiveportal.qml" : "browser.qml";
+
 #ifdef USE_RESOURCES
-    d->view->setSource(QUrl("qrc:///browser.qml"));
+    d->view->setSource(QUrl(QString("qrc:///") + mainQml));
 #else
-    d->view->setSource(QUrl::fromLocalFile(Browser::applicationFilePath() + "browser.qml"));
+    d->view->setSource(QUrl::fromLocalFile(Browser::applicationFilePath() + mainQml));
 #endif
 }
 

--- a/src/browser/browserservice.cpp
+++ b/src/browser/browserservice.cpp
@@ -12,6 +12,7 @@
 #include "browserservice.h"
 #include "browserservice_p.h"
 #include "declarativewebcontainer.h"
+#include "browserapp.h"
 
 #include "dbusadaptor.h"
 #include <QDBusConnection>
@@ -20,6 +21,7 @@
 
 #define SAILFISH_BROWSER_SERVICE QLatin1String("org.sailfishos.browser")
 #define SAILFISH_BROWSER_UI_SERVICE QLatin1String("org.sailfishos.browser.ui")
+#define SAILFISH_BROWSER_CAPTIVE_PORTAL_SERVICE QLatin1String("org.sailfishos.browser.captiveportal")
 
 #define IS_PRIVILEGED \
     if (!calledFromDBus()) { \
@@ -42,7 +44,7 @@ BrowserService::BrowserService(QObject * parent)
     new DBusAdaptor(this);
     QDBusConnection connection = QDBusConnection::sessionBus();
     if(!connection.registerObject("/", this)
-            || !connection.registerService(SAILFISH_BROWSER_SERVICE)) {
+            || !connection.registerService(serviceName())) {
         m_registered = false;
     }
 }
@@ -54,7 +56,10 @@ bool BrowserService::registered() const
 
 QString BrowserService::serviceName() const
 {
-    return SAILFISH_BROWSER_SERVICE;
+    if (BrowserApp::captivePortal())
+        return SAILFISH_BROWSER_CAPTIVE_PORTAL_SERVICE;
+    else
+        return SAILFISH_BROWSER_SERVICE;
 }
 
 void BrowserService::openUrl(const QStringList &args)
@@ -116,7 +121,6 @@ BrowserUIService::BrowserUIService(QObject *parent)
     : QObject(parent)
     , QDBusContext()
     , d_ptr(new BrowserUIServicePrivate())
-
 {
     Q_D(BrowserUIService);
 

--- a/src/captiveportal.qml
+++ b/src/captiveportal.qml
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
-** Copyright (c) 2013 - 2019 Jolla Ltd.
-** Copyright (c) 2019 - 2020 Open Mobile Platform LLC.
+** Copyright (c) 2020 Open Mobile Platform LLC.
 **
 ****************************************************************************/
 
@@ -15,8 +14,9 @@ import "pages"
 BrowserWindow {
     id: window
 
+    coverMode: false
     initialPage: Component {
-        BrowserPage {
+        CaptivePortalPage {
             id: browserPage
 
             Component.onCompleted: {

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -17,6 +17,7 @@
 #include "webpagefactory.h"
 #include "webpages.h"
 #include "browserpaths.h"
+#include "browserapp.h"
 
 #include <webengine.h>
 #include <QTimerEvent>

--- a/src/core/declarativewebcontainer.cpp
+++ b/src/core/declarativewebcontainer.cpp
@@ -93,7 +93,7 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     m_persistentTabModel = new PersistentTabModel(maxTabid + 1, this);
     m_privateTabModel = new PrivateTabModel(maxTabid + 1001, this);
 
-    setTabModel(privateMode() ? m_privateTabModel.data() : m_persistentTabModel.data());
+    setTabModel((BrowserApp::captivePortal() || m_privateMode) ? m_privateTabModel.data() : m_persistentTabModel.data());
 
     connect(DownloadManager::instance(), &DownloadManager::downloadStarted,
             this, &DeclarativeWebContainer::onDownloadStarted);
@@ -536,7 +536,7 @@ int DeclarativeWebContainer::findParentTabId(int tabId) const
 
 void DeclarativeWebContainer::updateMode()
 {
-    setTabModel(privateMode() ? m_privateTabModel.data() : m_persistentTabModel.data());
+    setTabModel((BrowserApp::captivePortal() || m_privateMode) ? m_privateTabModel.data() : m_persistentTabModel.data());
     emit tabIdChanged();
 
     // Reload active tab from new mode

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,12 +122,16 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterRevision<QQuickItem, 1>(uri, 1, 0);
     qmlRegisterRevision<QWindow, 1>(uri, 1, 0);
 
-    qmlRegisterType<DeclarativeBookmarkModel>(uri, 1, 0, "BookmarkModel");
     qmlRegisterUncreatableType<DeclarativeTabModel>(uri, 1, 0, "TabModel", "TabModel is abstract!");
-    qmlRegisterUncreatableType<PersistentTabModel>(uri, 1, 0, "PersistentTabModel", "");
     qmlRegisterUncreatableType<PrivateTabModel>(uri, 1, 0, "PrivateTabModel", "");
+
+    if (!BrowserApp::captivePortal())
+    {
+        qmlRegisterType<DeclarativeBookmarkModel>(uri, 1, 0, "BookmarkModel");
+        qmlRegisterUncreatableType<PersistentTabModel>(uri, 1, 0, "PersistentTabModel", "");
+        qmlRegisterType<DeclarativeHistoryModel>(uri, 1, 0, "HistoryModel");
+    }
     qmlRegisterUncreatableType<DownloadStatus>(uri, 1, 0, "DownloadStatus", "");
-    qmlRegisterType<DeclarativeHistoryModel>(uri, 1, 0, "HistoryModel");
     qmlRegisterType<DeclarativeWebContainer>(uri, 1, 0, "WebContainer");
     qmlRegisterType<DeclarativeWebPage>(uri, 1, 0, "WebPage");
     qmlRegisterType<DeclarativeWebPageCreator>(uri, 1, 0, "WebPageCreator");

--- a/src/pages/CaptivePortalPage.qml
+++ b/src/pages/CaptivePortalPage.qml
@@ -1,0 +1,228 @@
+/****************************************************************************
+**
+** Copyright (c) 2020 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+import QtQuick 2.2
+import QtQuick.Window 2.2 as QuickWindow
+import Sailfish.Silica 1.0
+import Sailfish.Silica.private 1.0 as Private
+import Sailfish.Browser 1.0
+import Sailfish.Policy 1.0
+import "components" as Browser
+
+Page {
+    id: browserPage
+
+    readonly property bool __hasBackground: true
+    readonly property rect inputMask: inputMaskForOrientation(orientation)
+    readonly property bool active: status == PageStatus.Active
+
+    property alias overlay: overlay
+    property alias url: webView.url
+    property alias title: webView.title
+    property alias webView: webView
+
+    function load(url, title) {
+        webView.load(url, title)
+    }
+
+    function bringToForeground(window) {
+        if ((webView.visibility < QuickWindow.Window.Maximized) && window) {
+            window.raise()
+        }
+    }
+
+    function inputMaskForOrientation(orientation) {
+        // mask is in portrait window coordinates
+        var mask = Qt.rect(0, 0, Screen.width, Screen.height)
+        if (!window.opaqueBackground && webView.enabled && browserPage.active && !webView.touchBlocked) {
+            var overlayVisibleHeight = browserPage.height - overlay.y
+
+            switch (orientation) {
+            case Orientation.None:
+            case Orientation.Portrait:
+                mask.y = overlay.y
+                // fallthrough
+            case Orientation.PortraitInverted:
+                mask.height = overlayVisibleHeight
+                break
+
+            case Orientation.LandscapeInverted:
+                mask.x = overlay.y
+                // fallthrough
+            case Orientation.Landscape:
+                mask.width = overlayVisibleHeight
+            }
+        }
+        return mask
+    }
+
+    property int pageOrientation: pageStack.currentPage._windowOrientation
+    onPageOrientationChanged: {
+        // When on other pages update immediately.
+        if (!active) {
+            webView.applyContentOrientation(pageOrientation)
+        }
+    }
+
+    orientationTransitions: orientationFader.orientationTransition
+
+    Browser.OrientationFader {
+        id: orientationFader
+
+        visible: webView.contentItem
+        page: browserPage
+        fadeTarget: overlay
+        color: webView.contentItem ? (webView.resourceController.videoActive &&
+                                      webView.contentItem.fullscreen ? "black" : webView.contentItem.bgcolor)
+                                   : "white"
+
+        onApplyContentOrientation: webView.applyContentOrientation(browserPage.orientation)
+    }
+
+    Private.VirtualKeyboardObserver {
+        id: virtualKeyboardObserver
+
+        active: webView.enabled
+        transpose: window._transpose
+        orientation: browserPage.orientation
+
+        onWindowChanged: webView.chromeWindow = window
+
+        // Update content height only after virtual keyboard fully opened.
+        states: State {
+            name: "boundHeightControl"
+            when: virtualKeyboardObserver.opened && webView.enabled
+            PropertyChanges {
+                target: webView.contentItem
+                virtualKeyboardMargin: virtualKeyboardObserver.panelSize
+            }
+        }
+    }
+
+    Browser.WebView {
+        id: webView
+
+        enabled: overlay.animator.allowContentUse
+        fullscreenHeight: portrait ? Screen.height : Screen.width
+        portrait: browserPage.isPortrait
+        maxLiveTabCount: 3
+        toolbarHeight: overlay.toolBar.height
+        rotationHandler: browserPage
+        imOpened: virtualKeyboardObserver.opened
+        canShowSelectionMarkers: false
+
+        // Show overlay immediately at top if needed.
+        onTabModelChanged: handleModelChanges(true)
+        onForegroundChanged: {
+            if (foreground && webView.chromeWindow) {
+                webView.chromeWindow.raise()
+            }
+        }
+
+        onWebContentOrientationChanged: orientationFader.waitForWebContentOrientationChanged = false
+
+        function applyContentOrientation(orientation) {
+            orientationFader.waitForWebContentOrientationChanged = (contentItem && contentItem.active)
+
+            switch (orientation) {
+            case Orientation.None:
+            case Orientation.Portrait:
+                updateContentOrientation(Qt.PortraitOrientation)
+                break
+            case Orientation.Landscape:
+                updateContentOrientation(Qt.LandscapeOrientation)
+                break
+            case Orientation.PortraitInverted:
+                updateContentOrientation(Qt.InvertedPortraitOrientation)
+                break
+            case Orientation.LandscapeInverted:
+                updateContentOrientation(Qt.InvertedLandscapeOrientation)
+                break
+            }
+        }
+
+        // Both model change and model count change are connected to this.
+        function handleModelChanges(openOverlayImmediately) {
+            if (webView.completed && (!webView.tabModel || webView.tabModel.count === 0)) {
+                overlay.animator.showOverlay(openOverlayImmediately)
+            }
+
+            window.setBrowserCover(webView.tabModel)
+        }
+    }
+
+    // Use Connections so that target updates when model changes.
+    Connections {
+        target: AccessPolicy.browserEnabled && webView && webView.tabModel || null
+        ignoreUnknownSignals: true
+        // Animate overlay to top if needed.
+        onCountChanged: webView.handleModelChanges(false)
+    }
+
+    InputRegion {
+        window: webView.chromeWindow
+        x: inputMask.x
+        y: inputMask.y
+        width: inputMask.width
+        height: inputMask.height
+    }
+
+    Browser.CaptivePortalOverlay {
+        id: overlay
+
+        active: true
+        webView: webView
+        containerPage: browserPage
+
+        animator.onAtBottomChanged: {
+            if (!animator.atBottom) {
+                webView.clearSelection()
+            }
+        }
+
+        onActiveChanged: {
+            if (active && webView.contentItem) {
+                overlay.animator.showChrome()
+            }
+
+            if (!active) {
+                if (webView.chromeWindow && webView.foreground) {
+                    webView.chromeWindow.raise()
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: WebUtils
+        onOpenUrlRequested: {
+            // Refuse if blocked by MDM
+            if (!AccessPolicy.browserEnabled) {
+                bringToForeground(webView.chromeWindow)
+                window.activate()
+                return
+            }
+
+            if (!webView.tabModel.activateTab(url)) {
+                webView.clearSelection()
+                webView.tabModel.newTab(url)
+                overlay.dismiss(!Qt.application.active /* immadiate */)
+            }
+            bringToForeground(webView.chromeWindow)
+            window.activate()
+        }
+        onShowChrome: {
+            overlay.dismiss(!Qt.application.active /* immadiate */)
+            bringToForeground(webView.chromeWindow)
+            window.activate()
+        }
+    }
+}

--- a/src/pages/captiveportal.js
+++ b/src/pages/captiveportal.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2020 Open Mobile Platform LLC.
+ *
+ * License: Proprietary
+ */
+
+Components.utils.import("resource://gre/modules/Services.jsm");
+
+Services.scriptloader.loadSubScript("chrome://embedlite/content/ClickEventBlocker.js");
+
+let global = this;
+
+// This will send "embed:OpenLink" message when a link is clicked.
+ClickEventBlocker.init(global, {allowNavigationInSameOrigin: true});

--- a/src/pages/components/CaptivePortalOverlay.qml
+++ b/src/pages/components/CaptivePortalOverlay.qml
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2014 - 2019 Jolla Ltd.
+ * Copyright (c) 2012 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.2
+import QtQuick.Window 2.2 as QuickWindow
+import Sailfish.Silica 1.0
+import Sailfish.Silica.private 1.0 as Private
+import Sailfish.Browser 1.0
+import Sailfish.Policy 1.0
+import Sailfish.WebView.Controls 1.0
+import com.jolla.settings.system 1.0
+import "." as Browser
+
+Background {
+    id: overlay
+
+    property bool active
+    property QtObject webView
+    property Item containerPage
+    property alias toolBar: toolBar
+    property alias progressBar: progressBar
+    property alias animator: overlayAnimator
+
+    function loadPage(url)  {
+        if (webView && webView.tabModel.count === 0) {
+            webView.clearSurface();
+        }
+        // let gecko figure out how to handle malformed URLs
+        var pageUrl = url
+        if (!isNaN(pageUrl) && pageUrl.trim()) {
+            pageUrl = "\"" + pageUrl.trim() + "\""
+        }
+
+        webView.load(pageUrl)
+        overlayAnimator.showChrome()
+    }
+
+    function dismiss(immediate) {
+        overlay.animator.showChrome(immediate)
+    }
+
+    y: webView.fullscreenHeight - toolBar.height
+
+    Private.VirtualKeyboardObserver {
+        id: virtualKeyboardObserver
+        active: overlay.active && !overlayAnimator.atBottom
+        orientation: containerPage.orientation
+    }
+
+    width: parent.width
+    height: toolBar.height + virtualKeyboardObserver.panelSize
+    // `visible` is controlled by Browser.OverlayAnimator
+    enabled: visible
+
+    // This is an invisible object responsible to hide/show Overlay in an animated way
+    Browser.OverlayAnimator {
+        id: overlayAnimator
+
+        overlay: overlay
+        portrait: containerPage.isPortrait
+        webView: overlay.webView
+
+        readonly property real _fullHeight: overlay.toolBar.height
+        // Referred from OverlayAnimator
+        readonly property real _infoHeight: 0
+    }
+
+    Browser.ProgressBar {
+        id: progressBar
+        width: parent.width
+        height: toolBar.height
+        opacity: webView.loading ? 1.0 : 0.0
+        progress: webView.loadProgress / 100.0
+    }
+
+    Browser.CaptivePortalToolBar {
+        id: toolBar
+
+        x: Theme.horizontalPageMargin
+        width: parent.width - 2 * x
+        url: webView.contentItem && webView.contentItem.url || ""
+        onShowChrome: overlayAnimator.showChrome()
+    }
+}

--- a/src/pages/components/CaptivePortalToolBar.qml
+++ b/src/pages/components/CaptivePortalToolBar.qml
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2014 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import Sailfish.Browser 1.0
+import "." as Browser
+
+Column {
+    id: toolBarRow
+
+    property string url
+    readonly property real toolsHeight: height
+
+    readonly property int horizontalOffset: largeScreen ? Theme.paddingLarge : Theme.paddingSmall
+    readonly property int buttonPadding: largeScreen || orientation === Orientation.Landscape || orientation === Orientation.LandscapeInverted
+                                         ? Theme.paddingMedium : Theme.paddingSmall
+    readonly property int iconWidth: largeScreen ? (Theme.iconSizeLarge + 3 * buttonPadding) : (Theme.iconSizeMedium + 2 * buttonPadding)
+    readonly property int smallIconWidth: largeScreen ? (Theme.iconSizeMedium + 3 * buttonPadding) : (Theme.iconSizeSmall + 2 * buttonPadding)
+    // Height of toolbar should be such that viewport height is
+    // even number both chrome and fullscreen modes. For instance
+    // height of 110px for toolbar would result 1px rounding
+    // error in chrome mode as viewport height would be 850px. This would
+    // result in CSS pixels viewport height of 566.66..px -> rounded to 566px.
+    // So, we make sure below that (device height - toolbar height) / pixel ratio is even number.
+    // target values when Theme.pixelratio == 1 are:
+    // portrait: 108px
+    // landcape: 78px
+    property int scaledPortraitHeight: Screen.height -
+                                       Math.floor((Screen.height - Settings.toolbarLarge * Theme.pixelRatio) /
+                                                  WebUtils.cssPixelRatio) * WebUtils.cssPixelRatio
+    property int scaledLandscapeHeight: Screen.width -
+                                        Math.floor((Screen.width - Settings.toolbarSmall * Theme.pixelRatio) /
+                                                   WebUtils.cssPixelRatio) * WebUtils.cssPixelRatio
+
+    signal showChrome
+
+    width: parent.width
+
+    Item {
+        width: 1
+        height: Theme.paddingMedium
+    }
+
+    Label {
+        width: parent.width
+        height: toolsRow.height
+        verticalAlignment: Text.AlignVCenter
+        //: Shown when sign in to captive portal
+        //% "Sign in"
+        text: qsTrId("sailfish_browser-la-sign_in")
+        maximumLineCount: 1
+        truncationMode: TruncationMode.Fade
+        color: Theme.highlightColor
+    }
+
+    Row {
+        id: toolsRow
+        width: parent.width
+        height: browserPage.isPortrait ? scaledPortraitHeight : scaledLandscapeHeight
+
+        Browser.ExpandingButton {
+            id: backIcon
+            expandedWidth: toolBarRow.iconWidth
+            icon.source: "image://theme/icon-m-back"
+            active: webView.canGoBack
+            onTapped: webView.goBack()
+        }
+
+        Label {
+            anchors.verticalCenter: parent.verticalCenter
+            width: toolBarRow.width - (reloadButton.width + backIcon.width + toolsRow.leftPadding) + Theme.paddingMedium
+            color: Theme.highlightColor
+
+            text: {
+                if (url) {
+                    return WebUtils.displayableUrl(url)
+                } else {
+                    //: Loading text that is visible when url is not yet resolved.
+                    //% "Loading"
+                    return qsTrId("sailfish_browser-la-loading")
+                }
+            }
+
+            truncationMode: TruncationMode.Fade
+        }
+
+        Browser.ExpandingButton {
+            id: reloadButton
+            expandedWidth: toolBarRow.iconWidth
+            icon.source: webView.loading ? "image://theme/icon-m-reset" : "image://theme/icon-m-refresh"
+            active: webView.contentItem
+            onTapped: {
+                if (webView.loading) {
+                    webView.stop()
+                } else {
+                    webView.reload()
+                }
+                toolBarRow.showChrome()
+            }
+        }
+    }
+}

--- a/src/pages/components/WebView.qml
+++ b/src/pages/components/WebView.qml
@@ -18,6 +18,7 @@ import Sailfish.WebView.Popups 1.0 as Popups
 import Sailfish.WebView.Controls 1.0
 import Qt5Mozilla 1.0
 import Sailfish.Policy 1.0
+import Sailfish.TextLinking 1.0
 import "." as Browser
 
 WebContainer {
@@ -58,6 +59,8 @@ WebContainer {
             Behavior on opacity { FadeAnimator {} }
         }
     }
+
+    property var linkHandler: LinkHandler {}
 
     function stop() {
         if (contentItem) {
@@ -332,6 +335,12 @@ WebContainer {
                     } else {
                         webView.findInPageHasResult = false
                     }
+                    break
+                }
+                // embed:OpenLink listener is registered only in the captive portal mode
+                case "embed:OpenLink": {
+                    linkHandler.handleLink(data.uri)
+                    break
                 }
                 }
             }

--- a/src/qtmozembed/declarativewebpage.cpp
+++ b/src/qtmozembed/declarativewebpage.cpp
@@ -10,6 +10,7 @@
 #include "declarativewebpage.h"
 #include "declarativewebcontainer.h"
 #include "dbmanager.h"
+#include "browserapp.h"
 #include "browserpaths.h"
 #include "logging.h"
 
@@ -25,6 +26,7 @@ static const QString gDomContentLoadedMessage("chrome:contentloaded");
 static const QString gContentOrientationChanged("embed:contentOrientationChanged");
 static const QString gLinkAddedMessage("chrome:linkadded");
 static const QString gFindMessage("embed:find");
+static const QString gOpenLink("embed:OpenLink");
 
 bool isBlack(QRgb rgb)
 {
@@ -70,6 +72,11 @@ DeclarativeWebPage::DeclarativeWebPage(QObject *parent)
     addMessageListener(gContentOrientationChanged);
 
     loadFrameScript("chrome://embedlite/content/embedhelper.js");
+
+    if (BrowserApp::captivePortal()) {
+        addMessageListener(gOpenLink);
+        loadFrameScript("file:///usr/share/sailfish-browser/pages/captiveportal.js");
+    }
 
     connect(this, &DeclarativeWebPage::recvAsyncMessage,
             this, &DeclarativeWebPage::onRecvAsyncMessage);

--- a/src/src.pro
+++ b/src/src.pro
@@ -42,6 +42,7 @@ EE_QM = $$OUT_PWD/sailfish-browser_eng_en.qm
 include(../translations/translations.pri)
 
 include(../defaults.pri)
+include(../common/browserapp.pri)
 include(../common/opensearchconfigs.pri)
 include(../common/paths.pri)
 include(core/core.pri)

--- a/src/src.pro
+++ b/src/src.pro
@@ -61,3 +61,4 @@ OTHER_FILES = *.qml \
               pages/components/*.qml \
               pages/components/*.js \
               rpm/sailfish-browser.spec
+

--- a/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
+++ b/tests/auto/tst_declarativewebcontainer/tst_declarativewebcontainer.pro
@@ -17,6 +17,7 @@ include(../mocks/opensearchconfigs/opensearchconfigs_mock.pri)
 include(../mocks/qmozsecurity/qmozsecurity.pri)
 
 include(../test_common.pri)
+include(../../../common/browserapp.pri)
 include(../../../common/paths.pri)
 include(../../../src/core/core.pri)
 include(../../../src/history/history.pri)

--- a/tests/auto/tst_webpages/tst_webpages.pro
+++ b/tests/auto/tst_webpages/tst_webpages.pro
@@ -17,6 +17,7 @@ include(../mocks/opensearchconfigs/opensearchconfigs_mock.pri)
 include(../mocks/qmozsecurity/qmozsecurity.pri)
 
 include(../test_common.pri)
+include(../../../common/browserapp.pri)
 include(../../../common/paths.pri)
 include(../../../src/core/core.pri)
 include(../../../src/history/history.pri)

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -17,6 +17,7 @@ include(../../../src/qtmozembed/qtmozembed.pri)
 include(../../../src/factories/factories.pri)
 include(../../../src/bookmarks/bookmarks.pri)
 include(../../../src/history/history.pri)
+include(../../../common/browserapp.pri)
 include(../../../common/paths.pri)
 
 SOURCES += tst_webview.cpp


### PR DESCRIPTION
This pull request adds support for starting browser with simplified UI and a separate profile enabled by -captiveportal flag, which is going to be used for opening Wi-Fi captive portal pages with separate browser profile to avoid leaking browser data.