### PR TITLE
Add device lock gate for password access

### DIFF
--- a/apps/browser/qml/pages/EditLoginPage.qml
+++ b/apps/browser/qml/pages/EditLoginPage.qml
@@ -11,11 +11,13 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Browser 1.0
+import "components"
 
 Dialog {
     id: page
     property int uid: -1
     property LoginModel loginModel
+    property SecureAction secureAction
     property alias hostname: hostnameField.text
     property alias username: usernameField.text
     property alias password: passwordField.text
@@ -63,6 +65,17 @@ Dialog {
             PasswordField {
                 id: passwordField
                 EnterKey.onClicked: focus = false
+                showEchoModeToggle: secureAction.available
+
+                _automaticEchoModeToggle: false
+
+                on_EchoModeToggleClicked: {
+                    if (_usePasswordEchoMode) {
+                        secureAction.perform(function () { _usePasswordEchoMode = false });
+                    } else {
+                        _usePasswordEchoMode = true
+                    }
+                }
             }
 
             Item {

--- a/apps/browser/qml/pages/SettingsPage.qml
+++ b/apps/browser/qml/pages/SettingsPage.qml
@@ -213,12 +213,13 @@ Page {
 
                     Icon {
                         id: loginsIcon
-                        source: "image://theme/icon-m-contact"
+                        source: "image://theme/icon-m-keys"
                     }
                     Label {
                         width: parent.width - parent.spacing - permissionIcon.width
-                        //% "Logins and passwords"
-                        text: qsTrId("settings_browser-la-logins-and-passwords")
+                        //: The label for the button for accessing password management
+                        //% "Passwords"
+                        text: qsTrId("settings_browser-la-passwords")
                         anchors.verticalCenter: loginsIcon.verticalCenter
                     }
                 }

--- a/apps/browser/qml/pages/components/SecureAction.qml
+++ b/apps/browser/qml/pages/components/SecureAction.qml
@@ -1,0 +1,38 @@
+/****************************************************************************
+**
+** Copyright (c) 2021 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.0
+import com.jolla.settings.system 1.0
+import org.nemomobile.devicelock 1.0
+
+Authenticator {
+    id: deviceLockQuery
+    property bool requireAuthentication: true
+    property bool available: availableMethods !== Authenticator.NoAuthentication
+    property string message
+    property var _resolve
+
+    function perform(resolve) {
+        if (requireAuthentication && available) {
+            _resolve = resolve
+
+            deviceLockQuery.requestPermission(message, {})
+        } else {
+            resolve()
+        }
+    }
+
+    onPermissionGranted: {
+        if (_resolve) {
+            requireAuthentication = false
+            _resolve()
+        }
+    }
+}


### PR DESCRIPTION
The Logins list in Settings allows access to the user's stored account passwords, either by copying the password or editing it. This change introduces a device lock gate, so that the user has to perform device authentication (e.g. PIN, fingerprint) before the passwords will be shown.

Once authenticated, the user won't be asked again until the Logins list page has been exited.

Builds on top of #836, so only the latest commit (a07b351e0f4bb853475766e82fe6bae15884212c) contains changes from that.