### PR TITLE
[browser] Cleanup 'Close all tabs on exit' description. Fixes JB#51764 OMP#JOLLA-165

### DIFF
--- a/apps/browser/qml/pages/SettingsPage.qml
+++ b/apps/browser/qml/pages/SettingsPage.qml
@@ -150,7 +150,7 @@ Page {
                 //: Label for text switch that makes all tabs closed upon closing browser application
                 //% "Close all tabs on exit"
                 text: qsTrId("settings_browser-la-close_all_tabs")
-                //% "Upon exiting Sailfish Browser all open tabs will be closed"
+                //% "When Browser is started next time, selected home page will be loaded"
                 description: qsTrId("settings_browser-la-close_all_tabs_description")
                 checked: closeAllTabsConfig.value
                 enabled: AccessPolicy.browserEnabled


### PR DESCRIPTION
Previously it was not clear what did happen after tabs were closed.
This commit changes description text to describe implications by saying
that "When Browser is started next time, selected Home page will be loaded".