### PR TITLE
[sailfish-browser] Move header from page root to SilicaListView. Fixes JB#52084

### DIFF
--- a/src/pages/BookmarkPage.qml
+++ b/src/pages/BookmarkPage.qml
@@ -11,6 +11,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Browser 1.0
+import "components"
 
 Page {
     property string searchText
@@ -23,34 +24,26 @@ Page {
         search: searchText
     }
 
-    Column {
-        id: column
-        width: parent.width
-        PageHeader {
-            //% "Bookmarks"
-            title: qsTrId("sailfish_browser-he-bookmarks")
-        }
-        SearchField {
-            width: parent.width
-            //% "Search"
-            placeholderText: qsTrId("sailfish_browser-ph-search")
-            EnterKey.onClicked: focus = false
-            onTextChanged: searchText = text
-        }
-    }
-
     SilicaListView {
         id: listView
 
-        clip: true
-
-        width: parent.width
-        anchors {
-            bottom: parent.bottom
-            top: column.bottom
-        }
-
+        anchors.fill: parent
         model: bookmarkFilterModel
+
+        header: Column {
+            width: parent.width
+            PageHeader {
+                //% "Bookmarks"
+                title: qsTrId("sailfish_browser-he-bookmarks")
+            }
+            SearchField {
+                width: parent.width
+                //% "Search"
+                placeholderText: qsTrId("sailfish_browser-ph-search")
+                EnterKey.onClicked: focus = false
+                onTextChanged: searchText = text
+            }
+        }
 
         delegate: BookmarkItem { width: listView.width }
 

--- a/src/pages/HistoryPage.qml
+++ b/src/pages/HistoryPage.qml
@@ -11,6 +11,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Browser 1.0
+import "components"
 
 Page {
     id: root

--- a/src/pages/components/SecondaryBar.qml
+++ b/src/pages/components/SecondaryBar.qml
@@ -38,7 +38,7 @@ Column {
 
         onClicked: {
             showChrome()
-            pageStack.push("BookmarkPage.qml", { bookmarkModel: bookmarkModel })
+            pageStack.push("../BookmarkPage.qml", { bookmarkModel: bookmarkModel })
         }
     }
 
@@ -53,7 +53,7 @@ Column {
 
         onClicked: {
             showChrome()
-            var historyPage = pageStack.push("HistoryPage.qml", { model: historyModel })
+            var historyPage = pageStack.push("../HistoryPage.qml", { model: historyModel })
             historyPage.loadPage.connect(loadPage)
         }
     }


### PR DESCRIPTION
When panning content search field and bookmarks headers should be moving as well.
Also move HistoryPage and BookmarkPage to "pages" directory.