### PR TITLE
Add RemovableMedia Sailjail permission

### DIFF
--- a/sailfish-browser.desktop
+++ b/sailfish-browser.desktop
@@ -6,7 +6,8 @@ X-MeeGo-Translation-Catalog=sailfish-browser
 Icon=icon-launcher-browser
 Exec=/usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser %U
 Comment=Sailfish UI application
+
 [X-Sailjail]
-Permissions=Mozilla;Audio;Location;Privileged;Internet;Downloads;Documents;Pictures;Videos;Music;Sharing
+Permissions=Mozilla;Audio;Location;Privileged;Internet;Downloads;Documents;Pictures;Videos;Music;Sharing;RemovableMedia
 OrganizationName=org.sailfishos
 ApplicationName=browser


### PR DESCRIPTION
Allow browser to access documents on removable, external data storages
such as USB sticks and SD cards.