### PR TITLE
[sailfish-browser] Fix popup menu drag to close with small menus. Fixes JB#54843 OMP#JOLLA-228

### DIFF
--- a/apps/browser/qml/pages/components/PopUpMenu.qml
+++ b/apps/browser/qml/pages/components/PopUpMenu.qml
@@ -97,6 +97,7 @@ SilicaControl {
 
                 interactive: popUpMenu.active   // Don't handle mouse events during fade out.
 
+                flickableDirection: Flickable.VerticalFlick
                 boundsBehavior: Flickable.DragOverBounds
 
                 onDragEnded: {


### PR DESCRIPTION
The gesture relies on vertical overscroll, so dragging must be enabled
even when the height of the menu content is not greater than the menu
itself.