### PR TITLE
Add touch drift/browser margins test page

### DIFF
--- a/tests/manual/testmargindrift.html
+++ b/tests/manual/testmargindrift.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="initial-scale=1">
+    </head>
+        <body>
+            <div style="position: fixed; border: black solid; width: calc(50% - 10px); min-height: calc(100vh - 20px);">
+                <a href="#">First link</a>
+                <br/><a href="#">Second link</a>
+                <br/><a href="#">Third link</a>
+                <br/><a href="#">Fourth link</a>
+                <br/><a href="#">Fifth link</a>
+                <br/><a href="#">Sixth link</a>
+                <br/><a href="#">Seventh link</a>
+                <br/><a href="#">Eighth link</a>
+                <br/><a href="#">Ninth link</a>
+                <br/><a href="#">Tenth link</a>
+                <br/><a href="#">Eleventh link</a>
+                <br/><a href="#">Twelfth link</a>
+                <br/><a href="#">Thirteenth link</a>
+                <br/><a href="#">Fourteenth link</a>
+                <br/><a href="#">Fifteenth link</a>
+                <br/><a href="#">Second link</a>
+                <br/><a href="#">Third link</a>
+                <br/><a href="#">Fourth link</a>
+                <br/><a href="#">Fifth link</a>
+                <br/><a href="#">Sixth link</a>
+                <br/><a href="#">Seventh link</a>
+                <br/><a href="#">Eighth link</a>
+            </div>
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            <br/>
+            <div style="position:absolute; border: red solid; left: 33%; width: calc(66% - 10px);">
+                <p/>Test page margins. Left fixed; right scrollable.
+                <p/>Press and hold on a link to check the selection position hasn't drifted.
+                <p/>Check that both boxes are fully visible.
+                <p/>Test with/without toolbar. Use input field for keyboard.
+                <br/>
+                <form>
+                    <input type="text"/>
+                </form>
+                <a href="#">First link</a>
+                <br/><a href="#">Second link</a>
+                <br/><a href="#">Third link</a>
+                <br/><a href="#">Fourth link</a>
+                <br/><a href="#">Fifth link</a>
+                <br/><a href="#">Sixth link</a>
+                <br/><a href="#">Seventh link</a>
+                <br/><a href="#">Eighth link</a>
+                <br/><a href="#">Ninth link</a>
+                <br/><a href="#">Tenth link</a>
+                <br/><a href="#">Eleventh link</a>
+                <br/><a href="#">Twelfth link</a>
+                <br/><a href="#">Thirteenth link</a>
+                <br/><a href="#">Fourteenth link</a>
+                <br/><a href="#">Fifteenth link</a>
+                <br/><a href="#">Second link</a>
+                <br/><a href="#">Third link</a>
+                <br/><a href="#">Fourth link</a>
+                <br/><a href="#">Fifth link</a>
+                <br/><a href="#">Sixth link</a>
+                <br/><a href="#">Seventh link</a>
+                <br/><a href="#">Eighth link</a>
+            </div>
+        </div>
+    </body>
+</html>
+

--- a/tests/manual/testpage.html
+++ b/tests/manual/testpage.html
@@ -156,6 +156,9 @@
     <div>
       <a href="testbuttontarget.html">Touch button target</a>
     </div>
+    <div>
+      <a href="testmargindrift.html">Touch drift and fixed element tests with browser margins</a>
+    </div>
 
     <div class="header"><h2>Misc</h2></div>
     <div>


### PR DESCRIPTION
Adds a manual test page that's intended to help testing various aspects
of page display with page margins and the toolbar:

1. Are fixed elements correctly moved if the toolbar/keyboard is open.
2. Does element touch selection drift when the page is scrolled.
3. Are all elements (fixed and scrollable) fully visible on the page.