### PR TITLE
RFC: Bring back the close button in the toolbar

### DIFF
--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -504,14 +504,6 @@ Shared.Background {
                 }
                 onShowChrome: overlayAnimator.showChrome()
 
-                onCloseActiveTab: {
-                    // Activates (loads) the tab next to the currect active.
-                    webView.tabModel.closeActiveTab()
-                    if (webView.tabModel.count === 0) {
-                        overlay.startPage(PageStackAction.Animated)
-                    }
-                }
-
                 onLoadPage: overlay.loadPage(url)
                 onEnterNewTabUrl: overlay.enterNewTabUrl()
                 onFindInPage: {

--- a/apps/browser/qml/pages/components/PopUpMenuFooter.qml
+++ b/apps/browser/qml/pages/components/PopUpMenuFooter.qml
@@ -27,6 +27,20 @@ Rectangle {
         height: root.height
 
         Shared.IconButton {
+            id: closeTabButton
+            width: Theme.itemSizeLarge
+            icon.source: "image://theme/icon-m-tab-close"
+            icon.opacity: enabled ? 1.0 : Theme.opacityLow
+            enabled: webView.tabModel.count > 0
+            onTapped: {
+                webView.tabModel.closeActiveTab()
+                if (webView.tabModel.count === 0) {
+                    overlay.startPage(PageStackAction.Animated)
+                }
+            }
+        }
+
+        Shared.IconButton {
             id: forwardButton
             width: Theme.itemSizeLarge
             icon.source: "image://theme/icon-m-forward"
@@ -34,18 +48,6 @@ Rectangle {
             enabled: webView.canGoForward
             onTapped: {
                 webView.goForward()
-                overlay.animator.showChrome()
-            }
-        }
-
-        Shared.IconButton {
-            id: shareButton
-            width: Theme.itemSizeLarge
-            icon.source: "image://theme/icon-m-share"
-            icon.opacity: enabled ? 1.0 : Theme.opacityLow
-            enabled: webView.contentItem
-            onTapped: {
-                overlay.toolBar.shareActivePage()
                 overlay.animator.showChrome()
             }
         }

--- a/apps/browser/qml/pages/components/PopUpMenuItem.qml
+++ b/apps/browser/qml/pages/components/PopUpMenuItem.qml
@@ -94,6 +94,22 @@ Item {
 
             OverlayListItem {
                 height: Theme.itemSizeSmall
+                enabled: webView.contentItem
+                opacity: enabled ? 1.0 : 0.5
+                iconWidth: root.iconWidth
+                horizontalOffset: root.horizontalOffset
+                iconSource: "image://theme/icon-m-share"
+                //% "Share"
+                text: qsTrId("sailfish_browser-la-share")
+
+                onClicked: {
+                    overlay.toolBar.shareActivePage()
+                    overlay.animator.showChrome()
+                }
+            }
+
+            OverlayListItem {
+                height: Theme.itemSizeSmall
                 enabled: !DownloadManager.pdfPrinting
                 opacity: enabled ? 1.0 : 0.5
                 iconWidth: root.iconWidth

--- a/apps/browser/qml/pages/components/ToolBar.qml
+++ b/apps/browser/qml/pages/components/ToolBar.qml
@@ -57,7 +57,6 @@ Column {
     signal showSecondaryTools
     signal showInfoOverlay
     signal showChrome
-    signal closeActiveTab
     signal showCertDetail
 
     // Used from the PopUpMenu


### PR DESCRIPTION
Closing annoying popups has become really hard with 4.2.0.19, because the close button wasn't clickable anymore. This happened for 3 reasons, the Animator sets the Overlay to disabled, the Flickable of the PopUpMenu covers the button and the InvertedMouseArea also stole the input from it. 0c03d773f2dd06a79612c45f0e9533950a39e41a fixes the Flickable covering the button, so we only needed to remove the `enabled: false` property change on the animator and make the InvertedMouseArea not steal inputs from it. That way the PopUpMenu still closes, when the close-tab button is pressed, but it also closes the tab, which imo is the right behaviour. The back button is now also clickable and closes the menu as well (and navigates back).

<del>
Because I thought the close button not working was an intentional change at first and the button was supposed to close the Menu now, I moved the share button to the menu and instead added a "close menu" button to the PopUpMenu. Since clicking outside and sliding down are the only ways to close the menu on next, this might be unnecessary.

There are a few small issues with this change though:

- The close button was later removed. I reverted that commit in this PR
- Background dimming was added. This makes the close button dimmed as well. Not sure if that is an issue and if it is, how it should be resolved.
- The menu doesn't render for me at all if I install this on 4.2.0.19, if I apply this patch on next. I think that is not my fault though, just that the shader the Background uses is maybe incompatible with 4.2.0.19? It works fine if I apply it on top of the 2.1.13 tag used in 4.2.0.19, but there the button is still covered by the Flickable and it sounds like useless duplication of effort to fix that there, if it is already fixed in next. EDIT: It seems like the shader does not work on my Xperia 10 II? Uncommenting the shader fixes it, but the menu is obviously scaled wrong in that case.
- If the Share change is acceptable, no idea if I did the localization stuff properly. I should probably find an existing share text instead and reuse its id?
</del>

I've since changed the approach to just add a close and back button to the menu footer as well as a close menu icon instead of the share button to prevent me from refreshing the page by accident. See https://github.com/sailfishos/sailfish-browser/pull/905#issuecomment-986977387 for more details.

For more discussion around the browser changes, see https://forum.sailfishos.org/t/browser-redesign-in-sailfish-4-2-feedback-thread/7867

I would appreciate some feedback on this change and if that would be an acceptable direction. It would also be nice to know, if I can somehow resolve the rendering issues so that I can properly test this. Thank you!