### PR TITLE
[sailfish-browser] Remove handling downloadpicker from WebEngine. Contributes to JB#53798

### DIFF
--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -16,7 +16,6 @@ import Sailfish.Silica 1.0
 import Sailfish.Silica.private 1.0 as Private
 import Sailfish.Browser 1.0
 import Sailfish.Policy 1.0
-import Sailfish.WebEngine 1.0
 import "components" as Browser
 import "../shared" as Shared
 
@@ -390,27 +389,6 @@ Page {
                 debug = component.createObject(browserPage)
             } else {
                 console.warn("Failed to create DebugOverlay " + component.errorString())
-            }
-        }
-    }
-
-    Connections {
-        target: WebEngine
-        onRecvObserve: {
-            if (message === "embed:downloadpicker") {
-                var page = pageStack.push("Sailfish.Pickers.FolderPickerPage", {
-                                              showSystemFiles: false,
-                                              //% "Download to"
-                                              dialogTitle: qsTrId("sailfish_browser-ti-download-to")
-                                          })
-                page.onSelectedPathChanged.connect(function() {
-                    WebEngine.notifyObservers("embedui:downloadpicker",
-                                              {
-                                                  "downloadDirectory": page.selectedPath,
-                                                  "defaultFileName": data.defaultFileName,
-                                                  "suggestedFileExtension": data.suggestedFileExtension
-                                              })
-                })
             }
         }
     }

--- a/apps/core/declarativewebutils.cpp
+++ b/apps/core/declarativewebutils.cpp
@@ -132,8 +132,7 @@ void DeclarativeWebUtils::updateWebEngineSettings()
                                           "media-decoder-info",
                                           "embed:download",
                                           "embed:allprefs",
-                                          "embed:search",
-                                          "embed:downloadpicker" };
+                                          "embed:search" };
     webEngine->addObservers(messages);
 
     // Enable internet search


### PR DESCRIPTION
It is no longer required to do this here, its already in the PickerOpener.