### PR TITLE
Ensure BookmarkFilterModel::filterAcceptsRow() can be called out-of-order

### DIFF
--- a/apps/browser/bookmarks/bookmarkfiltermodel.h
+++ b/apps/browser/bookmarks/bookmarkfiltermodel.h
@@ -36,9 +36,16 @@ signals:
     void maxDisplayedItemsChanged(int maxDisplayedItems);
 
 private:
+    void resetCounts();
+    void extendCheckPosition(int sourceRow, const QModelIndex &sourceParent) const;
+    bool filterAcceptsRowUnbounded(int sourceRow, const QModelIndex &sourceParent) const;
+
+private:
     QString m_search;
     int m_maxDisplayedItems;
     mutable int m_countFilterAccepts;
+    mutable int m_sourceMaxAccept;
+    mutable int m_maxSourceModelPosition;
 };
 
 #endif // BOOKMARKFILTERMODEL_H


### PR DESCRIPTION
To be added on top of https://github.com/sailfishos/sailfish-browser/pull/798, so will be WIP until that has been merged.

A small glitch meant that favicons downloaded when a favourite was added
could trigger a `dataChanged()` signal while the model was being
constructed, which interacted badly with the accept count.

This change ensures that `filterAcceptRow()` calls can be received in any
order and still respond correctly.
