### PR TITLE
Replace separate permissions with UserDirs.

### DIFF
--- a/sailfish-browser.desktop
+++ b/sailfish-browser.desktop
@@ -12,6 +12,6 @@ X-Maemo-Object-Path=/ui
 X-Maemo-Method=org.sailfishos.browser.ui.openUrl
 
 [X-Sailjail]
-Permissions=WebView;Audio;Location;Privileged;Internet;Downloads;Documents;Pictures;Videos;Music;Sharing;RemovableMedia;MediaIndexing
+Permissions=WebView;Audio;Location;Privileged;Internet;UserDirs;Sharing;RemovableMedia;MediaIndexing
 OrganizationName=org.sailfishos
 ApplicationName=browser


### PR DESCRIPTION
Replace separate Documents, Downloads, Music, Pictures and Videos
permission with UserDirs. This covers all the locations on user's $HOME
that should be available for the browser.