### PR TITLE
Activate multiple available locales. JB#54830 OMP#JOLLA-222

### DIFF
--- a/data/prefs.js
+++ b/data/prefs.js
@@ -4,3 +4,4 @@ user_pref("gfx.compositor.clear-context", false);
 user_pref("embedlite.compositor.external_gl_context", true);
 user_pref("apz.allow_zooming", true);
 user_pref("dom.meta-viewport.enabled", true);
+user_pref("intl.locale.requested", "");


### PR DESCRIPTION
If the "intl.locale.requested" preference is unset, gecko will default
to only a single fallback locale. If it's set to an empty string, it
will instead set the locale based on the OS setting.

This adds the preference as an empty string to the default preferences.