### PR TITLE
[sailfish-browser] Add shared folder to translations

### DIFF
--- a/apps/browser/browser.pro
+++ b/apps/browser/browser.pro
@@ -20,7 +20,7 @@ packagesExist(qdeclarative5-boostable) {
 }
 
 # Translations
-TS_PATH = $$PWD
+TS_PATH = $$PWD $$PWD/../shared
 TS_FILE = $$OUT_PWD/sailfish-browser.ts
 EE_QM = $$OUT_PWD/sailfish-browser_eng_en.qm
 include(../../translations/translations.pri)
@@ -33,6 +33,7 @@ include(../browser/browser.pri)
 include(../history/history.pri)
 include(../qtmozembed/qtmozembed.pri)
 include(../factories/factories.pri)
+include(../shared/shared.pri)
 include(settings/settings.pri)
 include(bookmarks/bookmarks.pri)
 
@@ -40,10 +41,6 @@ include(bookmarks/bookmarks.pri)
 qml.path = $$DEPLOYMENT_PATH
 qml.files = qml/*.qml qml/pages qml/cover
 INSTALLS += qml
-
-qmlshared.path = $$DEPLOYMENT_PATH/shared
-qmlshared.files = ../shared/*
-INSTALLS += qmlshared
 
 # C++ sources
 SOURCES += main.cpp

--- a/apps/captiveportal/captiveportal.pro
+++ b/apps/captiveportal/captiveportal.pro
@@ -19,7 +19,7 @@ packagesExist(qdeclarative5-boostable) {
     warning("qdeclarative5-boostable not available; startup times will be slower")
 }
 
-TS_PATH = $$PWD
+TS_PATH = $$PWD $$PWD/../shared
 TS_FILE = $$OUT_PWD/sailfish-captiveportal.ts
 EE_QM = $$OUT_PWD/sailfish-captiveportal_eng_en.qm
 include(../../translations/translations.pri)
@@ -31,15 +31,12 @@ include(../core/core.pri)
 include(../history/history.pri)
 include(../qtmozembed/qtmozembed.pri)
 include(../factories/factories.pri)
+include(../shared/shared.pri)
 
 # QML files and folders of captiveportal
 qml.path = $$DEPLOYMENT_PATH
 qml.files = qml/captiveportal.qml qml/pages
 INSTALLS += qml
-
-qmlshared.path = $$DEPLOYMENT_PATH/shared
-qmlshared.files = ../shared/*
-INSTALLS += qmlshared
 
 # Captive portal sources
 SOURCES += captiveportaladaptor.cpp \

--- a/apps/shared/shared.pri
+++ b/apps/shared/shared.pri
@@ -1,0 +1,4 @@
+qmlshared.path = $$DEPLOYMENT_PATH/shared
+qmlshared.files = ../shared/*.qml
+INSTALLS += qmlshared
+


### PR DESCRIPTION
To ensure lupdate runs over the QML files in the shared folder.