### PR TITLE
[sailfish-browser] Use invoker on D-Bus activation. Contributes to JB#52187

### DIFF
--- a/org.sailfishos.browser.service
+++ b/org.sailfishos.browser.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser
-Exec=/usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser -prestart
+Exec=/usr/bin/invoker -s --type=generic /usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser -prestart

--- a/org.sailfishos.browser.ui.service
+++ b/org.sailfishos.browser.ui.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser.ui
-Exec=/usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser -prestart
+Exec=/usr/bin/invoker -s --type=generic /usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser -prestart

--- a/org.sailfishos.captiveportal.service
+++ b/org.sailfishos.captiveportal.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.captiveportal
-Exec=/usr/bin/sailjail -p sailfish-captiveportal.desktop /usr/bin/sailfish-captiveportal -prestart -captiveportal
+Exec=/usr/bin/invoker -s --type=generic /usr/bin/sailjail -p sailfish-captiveportal.desktop /usr/bin/sailfish-captiveportal -prestart -captiveportal


### PR DESCRIPTION
Use invoker for correct cgroup delegation on D-Bus activation.