### PR TITLE
[browser] Focus url field when new tab view requested. Fixes JB#54805 OMP#JOLLA-240

### DIFF
--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -213,8 +213,6 @@ Page {
         onCountChanged: {
             if (webView.tabModel.count === 0) {
                 webView.handleModelChanges(false)
-            } else if (!webView.tabModel.waitingForNewTab) {
-                overlay.animator.showChrome()
             }
         }
         onWaitingForNewTabChanged: window.opaqueBackground = webView.tabModel.waitingForNewTab

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -375,7 +375,7 @@ Shared.Background {
                 }
 
                 onRequestingFocusChanged: {
-                    if (requestingFocus && webView.tabModel.count !== 0) {
+                    if (requestingFocus) {
                         forceActiveFocus()
                     }
                 }


### PR DESCRIPTION
There are following cases that should be covered when triggering "Search"
from the Top Menu:
1) Browser not running and all tabs were closed on previous browsing session
2) Browser not running and there are tabs from the previous browsing session
3) Browser running with tabs and browsing view active
4) Browser running with tabs and tabs view active
5) Browser running without tabs and browsing view active
6) Browser running without tabs and tabs view active

I didn't see JB#53613 regressing due to this (sha1 d70d01bc4669d96)