### PR TITLE
[sailfish-browser] Add touch-related test pages. Contributes to JB#50875

### DIFF
--- a/tests/manual/testpage.html
+++ b/tests/manual/testpage.html
@@ -143,6 +143,14 @@
       <a href="test-fullscreen-video-l.html">Long page containing embeded video</a>
     </div>
 
+    <div class="header"><h2>Touch input</h2></div>
+    <div>
+      <a href="testtouchaction.html">Touch actions and the touch-action css property</a>
+    </div>
+    <div>
+      <a href="testtouchclick.html">Touch input vs. mouse input</a>
+    </div>
+
     <div class="header"><h2>Misc</h2></div>
     <div>
       <a href="http://www.quirksmode.org/css/tests/mediaqueries/devicepixelratio.html">QuirksMode's MediaQueries DevicePixelRatio test page</a>

--- a/tests/manual/testtouchaction.html
+++ b/tests/manual/testtouchaction.html
@@ -1,0 +1,90 @@
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="initial-scale=1">
+    <!-- More info: https://css-tricks.com/almanac/properties/t/touch-action/ -->
+    <style>
+      body {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
+      .box {
+        margin: 1rem;
+        width: 240px;
+        height: 240px;
+        overflow: scroll;
+        position: relative;
+        margin-bottom: 15px;
+      }
+      .desc {
+        position: absolute;
+        width: 100%;
+        text-align: center;
+        font-weight: bold;
+        top: 130px;
+        font-size: 24px;
+      }
+      .touch-auto {
+        touch-action: auto;
+      }
+      .touch-none {
+        touch-action: none;
+      }
+      .touch-pan-x {
+        touch-action: pan-x;
+      }
+      .touch-pan-y {
+        touch-action: pan-y;
+      }
+      .touch-pan-right {
+        touch-action: pan-right;
+      }
+      .touch-manipulation {
+        touch-action: manipulation;
+      }
+
+      .back {
+        background-image: linear-gradient(45deg, #8F8 25%, transparent 25%, transparent),
+                          linear-gradient(-45deg, #8F8 25%, transparent 25%, transparent),
+                          linear-gradient(45deg, transparent 75%, #8F8 75%),
+                          linear-gradient(-45deg, transparent 75%, #8F8 75%);
+        background-size: 80px 80px;
+        width: 1200px;
+        height: 1200px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="box touch-auto">
+    <div class="back" />&nbsp;</div>
+    <code class="desc">touch-action: auto;</code>
+    </div>
+
+    <div class="box touch-none">
+    <div class="back" />&nbsp;</div>
+    <code class="desc">touch-action: none;</code>
+    </div>
+
+    <div class="box touch-pan-x">
+    <div class="back" />&nbsp;</div>
+    <code class="desc">touch-action: pan-x;</code>
+    </div>
+
+    <div class="box touch-pan-y">
+    <div class="back" />&nbsp;</div>
+    <code class="desc">touch-action: pan-y;</code>
+    </div>
+
+    <div class="box touch-pan-right">
+    <div class="back" />&nbsp;</div>
+    <code class="desc">touch-action: pan-right;</code>
+    </div>
+
+    <div class="box touch-manipulation">
+    <div class="back" />&nbsp;</div>
+    <code class="desc">touch-action: manipulation;</code>
+    </div>
+  </body>
+</html>
+

--- a/tests/manual/testtouchclick.html
+++ b/tests/manual/testtouchclick.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1">
+  <style>
+    @keyframes pop {
+      from {background-color: green;}
+      to {background-color: white;}
+    }
+
+    .rect {
+      position: absolute;
+      top: 1em;
+      width: 35%;
+      height: 3em;
+      border: 2px solid black;
+      background-color: red;
+      animation-name: pop;
+      animation-duration: 1s;
+      animation-fill-mode: forwards;
+      animation-timing-function: ease-out;
+      display: table-cell;
+      text-align: center;
+      line-height: 3em;
+    }
+
+    .section {
+      position: relative; width: 90%; left: 5%;
+      border: 2px dotted grey;
+      margin-top: 1em;
+      top: 4em;
+    }
+
+    .block {
+      position:relative; width: calc(100% - 2em);
+      height: 3em;
+      margin: 1em;
+    }
+  </style>
+  <script type="text/javascript">
+    function resetAnim(item) {
+      var elm = document.getElementById(item);
+      var newone = elm.cloneNode(true);
+      elm.parentNode.replaceChild(newone, elm);
+    }
+
+    function applyStopProp(event) {
+      event.stopPropagation();
+      resetAnim("showtouchstart");
+    }
+    function applyPreventDefault(event) {
+      event.preventDefault();
+      resetAnim("showtouchstart");
+    }
+    function clickThings(event) {
+      resetAnim("showmousedown");
+    }
+  </script>
+  </head>
+
+  <body>
+    <div id="showtouchstart" class="rect" style="left: 10%;">Touch Start</div>
+    <div id="showmousedown" class="rect" style="left: 55%;">Mouse Down</div>
+
+    <div class="section" style=";">
+      <p>Apply stopPropagation()</p>
+
+      <form method="GET" action="/" ontouchstart="applyStopProp(event)" onmousedown="clickThings(event)">
+        <input id="input" class="block" type="text" value="This is a text entry field" />
+      </form>
+
+      <a href="#" class="block" ontouchstart="applyStopProp(event)" onmousedown="clickThings(event)">This is a link</a>
+      <div class="block" style="border: 1px solid blue;" ontouchstart="applyStopProp(event)" onmousedown="clickThings(event)">This is a div</div>
+    </div>
+
+    <div class="section" style=";">
+      <p>Apply preventDefault()</p>
+
+      <form method="GET" action="/" ontouchstart="applyPreventDefault(event)" onmousedown="clickThings(event)">
+        <input id="input" class="block" type="text" value="This is a text entry field" />
+      </form>
+
+      <a href="#" class="block" ontouchstart="applyPreventDefault(event)" onmousedown="clickThings(event)">This is a link</a>
+      <div class="block" style="border: 1px solid blue;" ontouchstart="applyPreventDefault(event)" onmousedown="clickThings(event)">This is a div</div>
+    </div>
+
+  </body>
+</html>
+
+


### PR DESCRIPTION
Adds two new test pages:

1. Touch action test page, for testing the touch-action css property.
2. Touch/click test page. On desktop clicking on the items will generate
mouse but not touch events. On mobile pressing the items should trigger
both touch and mouse events.