### PR TITLE
[browser] Show toolbar properly when entering back to browser page. Fixes JB#45651

### DIFF
--- a/src/pages/BrowserPage.qml
+++ b/src/pages/BrowserPage.qml
@@ -290,7 +290,8 @@ Page {
         }
 
         onActiveChanged: {
-            if (active && webView.contentItem && !overlay.enteringNewTabUrl && !webView.contentItem.fullscreen) {
+            var isFullScreen = webView.contentItem && webView.contentItem.fullscreen
+            if (!isFullScreen && active && !overlay.enteringNewTabUrl) {
                 overlay.animator.showChrome()
             }
 


### PR DESCRIPTION
In case the contentItem does not exist, the fullscreen mode cannot be
true either. Fix showing up toolbar accordingly.