### PR TITLE
[browser] Avoid duplicating strings across subprojects. Fixes JB#54618

### DIFF
--- a/apps/browser/browser.pro
+++ b/apps/browser/browser.pro
@@ -20,7 +20,10 @@ packagesExist(qdeclarative5-boostable) {
 }
 
 # Translations
-TS_PATH = $$PWD $$PWD/../shared
+TS_PATH = $$PWD
+# Shared translations in browser.pro should be skipped from other subprojects
+# to avoid duplicated ids
+TS_PATH += $$PWD/../shared
 TS_FILE = $$OUT_PWD/sailfish-browser.ts
 EE_QM = $$OUT_PWD/sailfish-browser_eng_en.qm
 include(../../translations/translations.pri)

--- a/apps/captiveportal/captiveportal.pro
+++ b/apps/captiveportal/captiveportal.pro
@@ -19,7 +19,11 @@ packagesExist(qdeclarative5-boostable) {
     warning("qdeclarative5-boostable not available; startup times will be slower")
 }
 
-TS_PATH = $$PWD $$PWD/../shared
+# Translations
+TS_PATH = $$PWD
+# Shared translations in browser.pro should be skipped from other subprojects
+# to avoid duplicated ids
+#TS_PATH += $$PWD/../shared
 TS_FILE = $$OUT_PWD/sailfish-captiveportal.ts
 EE_QM = $$OUT_PWD/sailfish-captiveportal_eng_en.qm
 include(../../translations/translations.pri)


### PR DESCRIPTION
There are QML files shared by both the browser and captiveportal subprojects. If both projects run them through the translator there will be duplicate IDs, which unnecessarily increases work for the translators.

This change ensures the shared files are only parsed once.