### PR TITLE
Remove close button from the toolbar

### DIFF
--- a/apps/browser/qml/pages/components/AddToAppGridDialog.qml
+++ b/apps/browser/qml/pages/components/AddToAppGridDialog.qml
@@ -7,7 +7,7 @@ BookmarkEditDialog {
     property QtObject bookmarkWriterParent
 
     //% "Add to App Grid"
-    title: qsTrId("sailfish_browser-he-add_bookmark_to_launcher")
+    description: qsTrId("sailfish_browser-he-add_bookmark_to_launcher")
     canAccept: editedUrl !== "" && editedTitle !== ""
     onAccepted: {
         if (desktopBookmarkWriter) {

--- a/apps/browser/qml/pages/components/BookmarkEditDialog.qml
+++ b/apps/browser/qml/pages/components/BookmarkEditDialog.qml
@@ -14,9 +14,11 @@ import Sailfish.Silica 1.0
 import Sailfish.WebView.Popups 1.0
 
 UserPromptDialog {
+    id: root
     property string url
     property string title
     property int index
+    property string description
 
     property alias editedUrl: urlField.text
     property alias editedTitle: titleField.text
@@ -40,48 +42,62 @@ UserPromptDialog {
     //% "Save"
     acceptText: qsTrId("sailfish_browser-la-accept_edit")
 
-    Column {
-        width: parent.width
-        spacing: Theme.paddingMedium
+    SilicaFlickable {
+        anchors.fill: parent
+        contentHeight: contentColumn.height
 
-        TextField {
-            id: titleField
+        Column {
+            id: contentColumn
+            width: parent.width
+            spacing: Theme.paddingMedium
 
-            text: title
-            focus: true
+            DialogHeader {
+                dialog: root
+                _glassOnly: true
+                acceptText: root.acceptText
+                cancelText: root.cancelText
+                title: root.description
+            }
 
-            acceptableInput: text.length > 0
-            onActiveFocusChanged: if (!activeFocus) errorHighlight = !acceptableInput
-            onAcceptableInputChanged: if (acceptableInput) errorHighlight = false
+            TextField {
+                id: titleField
 
-            //: Label for bookmark/favorite's title edit field
-            //% "Title"
-            label: qsTrId("sailfish_browser-la-title_editor")
-            //% "Title is required"
-            description: errorHighlight ? qsTrId("sailfish_browser-la-title_editor_error") : ""
+                text: title
+                focus: true
 
-            EnterKey.iconSource: "image://theme/icon-m-enter-next"
-            EnterKey.onClicked: urlField.focus = true
-        }
+                acceptableInput: text.length > 0
+                onActiveFocusChanged: if (!activeFocus) errorHighlight = !acceptableInput
+                onAcceptableInputChanged: if (acceptableInput) errorHighlight = false
 
-        TextField {
-            id: urlField
-            text: url
+                //: Label for bookmark/favorite's title edit field
+                //% "Title"
+                label: qsTrId("sailfish_browser-la-title_editor")
+                //% "Title is required"
+                description: errorHighlight ? qsTrId("sailfish_browser-la-title_editor_error") : ""
 
-            acceptableInput: text.length > 0
-            onActiveFocusChanged: if (!activeFocus) errorHighlight = !acceptableInput
-            onAcceptableInputChanged: if (acceptableInput) errorHighlight = false
+                EnterKey.iconSource: "image://theme/icon-m-enter-next"
+                EnterKey.onClicked: urlField.focus = true
+            }
 
-            //: Label for textfield to edit bookmark's URL
-            //% "URL"
-            label: qsTrId("sailfish_browser-la-url_editor")
-            //% "URL is required"
-            description: errorHighlight ? qsTrId("sailfish_browser-la-url_editor_error") : ""
-            inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhUrlCharactersOnly
+            TextField {
+                id: urlField
+                text: url
 
-            EnterKey.enabled: canAccept
-            EnterKey.iconSource: "image://theme/icon-m-enter-accept"
-            EnterKey.onClicked: accept()
+                acceptableInput: text.length > 0
+                onActiveFocusChanged: if (!activeFocus) errorHighlight = !acceptableInput
+                onAcceptableInputChanged: if (acceptableInput) errorHighlight = false
+
+                //: Label for textfield to edit bookmark's URL
+                //% "URL"
+                label: qsTrId("sailfish_browser-la-url_editor")
+                //% "URL is required"
+                description: errorHighlight ? qsTrId("sailfish_browser-la-url_editor_error") : ""
+                inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhUrlCharactersOnly
+
+                EnterKey.enabled: canAccept
+                EnterKey.iconSource: "image://theme/icon-m-enter-accept"
+                EnterKey.onClicked: accept()
+            }
         }
     }
 }

--- a/apps/browser/qml/pages/components/BookmarkItem.qml
+++ b/apps/browser/qml/pages/components/BookmarkItem.qml
@@ -106,11 +106,14 @@ ListItem {
                                                   })
             }
             MenuItem {
-                //% "Edit"
+                // Defined in FavoriteContextMenu.qml
+                // "Edit"
                 text: qsTrId("sailfish_browser-me-edit")
                 onClicked: {
                     var page = pageStack.animatorPush(editDialog,
                                            {
+                                               //% "Edit bookmark"
+                                               "description": qsTrId("sailfish_browser-he-edit-bookmark"),
                                                "url": url,
                                                "title": title,
                                                "index": bookmarkFilterModel.getIndex(model.index)

--- a/apps/browser/qml/pages/components/FavoriteGrid.qml
+++ b/apps/browser/qml/pages/components/FavoriteGrid.qml
@@ -73,6 +73,9 @@ IconGridViewBase {
             // index, url, title
             pageStack.animatorPush(editDialog,
                                    {
+                                       // Defined in BookmarkItem.qml
+                                       // "Edit bookmark"
+                                       "description": qsTrId("sailfish_browser-he-edit-bookmark"),
                                        "url": url,
                                        "title": title,
                                        "index": index,

--- a/apps/browser/qml/pages/components/ToolBar.qml
+++ b/apps/browser/qml/pages/components/ToolBar.qml
@@ -139,10 +139,26 @@ Column {
             Browser.TabButton {
                 id: tabs
 
-                icon.source: webView.privateMode ? "image://theme/icon-m-incognito" : "image://theme/icon-m-tabs"
+                icon.source: {
+                    if (webView.privateMode) {
+                        return webView.tabModel.count > 0 ? "image://theme/icon-m-incognito-selected"
+                                                          : "image://theme/icon-m-incognito"
+                    } else {
+                        return "image://theme/icon-m-tabs"
+                    }
+                }
+
+                label.color: {
+                    if (webView.privateMode) {
+                        return Theme.overlayBackgroundColor ? Theme.overlayBackgroundColor : "black"
+                    } else {
+                        return highlighted ? Theme.highlightColor : Theme.primaryColor
+                    }
+                }
+
                 opacity: findInPageActive ? 0.0 : 1.0
                 horizontalOffset: toolBarRow.horizontalOffset
-                label.text: webView.tabModel.count
+                label.text: webView.privateMode && (webView.tabModel.count === 0) ? "" : webView.tabModel.count
                 onTapped: toolBarRow.showTabs()
 
                 RotationAnimator {

--- a/apps/browser/qml/pages/components/ToolBar.qml
+++ b/apps/browser/qml/pages/components/ToolBar.qml
@@ -140,7 +140,7 @@ Column {
                 id: tabs
 
                 icon.source: webView.privateMode ? "image://theme/icon-m-incognito" : "image://theme/icon-m-tabs"
-                opacity: secondaryToolsActive || findInPageActive ? 0.0 : 1.0
+                opacity: findInPageActive ? 0.0 : 1.0
                 horizontalOffset: toolBarRow.horizontalOffset
                 label.text: webView.tabModel.count
                 onTapped: toolBarRow.showTabs()
@@ -169,14 +169,6 @@ Column {
                         rotationAnimator.restart()
                     }
                 }
-            }
-
-            Shared.IconButton {
-                opacity: secondaryToolsActive && !findInPageActive ? 1.0 : 0.0
-                icon.source: "image://theme/icon-m-tab-close"
-                icon.anchors.horizontalCenterOffset: toolBarRow.horizontalOffset
-                active: webView.tabModel.count > 0
-                onTapped: closeActiveTab()
             }
 
             Shared.IconButton {


### PR DESCRIPTION
Rolls up a few changes:

1. Remove close button from the toolbar.
    
    With the popup menu replacing the toolbar, the button can no longer be
    pressed to close the current tab. This removes the button, the tab can
    still be closed from the tab grid.

2. Ensure tab number is visible in private mode.
    
    When in private mode the tab icon on the toolbar has inverted colours.
    This change inverts the text colour so it's still visible on top of the
    icon.

3. Fix bookmark edit dialog header.
    
    The missing header was causing the dialog fields to overlap with the
    action buttons at the top of the page. This adds a header to fix it.

I can split them into separate PRs if that would make it easier to handle.
Still needs an OMP bug ref associated with it.