### PR TITLE
[browser] Use combobox also for save destination. Fixes JB#55580

### DIFF
--- a/apps/browser/qml/pages/SettingsPage.qml
+++ b/apps/browser/qml/pages/SettingsPage.qml
@@ -45,32 +45,24 @@ Page {
                 title: qsTrId("sailfish_browser-he-settings")
             }
 
-            ComboBox {
+            BrowserComboBox {
                 id: homePage
 
                 readonly property bool _homePageBlank: homePageConfig.value === "about:blank"
 
-                width: parent.width
                 //: Label for home page text field
                 //% "Home Page"
                 label: qsTrId("settings_browser-la-home_page")
                 //% "Start view"
                 value: _homePageBlank ? qsTrId("sailfish_browser-la-start_view") : removeProtocolTypeFromUri(homePageConfig.value)
-                leftMargin: Theme.horizontalPageMargin + homePageIcon.width + Theme.paddingMedium
-                contentHeight: Theme.itemSizeMedium
 
                 currentIndex: _homePageBlank
                               ? 0 // For start view (blank)
                               : 1 // For web page
 
-                on_HomePageBlankChanged: currentIndex = _homePageBlank ? 0 : 1
+                iconSource: "image://theme/icon-m-home"
 
-                Icon {
-                    id: homePageIcon
-                    source: "image://theme/icon-m-home"
-                    anchors.verticalCenter: parent.verticalCenter
-                    x: Theme.horizontalPageMargin
-                }
+                on_HomePageBlankChanged: currentIndex = _homePageBlank ? 0 : 1
 
                 menu: ContextMenu {
                     MenuItem {
@@ -104,21 +96,13 @@ Page {
                 }
             }
 
-            ComboBox {
+            BrowserComboBox {
                 id: searchEngine
-                width: parent.width
+
                 //: Label for combobox that sets search engine used in browser
                 //% "Search with"
                 label: qsTrId("settings_browser-la-search_with")
-                leftMargin: Theme.horizontalPageMargin + searchIcon.width + Theme.paddingMedium
-                contentHeight: Theme.itemSizeMedium
-
-                Icon {
-                    id: searchIcon
-                    source: "image://theme/icon-m-search"
-                    anchors.verticalCenter: parent.verticalCenter
-                    x: Theme.horizontalPageMargin
-                }
+                iconSource: "image://theme/icon-m-search"
 
                 menu: ContextMenu {
                     Repeater {
@@ -280,7 +264,7 @@ Page {
                 text: qsTrId("settings_browser-la-downloads")
             }
 
-            BrowserListItem {
+            BrowserComboBox {
                 //% "Save destination"
                 label: qsTrId("settings_browser-la-save_destination")
                 iconSource: "image://theme/icon-m-downloads"
@@ -293,6 +277,9 @@ Page {
                         return qsTrId("sailfish_browser-me-always_ask")
                     }
                 }
+                currentIndex: WebEngineSettings.useDownloadDir
+                              ? 0 // for selection a download folder
+                              : 1 // for always ask
 
                 description: {
                     if (WebEngineSettings.useDownloadDir) {
@@ -310,6 +297,8 @@ Page {
                         text: qsTrId("sailfish_browser-me-select_download_folder")
                         onClicked: {
                             WebEngineSettings.useDownloadDir = true
+                            // If the user will reject, choose download path as default
+                            WebEngineSettings.downloadDir = StandardPaths.download
                             pageStack.animatorPush(folderPickerPage)
                         }
                     }

--- a/apps/browser/qml/pages/components/BrowserComboBox.qml
+++ b/apps/browser/qml/pages/components/BrowserComboBox.qml
@@ -1,0 +1,26 @@
+/****************************************************************************
+**
+** Copyright (c) 2021 Open Mobile Platform LLC
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+ComboBox {
+    property alias iconSource: icon.source
+
+    width: parent.width
+    leftMargin: Theme.horizontalPageMargin + icon.width + Theme.paddingMedium
+
+    Icon {
+        id: icon
+
+        anchors.verticalCenter: parent.verticalCenter
+        x: Theme.horizontalPageMargin
+    }
+}


### PR DESCRIPTION
The BrowserListItem isn't good for this case, because this should be highlighted by default for currentIndex.
So, it's good to use ComboBox instead and move general code to BrowserComboBox for avoiding duplicated code.
Set save destination by default if the user reject to choose download folder.