### PR TITLE
[sailfish-browser] Add icon for open-url .desktop entry. Contributes to JB#44657

### DIFF
--- a/open-url.desktop
+++ b/open-url.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Browser
+Icon=icon-launcher-browser
 NoDisplay=true
 X-MeeGo-Logical-Id=sailfish-browser-ap-name
 X-MeeGo-Translation-Catalog=sailfish-browser


### PR DESCRIPTION
Can be needed if there are multiple apps handling a url opening
and the user is presented a list to choose the app.

See also https://git.sailfishos.org/mer-core/libcontentaction/merge_requests/18

@rainemak 