### PR TITLE
[sailfish-browser] Rename favorites to bookmark. Fixes JB#51984

### DIFF
--- a/src/pages/PrivacySettingsPage.qml
+++ b/src/pages/PrivacySettingsPage.qml
@@ -93,8 +93,8 @@ Page {
 
                 TextSwitch {
                     id: clearBookmarks
-                    //% "Favorites"
-                    text: qsTrId("settings_browser-la-clear_favorites")
+                    //% "Bookmarks"
+                    text: qsTrId("settings_browser-la-clear_bookmarks")
                     checked: true
                 }
 

--- a/src/pages/components/BookmarkEditDialog.qml
+++ b/src/pages/components/BookmarkEditDialog.qml
@@ -23,10 +23,10 @@ UserPrompt {
 
     canAccept: urlField.text && titleField.text && (urlField.text !== url || titleField.text !== title)
 
-    //% "Edit favorite"
-    title: qsTrId("sailfish_browser-he-edit_favorite")
+    //% "Edit"
+    title: qsTrId("sailfish_browser-he-edit")
 
-    //: Save the bookmark/favorite
+    //: Accept text of bookmark edit dialog
     //% "Save"
     acceptText: qsTrId("sailfish_browser-la-accept_edit")
 

--- a/src/pages/components/FavoriteContextMenu.qml
+++ b/src/pages/components/FavoriteContextMenu.qml
@@ -45,15 +45,15 @@ Component {
         }
 
         MenuItem {
-            //% "Edit favorite"
-            text: qsTrId("sailfish_browser-me-edit_favorite")
+            //% "Edit"
+            text: qsTrId("sailfish_browser-me-edit")
             onClicked: delegate.editBookmark()
         }
 
         MenuItem {
-            //: "Remove favorited / bookmarked web page"
-            //% "Remove favorite"
-            text: qsTrId("sailfish_browser-me-remove_favorite")
+            //: "Remove bookmarked web page"
+            //% "Remove"
+            text: qsTrId("sailfish_browser-me-remove")
             onClicked: {
                 var d = delegate
                 var i = index

--- a/src/pages/components/SecondaryBar.qml
+++ b/src/pages/components/SecondaryBar.qml
@@ -33,8 +33,8 @@ Column {
         iconWidth: root.iconWidth
         horizontalOffset: root.horizontalOffset
         iconSource: "image://theme/icon-m-favorite-selected"
-        //% "Favourites"
-        text: qsTrId("sailfish_browser-la-favourites")
+        //% "Bookmarks"
+        text: qsTrId("sailfish_browser-la-bookmarks")
 
         onClicked: {
             showChrome()
@@ -93,7 +93,7 @@ Column {
             onTapped: webView.goForward()
         }
 
-        // Spacer for pushing Search, Favorite, Share, Downloads to the right hand side
+        // Spacer for pushing Search, Bookmark, Share, Downloads to the right hand side
         Item {
             height: parent.height
             width: parent.width - addTabButton.width - forwardButton.width - midIconWidth * 4 - downloadsButton.width


### PR DESCRIPTION
We have no technical differences for bookmark and favorite now. Same model used
However, the separate BookmarkPage is the bookmark for the user.
It is necessary to rename the places where are "favorite" words to "bookmark",
where is it clear. In the future, these will be different models