### PR TITLE
[sailfish-browser] Do not call CloseEventFilter::cancelStopApplication. Contributes to JB#54813

### DIFF
--- a/apps/core/browser.cpp
+++ b/apps/core/browser.cpp
@@ -128,7 +128,6 @@ QString Browser::applicationFilePath()
 void Browser::openUrl(const QString &url)
 {
     Q_D(Browser);
-    d->closeEventFilter->cancelStopApplication();
     DeclarativeWebUtils::instance()->openUrl(url);
 }
 
@@ -140,14 +139,12 @@ void Browser::openSettings()
 void Browser::openNewTabView()
 {
     Q_D(Browser);
-    d->closeEventFilter->cancelStopApplication();
     emit DeclarativeWebUtils::instance()->activateNewTabViewRequested();
 }
 
 void Browser::showChrome()
 {
     Q_D(Browser);
-    d->closeEventFilter->cancelStopApplication();
     emit DeclarativeWebUtils::instance()->showChrome();
 }
 

--- a/apps/core/closeeventfilter.cpp
+++ b/apps/core/closeeventfilter.cpp
@@ -60,10 +60,3 @@ void CloseEventFilter::onWatchdogTimeout()
 {
     qFatal("Browser failed to terminate in acceptable time!");
 }
-
-void CloseEventFilter::cancelStopApplication()
-{
-    disconnect(m_downloadManager, &DownloadManager::allTransfersCompleted,
-               this, &CloseEventFilter::stopApplication);
-    m_shutdownWatchdog.stop();
-}

--- a/apps/core/closeeventfilter.h
+++ b/apps/core/closeeventfilter.h
@@ -24,9 +24,6 @@ class CloseEventFilter : public QObject
 public:
     explicit CloseEventFilter(DownloadManager *dlMgr, QObject *parent = 0);
 
-public slots:
-    void cancelStopApplication();
-
 private slots:
     void stopApplication();
     void onLastWindowDestroyed();


### PR DESCRIPTION
CloseEventFilter::cancelStopApplication stops the browser process from
closing, but does not restore the browser window. This makes it impossible
to close current process and start a new instance of the browser without
the device reboot.