### PR TITLE
Add touch button target test page

### DIFF
--- a/tests/manual/testbuttontarget.html
+++ b/tests/manual/testbuttontarget.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script>
+            function colswap(style, col1, col2) {
+                style.backgroundColor = style.backgroundColor == col1 ? col2 : col1;
+            }
+        </script>
+    </head>
+    <body>
+        <p/>This demonstrates how the target of a &lt;button&gt; element is chosen.
+        <p/>Everything should be clickable, everything should change colour.
+        <p/>Broken in ESR60, should be fixed in ESR68, see mozilla bug 1089326.
+        <p/>
+        <button style="padding: 0; width: 600px; height: 300px; background-color: blue;" onClick="colswap(this.style, 'blue', 'cyan')">
+            <div style="width: 50%; height: 200%; background-color: red;" onClick="colswap(this.style, 'red', 'green')" />
+        </button>
+    </body>
+</html>
+

--- a/tests/manual/testpage.html
+++ b/tests/manual/testpage.html
@@ -153,6 +153,9 @@
     <div>
       <a href="testtouchclick.html">Touch input vs. mouse input</a>
     </div>
+    <div>
+      <a href="testbuttontarget.html">Touch button target</a>
+    </div>
 
     <div class="header"><h2>Misc</h2></div>
     <div>


### PR DESCRIPTION
Adds a manual test page for testing whether child elements within a
button element can be touch targets.

Prior to mozilla 66 the button was always the target. This was fixed
from 66 onwards to allow child elements to claim click, hover, etc.
events as well. The new behaviour matches that of other browsers and is
expected by some sites.

See mozilla bug 1089326.