### PR TITLE
[ua] User agent fix for ok.ru, zoom.us and corp.express. Fixes JB#55234

### DIFF
--- a/data/ua-update.json
+++ b/data/ua-update.json
@@ -87,5 +87,8 @@
   "trueconf.rt.ru": "Mozilla/5.0 (Android; Mobile; rv:66.0) Gecko/66.0 Firefox/66.0",
   "videomost.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
   "vk.com": "Sailfish 4.0#Android",
-  "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0; Linux) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396"
+  "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0; Linux) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
+  "ok.ru": "Sailfish 4.0#Android",
+  "zoom.us": "Sailfish 4.0#Android",
+  "corp.express": "Sailfish 4.0#Android"
 }

--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -112,5 +112,8 @@
   "trueconf.rt.ru": "Mozilla/5.0 (Android; Mobile; rv:66.0) Gecko/66.0 Firefox/66.0",
   "videomost.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
   "vk.com": "Sailfish 4.0#Android",
-  "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0; Linux) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396"
+  "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0; Linux) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
+  "ok.ru": "Sailfish 4.0#Android",
+  "zoom.us": "Sailfish 4.0#Android",
+  "corp.express": "Sailfish 4.0#Android"
 }

--- a/data/ua/60.0/ua-update.json
+++ b/data/ua/60.0/ua-update.json
@@ -87,5 +87,8 @@
   "trueconf.rt.ru": "Mozilla/5.0 (Android; Mobile; rv:66.0) Gecko/66.0 Firefox/66.0",
   "videomost.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
   "vk.com": "Sailfish 4.0#Android",
-  "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0; Linux) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396"
+  "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:60.0; Linux) Gecko/60.0 Firefox/60.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
+  "ok.ru": "Sailfish 4.0#Android",
+  "zoom.us": "Sailfish 4.0#Android",
+  "corp.express": "Sailfish 4.0#Android"
 }


### PR DESCRIPTION
The site ok.ru show mobile version.
The zoom.us doesn't show the error "The Operating System or the version of Operation System running is not supported" anymore.
The corp.express doesn't redirect to mobile version when opening desktop mode anymore.