### PR TITLE
[browser] Remove favicons when clearing history. Contributes to JB#54864 OMP#JOLLA-237

### DIFF
--- a/apps/storage/dbmanager.cpp
+++ b/apps/storage/dbmanager.cpp
@@ -13,6 +13,7 @@
 #include <QMetaObject>
 
 #include "dbworker.h"
+#include "faviconmanager.h"
 
 static DBManager *gDbManager = 0;
 
@@ -141,6 +142,7 @@ void DBManager::addHistoryEntry(const QString &url, const QString &title)
 
 void DBManager::clearHistory()
 {
+    FaviconManager::instance()->clear(QStringLiteral("history"));
     QMetaObject::invokeMethod(worker, "clearHistory", Qt::QueuedConnection);
 }
 

--- a/tests/auto/tst_dbmanager/tst_dbmanager.pro
+++ b/tests/auto/tst_dbmanager/tst_dbmanager.pro
@@ -5,5 +5,6 @@ QT += quick concurrent sql
 include(../test_common.pri)
 include(../../../common/browserapp.pri)
 include(../../../apps/storage/storage.pri)
+include(../mocks/faviconmanager/faviconmanager_mock.pri)
 
 SOURCES += tst_dbmanager.cpp

--- a/tests/auto/tst_webpagefactory/tst_webpagefactory.pro
+++ b/tests/auto/tst_webpagefactory/tst_webpagefactory.pro
@@ -9,6 +9,7 @@ include(../test_common.pri)
 include(../../../common/browserapp.pri)
 include(../../../apps/storage/storage.pri)
 include(../../../apps/factories/factories.pri)
+include(../mocks/faviconmanager/faviconmanager_mock.pri)
 
 SOURCES += tst_webpagefactory.cpp
 


### PR DESCRIPTION
SettingManager::clearHistory() calls
DBManager::clearHistory() calls
DBWorker::clearHistory() emits historyAvailable() which triggers
DeclarativeHistoryModel::historyAvailable() which calls
DeclarativeHistoryModel::updateModel().

Thus, DeclarativeHistoryModel::clear() is never invoked in this
codepath.  We cannot simply clear the favicon for any url which is
no longer represented in the history model within updateModel()
since historyAvailable() will be emitted with limited data (due to
the LIMIT in the query in the general case, or due to the WHERE
in the dynamic filter case).  As such, we need to ensure that we
manually clear the history favicons when DBManager::clearHistory()
is called.