### PR TITLE
[sailfish-browser] Fix restoring old backups. Fixes JB#52318

### DIFF
--- a/backup-unit/browserunit.cpp
+++ b/backup-unit/browserunit.cpp
@@ -6,6 +6,8 @@
 #include <QVariantMap>
 #include <QDebug>
 #include <QLoggingCategory>
+#include <QFileInfo>
+#include <QDir>
 #include <sys/types.h>
 #include <signal.h>
 #include <set>
@@ -70,21 +72,67 @@ const QString browser_dir = ".local/share/org.sailfishos/browser";
 const QString moz_dir = browser_dir + "/.mozilla";
 // thumbs
 const QString cache_dir = ".cache/org.sailfishos/browser";
+// files
+const QString bookmarks = "/bookmarks.json";
+const QString database = "/sailfish-browser.sqlite";
+const QString keys = "/key3.db";
+const QString signons = "/signons.sqlite";
 
 const QVariantMap info = {
     {"home", QVariantMap({
                 {"data", QVariantList({
-                                  browser_dir + "/bookmarks.json"
+                                  browser_dir + bookmarks
                                 })}
                 , {"bin", QVariantList({
-                                  moz_dir + "/key3.db"
-                                , browser_dir + "/sailfish-browser.sqlite"
+                                  moz_dir + keys
+                                , browser_dir + database
                                 , cache_dir
-                                , moz_dir + "/signons.sqlite"
+                                , moz_dir + signons
                                 })
                         }})}
     , {"options", QVariantMap({{"overwrite", true}})}
 };
+
+// old paths
+const QString old_browser_dir = ".local/share/org.sailfishos/sailfish-browser";
+const QString old_moz_dir = ".mozilla/mozembed";
+const QString old_cache_dir = ".cache/org.sailfishos/sailfish-browser";
+
+}
+
+void fix(QString common, QString file, QString oldPath, QString newPath)
+{
+    const auto pathTemplate = QStringLiteral("%1/%3/%2").arg(common).arg(file);
+    QFileInfo source(pathTemplate.arg(oldPath));
+    if (source.exists()) {
+        QFileInfo dest(pathTemplate.arg(newPath));
+        dest.dir().mkpath(".");
+        if (!source.dir().rename(source.fileName(), dest.absoluteFilePath())) {
+            qCWarning(lcBackupLog) << "Moving" << source.filePath()
+                                   << "to" << dest.absoluteFilePath() << "failed";
+        }
+    }
+}
+
+void fix_dir(QString common, QString oldPath, QString newPath)
+{
+    if (QFileInfo(common + "/" + oldPath).exists()) {
+        if (!QDir(common).rename(oldPath, newPath)) {
+            qCWarning(lcBackupLog) << "Moving" << oldPath
+                                   << "to" << newPath << "failed";
+        }
+    }
+}
+
+void fix_import()
+{
+    // Check for old style backup and convert to current structure if needed
+    fix(vault::unit::optValue("dir"), bookmarks, old_browser_dir, browser_dir);
+    auto blobDir = vault::unit::optValue("bin-dir");
+    fix(blobDir, database, old_browser_dir, browser_dir);
+    fix(blobDir, keys, old_moz_dir, moz_dir);
+    fix(blobDir, signons, old_moz_dir, moz_dir);
+    fix_dir(blobDir, old_cache_dir, cache_dir);
 }
 
 int main(int argc, char *argv[])
@@ -95,6 +143,9 @@ int main(int argc, char *argv[])
     } catch (std::exception const &e) {
         qCDebug(lcBackupLog) << e.what();
         return 1;
+    }
+    if (vault::unit::optValue("action") == "import") {
+        fix_import();
     }
     return vault::unit::execute(info);
 }


### PR DESCRIPTION
This moves the files around in the in memory copy of the archive before
restoring it. This doesn't modify the archive itself because it is
mounted with nosave option.