### PR TITLE
Allow some D-Bus APIs for unprivileged clients

### DIFF
--- a/apps/browser/browserservice.h
+++ b/apps/browser/browserservice.h
@@ -74,6 +74,8 @@ signals:
 
 private:
     bool isPrivileged() const;
+    uint getCallerPid() const;
+    bool matchesOwner(uint pid) const;
 
     BrowserUIServicePrivate *d_ptr;
     Q_DISABLE_COPY(BrowserUIService)

--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -343,7 +343,9 @@ Page {
             }
 
             webView.grabActivePage()
-            if (!webView.tabModel.activateTab(url)) {
+            if (webView.tabModel.activateTab(url)) {
+                webView.releaseActiveTabOwnership()
+            } else {
                 webView.clearSelection()
                 webView.tabModel.newTab(url)
                 overlay.dismiss(true, !Qt.application.active /* immadiate */)

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -56,6 +56,7 @@ Shared.Background {
             }
 
             if (!searchField.enteringNewTabUrl) {
+                webView.releaseActiveTabOwnership()
                 webView.load(pageUrl)
             } else {
                 // Loading will start once overlay animator has animated chrome visible.

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -134,6 +134,10 @@ public:
     bool isActiveTab(int tabId);
     bool activatePage(const Tab& tab, bool force = false, int parentId = 0);
     int findParentTabId(int tabId) const;
+    // For D-Bus interfaces
+    uint tabOwner(int tabId) const;
+    int requestTabWithOwner(int tabId, const QString &url, uint ownerPid);
+    Q_INVOKABLE void releaseActiveTabOwnership();
 
     Q_INVOKABLE void load(const QString &url = QString(), bool force = false);
     Q_INVOKABLE void reload(bool force = true);
@@ -291,6 +295,8 @@ private:
     QMozContext::TaskHandle m_clearSurfaceTask;
 
     bool m_closing;
+
+    QHash<int, uint> m_tabOwners;
 
     friend class tst_webview;
     friend class tst_declarativewebcontainer;


### PR DESCRIPTION
Privileged check doesn't work inside sandbox. There is little reason to
keep requestTab privileged API. This allow it for unprivileged clients.

It would be bad to allow closeTab for all. Mark the process that called
requestTab as owner of the tab and allow the owner to call it.