### PR TITLE
[sailfish-browser] Add to history list: call context menu, open in incognito tab, save to bookmarks. Fixes JB#54882

### DIFF
--- a/apps/browser/qml/pages/HistoryPage.qml
+++ b/apps/browser/qml/pages/HistoryPage.qml
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (c) 2020 Open Mobile Platform LLC.
+** Copyright (c) 2020 - 2021 Open Mobile Platform LLC.
 **
 ****************************************************************************/
 
@@ -20,7 +20,8 @@ Page {
     property var remorse
     readonly property bool pendingRemorse: remorse ? remorse.pending : false
 
-    signal loadPage(string url)
+    signal loadPage(string url, bool newTab)
+    signal saveBookmark(string url, string title)
 
     HistoryList {
         id: view
@@ -32,8 +33,10 @@ Page {
         onLoad: {
             view.focus = true
             pageStack.pop()
-            root.loadPage(url)
+            root.loadPage(url, newTab)
         }
+
+        onSaveBookmark: root.saveBookmark(url, title)
 
         Component.onCompleted: model.search("")
 

--- a/apps/browser/qml/pages/components/HistoryItem.qml
+++ b/apps/browser/qml/pages/components/HistoryItem.qml
@@ -26,8 +26,53 @@ ListItem {
 
     width: parent.width
     contentHeight: Math.max(Theme.itemSizeMedium, column.height + 2*Theme.paddingMedium)
+    menu: Component {
+        ContextMenu {
+            MenuItem {
+                //% "Open in normal mode tab"
+                text: webView.privateMode ? qsTrId("sailfish_browser-me-open-in-normal-mode-tab")
+                                          : //% "Open in private tab"
+                                            qsTrId("sailfish_browser-me-open-in-private-tab")
+                onClicked: view.load(model.url, model.title, true)
+            }
+            MenuItem {
+                //: Share link from browser history pulley menu
+                //% "Share"
+                text: qsTrId("sailfish_browser-me-share-link")
+                onClicked: webShareAction.shareLink(model.url, model.title)
+            }
+            MenuItem {
+                //% "Copy to clipboard"
+                text: qsTrId("sailfish_browser-me-copy-to-clipboard")
+                onClicked: {
+                    Clipboard.text = model.url
+                    //% "Link address copied"
+                    notification.text = qsTrId("sailfish_browser-me-link_address_copied")
+                    notification.show()
+                }
+            }
+            MenuItem {
+                //% "Add to bookmarks"
+                text: qsTrId("sailfish_browser-me-add-to-bookmarks")
+                onClicked: view.saveBookmark(model.url, model.title)
+            }
+            MenuItem {
+                //: Delete history entry
+                //% "Delete"
+                text: qsTrId("sailfish_browser-me-delete")
+                onClicked: historyDelegate.remove(model.url)
+            }
+        }
+    }
 
     ListView.onAdd: AddAnimation { target: root }
+
+    Notice {
+        id: notification
+
+        duration: Notice.Short
+        verticalOffset: -Theme.itemSizeMedium
+    }
 
     Row {
         id: row
@@ -67,5 +112,5 @@ ListItem {
     }
 
     ListView.onRemove: animateRemoval()
-    onClicked: view.load(model.url, model.title)
+    onClicked: view.load(model.url, model.title, false)
 }

--- a/apps/browser/qml/pages/components/HistoryList.qml
+++ b/apps/browser/qml/pages/components/HistoryList.qml
@@ -20,42 +20,20 @@ SilicaListView {
     property bool showDeleteButton
     property bool menuClosed
 
-    signal load(string url, string title)
+    signal load(string url, string title, bool newTab)
+    signal saveBookmark(string url, string title)
+
+    onLoad: if (newTab) webView.privateMode = !webView.privateMode
 
     // To prevent model to steal focus
     currentIndex: -1
 
     delegate: HistoryItem {
         id: historyDelegate
-        menu: contextMenuComponent
+
         search: view.search
         showDeleteButton: view.showDeleteButton
         onMenuOpenChanged: view.menuClosed = !menuOpen
-
-        Component {
-            id: contextMenuComponent
-
-            ContextMenu {
-                MenuItem {
-                    //: Share link from browser history pulley menu
-                    //% "Share"
-                    text: qsTrId("sailfish_browser-me-share-link")
-                    onClicked: webShareAction.shareLink(model.url, model.title)
-                }
-                MenuItem {
-                    //% "Copy to clipboard"
-                    text: qsTrId("sailfish_browser-me-copy-to-clipboard")
-                    onClicked: Clipboard.text = model.url
-                }
-
-                MenuItem {
-                    //: Delete history entry
-                    //% "Delete"
-                    text: qsTrId("sailfish_browser-me-delete")
-                    onClicked: historyDelegate.remove(model.url)
-                }
-            }
-        }
     }
 
     WebShareAction {

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -42,7 +42,7 @@ Shared.Background {
     property bool _showUrlEntry
     readonly property bool _topGap: _showUrlEntry || _showFindInPage
 
-    function loadPage(url) {
+    function loadPage(url, newTab) {
         if (url == "about:config") {
             pageStack.animatorPush(Qt.resolvedUrl("ConfigWarning.qml"), {"browserPage": browserPage})
         } else if (url == "about:settings") {
@@ -57,7 +57,7 @@ Shared.Background {
                 pageUrl = "\"" + pageUrl.trim() + "\""
             }
 
-            if (!searchField.enteringNewTabUrl) {
+            if (!searchField.enteringNewTabUrl && !newTab) {
                 webView.releaseActiveTabOwnership()
                 webView.load(pageUrl)
             } else {
@@ -426,6 +426,9 @@ Shared.Background {
                 onClicked: {
                     var historyPage = pageStack.push("../HistoryPage.qml", { model: historyModel })
                     historyPage.loadPage.connect(loadPage)
+                    historyPage.saveBookmark.connect(function(url, title) {
+                        bookmarkModel.add(url, title || url, "", true)
+                    })
                 }
             }
 
@@ -596,10 +599,11 @@ Shared.Background {
                 showDeleteButton: true
                 onLoad: {
                     historyList.focus = true
-                    overlay.loadPage(url)
+                    overlay.loadPage(url, newTab)
                 }
                 // necessary for correct display of context menu of FavoriteGrid
                 onContentHeightChanged: if (menuClosed) contentY = favoriteGrid.y
+                onSaveBookmark: bookmarkModel.add(url, title || url, "", true)
 
                 Behavior on opacity { FadeAnimator {} }
             }


### PR DESCRIPTION
Added a fix for opening context menu of the history list.
Also added menu items (open in incognito tab, add to bookmarks) in accordance with the design:
![image](https://user-images.githubusercontent.com/78217859/124582325-97cab800-de5a-11eb-8960-a9fc861e7656.png)

It should be noted that when saving to bookmarks, the standard icon is always used.