### PR TITLE
[browser] Ensure rendering is resumed when the window becomes visible. Contributes to JB#53152

### DIFF
--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -397,14 +397,18 @@ bool DeclarativeWebContainer::readyToPaint() const
 
 void DeclarativeWebContainer::setReadyToPaint(bool ready)
 {
-    if (m_mozWindow && m_mozWindow->setReadyToPaint(ready)) {
+    if (m_mozWindow) {
+        bool changed = m_mozWindow->setReadyToPaint(ready);
+
         if (ready) {
             m_mozWindow->resumeRendering();
         } else {
             m_mozWindow->suspendRendering();
         }
 
-        emit readyToPaintChanged();
+        if (changed) {
+            emit readyToPaintChanged();
+        }
     }
 }
 


### PR DESCRIPTION
Rendering can be suspended by means other than setting readyToPaint to
false so the previous value has limited meaning.