### PR TITLE
Update audio test page

### DIFF
--- a/tests/manual/testhtml5audio.html
+++ b/tests/manual/testhtml5audio.html
@@ -13,25 +13,31 @@
     <div>
       <h2>HTML5 Audio controls MP3</h2>
       <audio controls>
-        <source src="http://jolla.com/media/documents/Jolla_music_ringtone.mp3" type="audio/mpeg">
+        <source src="https://browser.sailfishos.org/media/jolla-ringtone.mp3" type="audio/mpeg">
         Browser does not support HTML5 Audio MP3 playback.
       </audio>
 
       <h2>HTML5 Audio controls OGG</h2>
       <audio controls>
-        <source src="http://jolla.com/media/documents/Jolla_music_ringtone.ogg" type="audio/ogg">
+        <source src="https://browser.sailfishos.org/media/jolla-ringtone.ogg" type="audio/ogg">
         Browser does not support HTML5 Audio OGG playback.
+      </audio>
+
+      <h2>HTML5 Audio controls FLAC</h2>
+      <audio controls>
+        <source src="https://browser.sailfishos.org/media/jolla-ringtone.flac" type="audio/flac">
+        Browser does not support HTML5 Audio FLAC playback.
       </audio>
     </div>
     <br/><br/><br/>
     <div>
-      <a href="http://jolla.com/media/documents/Jolla_music_ringtone.mp3">Download Jolla Ringtone MP3</a>
+      <a href="https://browser.sailfishos.org/media/jolla-ringtone.mp3">Download Jolla Ringtone MP3</a>
     </div>
     <div>
-      <a href="http://jolla.com/media/documents/Jolla_music_ringtone.ogg">Download Jolla Ringtone OGG</a>
+      <a href="https://browser.sailfishos.org/media/jolla-ringtone.ogg">Download Jolla Ringtone OGG</a>
     </div>
     <div>
-      <a href="http://jolla.com/media/documents/Jolla_music_ringtone.flac">Download Jolla Ringtone FLAC</a>
+      <a href="https://browser.sailfishos.org/media/jolla-ringtone.flac">Download Jolla Ringtone FLAC</a>
     </div>
   </body>
 </html>


### PR DESCRIPTION
The audio files being linked to by the audio test page were missing.
This updates the URLs to point to valid locations.

An audio player for FLAC is also now included.