### PR TITLE
[sailfish-browser] Require MediaIndexing permissions. Fixes JB#54534 OMP#JOLLA-188

### DIFF
--- a/sailfish-browser.desktop
+++ b/sailfish-browser.desktop
@@ -12,6 +12,6 @@ X-Maemo-Object-Path=/ui
 X-Maemo-Method=org.sailfishos.browser.ui.openUrl
 
 [X-Sailjail]
-Permissions=WebView;Audio;Location;Privileged;Internet;Downloads;Documents;Pictures;Videos;Music;Sharing;RemovableMedia
+Permissions=WebView;Audio;Location;Privileged;Internet;Downloads;Documents;Pictures;Videos;Music;Sharing;RemovableMedia;MediaIndexing
 OrganizationName=org.sailfishos
 ApplicationName=browser


### PR DESCRIPTION
Access to tracker is required for the file pickers.