### PR TITLE
[browser] Move placholder from HistoryPage to the HistoryList. Fixes JB#55176

### DIFF
--- a/apps/browser/qml/pages/HistoryPage.qml
+++ b/apps/browser/qml/pages/HistoryPage.qml
@@ -51,7 +51,7 @@ Page {
                 width: parent.width
                 //% "Search"
                 placeholderText: qsTrId("sailfish_browser-ph-search")
-                enabled: !pendingRemorse && view.model && view.model.count > 0
+                enabled: !pendingRemorse && view.model
 
                 EnterKey.onClicked: focus = false
                 onTextChanged: {
@@ -70,6 +70,8 @@ Page {
             }
         }
 
+        viewPlaceholder.enabled: root.pendingRemorse || !model.count
+
         PullDownMenu {
             visible: view.model && view.model.count
             MenuItem {
@@ -85,12 +87,6 @@ Page {
                                 })
                 }
             }
-        }
-
-        ViewPlaceholder {
-            //% "Websites you visit show up here"
-            text: qsTrId("sailfish_browser-la-websites-show-up-here")
-            enabled: root.pendingRemorse || !model.count
         }
     }
 }

--- a/apps/browser/qml/pages/components/HistoryList.qml
+++ b/apps/browser/qml/pages/components/HistoryList.qml
@@ -16,6 +16,8 @@ import Sailfish.WebView.Popups 1.0
 
 SilicaListView {
     id: view
+
+    property alias viewPlaceholder: viewPlaceholder
     property string search
     property bool showDeleteButton
     property bool menuClosed
@@ -38,6 +40,13 @@ SilicaListView {
 
     WebShareAction {
         id: webShareAction
+    }
+
+    ViewPlaceholder {
+        id: viewPlaceholder
+
+        //% "Websites you visit show up here"
+        text: qsTrId("sailfish_browser-la-websites-show-up-here")
     }
 
     VerticalScrollDecorator {}

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -605,6 +605,8 @@ Shared.Background {
                 onContentHeightChanged: if (menuClosed) contentY = favoriteGrid.y
                 onSaveBookmark: bookmarkModel.add(url, title || url, "", true)
 
+                viewPlaceholder.enabled: historyList.model && !historyList.model.count
+
                 Behavior on opacity { FadeAnimator {} }
             }
         }


### PR DESCRIPTION
Move placeholder and change condition for enabled property.
Make SearchField enabled when history model is empty.