### PR TITLE
Switch from NetworkManager to ConnectionHelper. JB#54831 OMP#JOLLA-223

### DIFF
--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -58,6 +58,7 @@ Requires: sailfish-components-pickers-qt5 >= 0.1.7
 Requires: nemo-qml-plugin-notifications-qt5 >= 1.0.12
 Requires: nemo-qml-plugin-systemsettings >= %{min_systemsettings_version}
 Requires: mapplauncherd-booster-browser
+Requires: nemo-qml-plugin-connectivity
 
 %{_oneshot_requires_post}
 


### PR DESCRIPTION
Introduces the ConnectionHelper to allow the network selector to be
triggered when the "network-enable" notification is sent.

NetworkManager was previously used for determining the  online status.
ConnectionHelper exposes the same functionality (it's a very light
wrapper around NetworkManager in fact), so ConnectionHelper is now used
for this instead.