### PR TITLE
Use WebEngine.initialized property

### DIFF
--- a/apps/shared/ResourceController.qml
+++ b/apps/shared/ResourceController.qml
@@ -104,7 +104,7 @@ Item {
         readonly property bool online: state == "online" || state == "ready"
 
         function notifyOfflineStatus() {
-            if (WebEngine.isInitialized) {
+            if (WebEngine.initialized) {
                 WebEngine.notifyObservers("embed-network-link-status",
                                           {
                                               "offline": !networkManager.online


### PR DESCRIPTION
`WebEngine.initialized` is now a property (see qtmozembed) so we can use it as such.