### PR TITLE
[sailfish-browser] Hide captive portal browser from application grid. Contributes to JB#40777

### DIFF
--- a/sailfish-browser-captiveportal.desktop
+++ b/sailfish-browser-captiveportal.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Type=Application
+NoDisplay=true
 Name=Captive Portal Browser
 X-MeeGo-Logical-Id=sailfish-browser-ap-name
 X-MeeGo-Translation-Catalog=sailfish-browser-captiveportal


### PR DESCRIPTION
A follow up to #701. This hides captive portal browser icon from application grid which was left for testing.