### PR TITLE
[sailfish-browser] Recreate browser window from existing process on browser launch. Contributes to JB#54813

### DIFF
--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -385,6 +385,7 @@ Page {
                     overlay.enterNewTabUrl(PageStackAction.Immediate)
                 }
 
+                window.activate()
                 return
             }
 

--- a/apps/core/browser.cpp
+++ b/apps/core/browser.cpp
@@ -12,7 +12,6 @@
 
 #include "browser.h"
 #include "browser_p.h"
-#include "closeeventfilter.h"
 #include "declarativewebutils.h"
 #include "downloadmanager.h"
 #include "settingmanager.h"
@@ -36,7 +35,6 @@ const auto MOZILLA_DATA_PREFS_SOURCE = QStringLiteral("/usr/share/sailfish-brows
 
 BrowserPrivate::BrowserPrivate(QQuickView *view)
     : view(view)
-    , closeEventFilter(nullptr)
 {
     initUserData();
 }
@@ -90,9 +88,6 @@ Browser::Browser(QQuickView *view, QObject *parent)
     d->view->rootContext()->setContextProperty("Settings", SettingManager::instance());
     d->view->rootContext()->setContextProperty("DownloadManager", downloadManager);
 
-    d->closeEventFilter = new CloseEventFilter(downloadManager, this);
-    d->view->installEventFilter(d->closeEventFilter);
-
     QString mainQml = BrowserApp::captivePortal() ? "captiveportal.qml" : "browser.qml";
 
 #ifdef USE_RESOURCES
@@ -128,7 +123,6 @@ QString Browser::applicationFilePath()
 void Browser::openUrl(const QString &url)
 {
     Q_D(Browser);
-    d->closeEventFilter->cancelStopApplication();
     DeclarativeWebUtils::instance()->openUrl(url);
 }
 
@@ -140,14 +134,12 @@ void Browser::openSettings()
 void Browser::openNewTabView()
 {
     Q_D(Browser);
-    d->closeEventFilter->cancelStopApplication();
     emit DeclarativeWebUtils::instance()->activateNewTabViewRequested();
 }
 
 void Browser::showChrome()
 {
     Q_D(Browser);
-    d->closeEventFilter->cancelStopApplication();
     emit DeclarativeWebUtils::instance()->showChrome();
 }
 

--- a/apps/core/browser_p.h
+++ b/apps/core/browser_p.h
@@ -12,7 +12,6 @@
 #ifndef BROWSER_PRIVATE_H
 #define BROWSER_PRIVATE_H
 
-class CloseEventFilter;
 class QQuickView;
 
 class BrowserPrivate {
@@ -26,7 +25,6 @@ private:
 
 protected:
     QQuickView *view;
-    CloseEventFilter *closeEventFilter;
 };
 
 #endif // BROWSER_PRIVATE_H

--- a/apps/core/closeeventfilter.cpp
+++ b/apps/core/closeeventfilter.cpp
@@ -29,6 +29,16 @@ CloseEventFilter::CloseEventFilter(DownloadManager *dlMgr, QObject *parent)
             this, &CloseEventFilter::closeApplication);
 }
 
+void CloseEventFilter::applicationClosingStarted()
+{
+    if (!m_downloadManager->existActiveTransfers()) {
+        // Give the engine 60 seconds to send lastWindowDestroyed signal.
+        m_shutdownWatchdog.start(60000);
+    } else {
+        m_closing = true;
+    }
+}
+
 void CloseEventFilter::closeApplication()
 {
     if (m_downloadManager->existActiveTransfers()) {

--- a/apps/core/closeeventfilter.h
+++ b/apps/core/closeeventfilter.h
@@ -25,17 +25,18 @@ public:
     explicit CloseEventFilter(DownloadManager *dlMgr, QObject *parent = 0);
 
 public slots:
-    void cancelStopApplication();
+    void cancelCloseApplication();
+    void closeApplication();
 
 private slots:
-    void stopApplication();
-    void onLastWindowDestroyed();
     void onContextDestroyed();
     void onWatchdogTimeout();
+    void allTransfersCompleted();
 
 private:
     DownloadManager *m_downloadManager;
     QTimer m_shutdownWatchdog;
+    bool m_closing;
 };
 
 #endif

--- a/apps/core/closeeventfilter.h
+++ b/apps/core/closeeventfilter.h
@@ -25,6 +25,7 @@ public:
     explicit CloseEventFilter(DownloadManager *dlMgr, QObject *parent = 0);
 
 public slots:
+    void applicationClosingStarted();
     void cancelCloseApplication();
     void closeApplication();
 

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -913,6 +913,8 @@ void DeclarativeWebContainer::initialize()
                 this, &DeclarativeWebContainer::drawUnderlay, Qt::DirectConnection);
         connect(m_mozWindow.data(), &QMozWindow::orientationChangeFiltered,
                 this, &DeclarativeWebContainer::handleContentOrientationChanged);
+        connect(m_mozWindow.data(), &QMozWindow::compositorCreated,
+                this, &DeclarativeWebContainer::postClearWindowSurfaceTask);
         m_mozWindow->reserve();
         m_mozWindow->setReadyToPaint(false);
         if (m_chromeWindow) {

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -913,6 +913,7 @@ void DeclarativeWebContainer::initialize()
                 this, &DeclarativeWebContainer::drawUnderlay, Qt::DirectConnection);
         connect(m_mozWindow.data(), &QMozWindow::orientationChangeFiltered,
                 this, &DeclarativeWebContainer::handleContentOrientationChanged);
+        m_mozWindow->reserve();
         m_mozWindow->setReadyToPaint(false);
         if (m_chromeWindow) {
             updateContentOrientation(m_chromeWindow->contentOrientation());

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -661,6 +661,7 @@ bool DeclarativeWebContainer::eventFilter(QObject *obj, QEvent *event)
 {
     if (obj == m_chromeWindow) {
         if (event->type() == QEvent::Close) {
+            m_closeEventFilter->applicationClosingStarted();
             if (!m_closing) {
                 m_webPages->clear();
                 m_initialUrl = "";

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -233,6 +233,7 @@ private slots:
     void updateActiveTabRendered();
     void onLastViewDestroyed();
 
+    void onLastWindowDestroyed();
     void updateWindowFlags();
 
     // QMozWindow related slots:

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -241,6 +241,10 @@ private slots:
     void drawUnderlay();
 
     void handleContentOrientationChanged(Qt::ScreenOrientation orientation);
+    // Clears window surface on the compositor thread. Can be called even when there are
+    // no active views. In case this function is called too early during gecko initialization,
+    // before compositor thread has actually been started the function returns false.
+    bool postClearWindowSurfaceTask();
 
 private:
     void setWebPage(DeclarativeWebPage *webPage, bool triggerSignals = false);
@@ -253,10 +257,6 @@ private:
     bool browserEnabled() const;
 
     void destroyWindow();
-    // Clears window surface on the compositor thread. Can be called even when there are
-    // no active views. In case this function is called too early during gecko initialization,
-    // before compositor thread has actually been started the function returns false.
-    bool postClearWindowSurfaceTask();
     static void clearWindowSurfaceTask(void* data);
     void clearWindowSurface();
 

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -32,6 +32,7 @@ class DeclarativeWebPage;
 class WebPages;
 class Tab;
 class DeclarativeHistoryModel;
+class CloseEventFilter;
 
 class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protected QOpenGLFunctions {
     Q_OBJECT
@@ -310,6 +311,8 @@ private:
 
     QHash<int, uint> m_tabOwners;
     DeclarativeHistoryModel *m_historyModel;
+
+    CloseEventFilter *m_closeEventFilter;
 
     friend class tst_webview;
     friend class tst_declarativewebcontainer;

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -252,6 +252,7 @@ private:
     void setActiveTabRendered(bool rendered);
     bool browserEnabled() const;
 
+    void destroyWindow();
     // Clears window surface on the compositor thread. Can be called even when there are
     // no active views. In case this function is called too early during gecko initialization,
     // before compositor thread has actually been started the function returns false.
@@ -259,7 +260,7 @@ private:
     static void clearWindowSurfaceTask(void* data);
     void clearWindowSurface();
 
-    QScopedPointer<QMozWindow> m_mozWindow;
+    QPointer<QMozWindow> m_mozWindow;
     QPointer<QQuickItem> m_rotationHandler;
     QPointer<DeclarativeWebPage> m_webPage;
     QPointer<QQuickView> m_chromeWindow;


### PR DESCRIPTION
The full set of PRs related to this:
1. https://github.com/sailfishos/gecko-dev/pull/9
2. https://github.com/sailfishos/qtmozembed/pull/3
3. https://github.com/sailfishos/sailfish-browser/pull/897 (this)