### PR TITLE
[sailfish-browser] Remove unneeded Sharing permission. JB#55380

### DIFF
--- a/sailfish-browser.desktop
+++ b/sailfish-browser.desktop
@@ -12,6 +12,6 @@ X-Maemo-Object-Path=/ui
 X-Maemo-Method=org.sailfishos.browser.ui.openUrl
 
 [X-Sailjail]
-Permissions=WebView;Audio;Location;Internet;UserDirs;Sharing;RemovableMedia;MediaIndexing
+Permissions=WebView;Audio;Location;Internet;UserDirs;RemovableMedia;MediaIndexing
 OrganizationName=org.sailfishos
 ApplicationName=browser


### PR DESCRIPTION
Sharing is allowed by default, separate permission is not needed.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>