### PR TITLE
[sailfish-browser] Use sandboxed booster. JB#54788 OMP#JOLLA-213

### DIFF
--- a/50-sailfish-browser.conf
+++ b/50-sailfish-browser.conf
@@ -1,0 +1,2 @@
+[Unit]
+Wants=booster-browser@sailfish-browser.service

--- a/data/70-browser.conf
+++ b/data/70-browser.conf
@@ -1,1 +1,1 @@
-BROWSER="invoker -s --type=generic /usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser"
+BROWSER="/usr/bin/invoker --type=browser,silica-qt5 -A -- /usr/bin/sailfish-browser"

--- a/org.sailfishos.browser.service
+++ b/org.sailfishos.browser.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser
-Exec=/usr/bin/invoker -s --type=generic /usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser -prestart
+Exec=/usr/bin/invoker --type=browser,silica-qt5 -A -- /usr/bin/sailfish-browser -prestart

--- a/org.sailfishos.browser.ui.service
+++ b/org.sailfishos.browser.ui.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.sailfishos.browser.ui
-Exec=/usr/bin/invoker -s --type=generic /usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser -prestart
+Exec=/usr/bin/invoker --type=browser,silica-qt5 -A -- /usr/bin/sailfish-browser -prestart

--- a/rpm/sailfish-browser.privileges
+++ b/rpm/sailfish-browser.privileges
@@ -1,1 +1,0 @@
-/usr/bin/sailfish-browser,lp

--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -14,7 +14,6 @@ Release:    1
 License:    MPLv2.0
 Url:        https://github.com/sailfishos/sailfish-browser
 Source0:    %{name}-%{version}.tar.bz2
-Source1:    %{name}.privileges
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Gui)
@@ -58,6 +57,7 @@ Requires: libkeepalive >= 1.7.0
 Requires: sailfish-components-pickers-qt5 >= 0.1.7
 Requires: nemo-qml-plugin-notifications-qt5 >= 1.0.12
 Requires: nemo-qml-plugin-systemsettings >= %{min_systemsettings_version}
+Requires: mapplauncherd-booster-browser
 
 %{_oneshot_requires_post}
 
@@ -108,9 +108,6 @@ chmod +x %{buildroot}/%{_oneshotdir}/*
 mkdir -p %{buildroot}/%{_sharedstatedir}/environment/nemo/
 cp -f data/70-browser.conf %{buildroot}/%{_sharedstatedir}/environment/nemo/
 
-mkdir -p %{buildroot}%{_datadir}/mapplauncherd/privileges.d
-install -m 644 -p %{SOURCE1} %{buildroot}%{_datadir}/mapplauncherd/privileges.d/
-
 %post
 /usr/bin/update-desktop-database -q || :
 
@@ -133,8 +130,8 @@ fi
 %{_datadir}/translations/%{name}*.qm
 %{_datadir}/translations/%{captiveportal}*.qm
 %{_datadir}/dbus-1/services/*.service
-%{_datadir}/mapplauncherd/privileges.d/*
 %{_oneshotdir}/*
+%{_userunitdir}/user-session.target.d/50-sailfish-browser.conf
 # Let main package own import root level
 %dir %{_libdir}/qt5/qml/org/sailfishos/browser
 %{_sharedstatedir}/environment/nemo/*

--- a/sailfish-browser.desktop
+++ b/sailfish-browser.desktop
@@ -4,7 +4,7 @@ Name=Web Browser
 X-MeeGo-Logical-Id=sailfish-browser-ap-name
 X-MeeGo-Translation-Catalog=sailfish-browser
 Icon=icon-launcher-browser
-Exec=/usr/bin/sailjail -p sailfish-browser.desktop /usr/bin/sailfish-browser %U
+Exec=/usr/bin/invoker --type=browser,silica-qt5 -A -- /usr/bin/sailfish-browser %U
 Comment=Sailfish UI application
 MimeType=text/html;application/xhtml+xml;application/xml;text/xml;x-scheme-handler/http;x-scheme-handler/https;
 X-Maemo-Service=org.sailfishos.browser.ui

--- a/sailfish-browser.pro
+++ b/sailfish-browser.pro
@@ -25,5 +25,9 @@ data.path = /usr/share/sailfish-browser/data
 
 INSTALLS += desktop dbus_service chrome_scripts oneshots data
 
+usersession.path = /usr/lib/systemd/user/user-session.target.d
+usersession.files += 50-sailfish-browser.conf
+INSTALLS += usersession
+
 OTHER_FILES += \
     rpm/*.spec

--- a/tests/manual/test-sailfish-browser.desktop
+++ b/tests/manual/test-sailfish-browser.desktop
@@ -2,5 +2,5 @@
 Type=Application
 Name=Test Web Browser
 Icon=/opt/tests/sailfish-browser/manual/icon-launcher-testbrowser.png
-Exec=/usr/bin/invoker -s --type=browser -G /usr/bin/sailfish-browser file:///opt/tests/sailfish-browser/manual/testpage.html
+Exec=/usr/bin/invoker --type=browser,silica-qt5 -A -- /usr/bin/sailfish-browser file:///opt/tests/sailfish-browser/manual/testpage.html
 Comment=Test Sailfish UI application


### PR DESCRIPTION
Instantiate browser booster on user session startup.

Modify exec lines in desktop and D-Bus autostart files so that
browser booster is used for launching.

Remove booster privilege configuration that is no longer needed.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>