### PR TITLE
[sailfish-browser] Fix online network link status. Contributes to JB#45654

### DIFF
--- a/src/pages/components/ResourceController.qml
+++ b/src/pages/components/ResourceController.qml
@@ -101,7 +101,7 @@ Item {
 
     NetworkManager {
         id: networkManager
-        readonly property bool online: state == "online"
+        readonly property bool online: state == "online" || state == "ready"
 
         function notifyOfflineStatus() {
             if (WebEngine.isInitialized) {


### PR DESCRIPTION
States "online" and "ready" mean connman is online.
If online check fails then connman state is "ready".