### PR TITLE
[browser] Move data to new location. JB#51740

### DIFF
--- a/common/browserapp.cpp
+++ b/common/browserapp.cpp
@@ -10,6 +10,7 @@
 
 #include <QCoreApplication>
 #include <QString>
+#include <QStandardPaths>
 #include "browserapp.h"
 
 bool BrowserApp::captivePortal()
@@ -18,7 +19,7 @@ bool BrowserApp::captivePortal()
     static bool argsChecked = false;
 
     if (!argsChecked) {
-        if (QCoreApplication::arguments().contains(QStringLiteral("-captiveportal")))
+        if (QCoreApplication::arguments().contains(QLatin1String("-captiveportal")))
             captivePortalMode = true;
         argsChecked = true;
     }
@@ -28,20 +29,10 @@ bool BrowserApp::captivePortal()
 
 QString BrowserApp::profileName()
 {
-    static QString profileName = QStringLiteral("mozembed");
-    static bool argsChecked = false;
-
-    if (!argsChecked) {
-        const QStringList &arguments = QCoreApplication::arguments();
-
-        if (arguments.contains(QStringLiteral("-profile"))) {
-            int index = arguments.indexOf(QStringLiteral("-profile"));
-            if (index + 1 < arguments.size()) {
-                profileName = arguments.at(index + 1);
-            }
-        } else if (BrowserApp::captivePortal()) {
-            profileName = QStringLiteral("captiveportal");
-        }
+    const QStringList &arguments = QCoreApplication::arguments();
+    int index = arguments.indexOf(QLatin1String("-profile"));
+    if (index >= 0 && index + 1 < arguments.size()) {
+        return arguments.at(index + 1);
     }
-    return profileName;
+    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
 }

--- a/oneshot.d/browser-cleanup-startup-cache
+++ b/oneshot.d/browser-cleanup-startup-cache
@@ -1,3 +1,7 @@
 #!/bin/sh
+# Old startup cache location
 rm -rf ~/.mozilla/mozembed/startupCache
 rm -rf ~/.mozilla/captiveportal/startupCache
+# New startup cache location
+rm -rf ~/.local/share/sailfish-browser/.mozilla/startupCache
+rm -rf ~/.local/share/sailfish-browser-captiveportal/.mozilla/startupCache

--- a/oneshot.d/browser-move-data-to-new-location
+++ b/oneshot.d/browser-move-data-to-new-location
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Moves Browser and Captive portal profiles to new location
+OLD_BROWSER_PROFILE_PATH="$HOME/.mozilla/mozembed"
+NEW_BROWSER_PROFILE_PATH="$HOME/.local/share/org.sailfishos/sailfish-browser/.mozilla"
+
+OLD_CAPTIVE_PORTAL_PROFILE_PATH="$HOME/.mozilla/captiveportal"
+NEW_CAPTIVE_PORTAL_PROFILE_PATH="$HOME/.local/share/org.sailfishos/sailfish-browser-captiveportal/.mozilla"
+
+if [ -e "$OLD_BROWSER_PROFILE_PATH/" ] && [ ! -e "$NEW_BROWSER_PROFILE_PATH/" ]
+then
+    rm -f $OLD_BROWSER_PROFILE_PATH/.parentlock
+    mkdir -p "$NEW_BROWSER_PROFILE_PATH"
+    if mv "$OLD_BROWSER_PROFILE_PATH/"* "$NEW_BROWSER_PROFILE_PATH/"
+    then
+        rmdir "$OLD_BROWSER_PROFILE_PATH"
+    fi
+fi
+
+if [ -e "$OLD_CAPTIVE_PORTAL_PROFILE_PATH/" ] && [ ! -e "$NEW_CAPTIVE_PORTAL_PROFILE_PATH/" ]
+then
+    rm -f $OLD_CAPTIVE_PORTAL_PROFILE_PATH/.parentlock
+    mkdir -p "$NEW_CAPTIVE_PORTAL_PROFILE_PATH"
+    if mv "$OLD_CAPTIVE_PORTAL_PROFILE_PATH/"* "$NEW_CAPTIVE_PORTAL_PROFILE_PATH/"
+    then
+        rmdir "$OLD_CAPTIVE_PORTAL_PROFILE_PATH"
+    fi
+fi
+
+exit 0

--- a/oneshot.d/browser-update-default-data
+++ b/oneshot.d/browser-update-default-data
@@ -1,9 +1,9 @@
 #!/bin/sh
-MOZEMBED_DIR=~/.mozilla/mozembed
-CAPTIVE_PORTAL_DIR=~/.mozilla/captiveportal
+BROWSER_PROFILE_DIR=~/.local/share/org.sailfishos/sailfish-browser/.mozilla
+CAPTIVE_PORTAL_PROFILE_DIR=~/.local/share/org.sailfishos/sailfish-browser-captiveportal/.mozilla
 BROWSER_DATA_DIR=/usr/share/sailfish-browser/data
 
-for PROFILE_DIR in $MOZEMBED_DIR $CAPTIVE_PORTAL_DIR; do
+for PROFILE_DIR in $BROWSER_PROFILE_DIR $CAPTIVE_PORTAL_PROFILE_DIR; do
     if [ ! -d "$PROFILE_DIR" ]; then
         mkdir -p $PROFILE_DIR
     fi

--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -120,6 +120,7 @@ ln -s %{name} %{buildroot}%{_bindir}/%{name}-captiveportal
 if [ "$1" -ge 2 ]; then
     %{_bindir}/add-oneshot --all-users --now browser-cleanup-startup-cache || :
     %{_bindir}/add-oneshot --new-users --all-users --late browser-update-default-data || :
+    %{_bindir}/add-oneshot --all-users browser-move-data-to-new-location || :
 fi
 
 %files

--- a/sailfish-browser.pro
+++ b/sailfish-browser.pro
@@ -14,7 +14,8 @@ chrome_scripts.files = chrome/*.js
 chrome_scripts.path = $$[QT_INSTALL_LIBS]/mozembedlite/chrome/embedlite/content
 
 oneshots.files = oneshot.d/browser-cleanup-startup-cache \
-                 oneshot.d/browser-update-default-data
+                 oneshot.d/browser-update-default-data \
+                 oneshot.d/browser-move-data-to-new-location
 oneshots.path  = /usr/lib/oneshot.d
 
 data.files = data/prefs.js \

--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -27,8 +27,8 @@
 #include <QDebug>
 #include <webengine.h>
 #include <webenginesettings.h>
+#include <browserapp.h>
 
-const auto MOZILLA_DATA_DIR = QStringLiteral("/.mozilla/mozembed/");
 const auto MOZILLA_DATA_UA_UPDATE = QStringLiteral("ua-update.json");
 const auto MOZILLA_DATA_UA_UPDATE_SOURCE = QStringLiteral("/usr/share/sailfish-browser/data/ua-update.json.in");
 const auto MOZILLA_DATA_PREFS = QStringLiteral("prefs.js");
@@ -43,11 +43,12 @@ BrowserPrivate::BrowserPrivate(QQuickView *view)
 
 void BrowserPrivate::initUserData()
 {
-    QDir dir(QDir::homePath() + MOZILLA_DATA_DIR);
+    QString mozillaDir = QString("%1/.mozilla/").arg(BrowserApp::profileName());
+    QDir dir(mozillaDir);
     if (!dir.exists())
         dir.mkpath(dir.path());
 
-    QFile ua(QDir::homePath() + MOZILLA_DATA_DIR + MOZILLA_DATA_UA_UPDATE);
+    QFile ua(mozillaDir + MOZILLA_DATA_UA_UPDATE);
     if (!ua.exists()) {
         if (ua.open(QIODevice::WriteOnly)) {
             QFile source(MOZILLA_DATA_UA_UPDATE_SOURCE);
@@ -66,8 +67,8 @@ void BrowserPrivate::initUserData()
         }
     }
 
-    if (!QFile::exists(QDir::homePath() + MOZILLA_DATA_DIR + MOZILLA_DATA_PREFS))
-        QFile::copy(MOZILLA_DATA_PREFS_SOURCE, QDir::homePath() + MOZILLA_DATA_DIR + MOZILLA_DATA_PREFS);
+    if (!QFile::exists(mozillaDir + MOZILLA_DATA_PREFS))
+        QFile::copy(MOZILLA_DATA_PREFS_SOURCE, mozillaDir + MOZILLA_DATA_PREFS);
 }
 
 Browser::Browser(QQuickView *view, QObject *parent)


### PR DESCRIPTION
Move browser and captive portal profiles to .cache/org.sailfishos/sailfish-browser
and .cache/org.sailfishos/sailfish-browser-captiveportal respectively
to better adhere to freedesktop standards.

Adds oneshot that can be removed after it's been in one stop release.