### PR TITLE
Remove clearance of general.useragent.override user pref

### DIFF
--- a/oneshot.d/browser-update-default-data
+++ b/oneshot.d/browser-update-default-data
@@ -23,6 +23,5 @@ for PROFILE_DIR in $BROWSER_PROFILE_DIR $CAPTIVE_PORTAL_PROFILE_DIR; do
                 echo "$line" >> $PROFILE_DIR/prefs.js
             fi
         done < "$BROWSER_DATA_DIR/prefs.js"
-        sed -i /^user_pref\(\"general.useragent.override\"/d $PROFILE_DIR/prefs.js
     fi
 done


### PR DESCRIPTION
Clearing the general.useragent.override user pref was a temporary
addition intended to be removed on the next upgrade.

Reverts 426e60bed917d46e2191f6f1b15ebe22dacfd681