### PR TITLE
Avoid duplicating ConfigurationValue

### DIFF
--- a/apps/browser/qml/pages/SettingsPage.qml
+++ b/apps/browser/qml/pages/SettingsPage.qml
@@ -82,7 +82,10 @@ Page {
                         textFormat: Text.StyledText
                         color: highlighted ? Theme.highlightColor : Theme.primaryColor
                         text: Theme.highlightText(title, site, Theme.highlightColor)
-                        onClicked: pageStack.animatorPush(Qt.resolvedUrl("components/AddHomePageDialog.qml"))
+                        onClicked: {
+                            pageStack.animatorPush(Qt.resolvedUrl("components/AddHomePageDialog.qml"),
+                                                   {homePageConfig: homePageConfig})
+                        }
                     }
                 }
             }

--- a/apps/browser/qml/pages/components/AddHomePageDialog.qml
+++ b/apps/browser/qml/pages/components/AddHomePageDialog.qml
@@ -15,6 +15,8 @@ import org.nemomobile.configuration 1.0
 
 Dialog {
     id: dialog
+
+    property ConfigurationValue homePageConfig
     canAccept: textField.text !== ""
     onAccepted: {
         homePageConfig.value = textField.text.trim() || "about:blank"
@@ -38,12 +40,5 @@ Dialog {
         label: placeholderText
         inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhUrlCharactersOnly
         EnterKey.onClicked: dialog.accept()
-    }
-
-    ConfigurationValue {
-        id: homePageConfig
-
-        key: "/apps/sailfish-browser/settings/home_page"
-        defaultValue: "http://jolla.com/"
     }
 }


### PR DESCRIPTION
If two or more ConfigurationValue instances are duplicated simultaneously, the values are not correctly updated for sandboxed apps. There is no problem if only a single instance exists at a time.

This change ensures the ConfigurationValue for the home page is shared rather than duplicated when the folder picker is pushed.

This doesn't address the underlying Sailjail issue, however even once addressed, I believe this change is appropriate anyway (since it shouldn't be necessary to use DBus to send data within the same app).