### PR TITLE
[browser] Use p2p dbus for transfer engine API. Contributes to JB#54084 OMP#JOLLA-113

### DIFF
--- a/apps/core/downloadmanager.h
+++ b/apps/core/downloadmanager.h
@@ -47,6 +47,8 @@ public slots:
 
 private slots:
     void recvObserve(const QString message, const QVariant data);
+    void discoveryFailed();
+    void discoverySucceeded(const QString &p2pAddress);
 
 private:
     explicit DownloadManager();


### PR DESCRIPTION
Asynchronously initialize the interface, via a two step process:
- discovery via session bus (will autostart transfer-engine)
- connection via p2p bus (ensures transferred data is private)