### PR TITLE
Use connectivity to establish online status. Fixes JB#55628 OMP#JOLLA-401

### DIFF
--- a/apps/shared/ResourceController.qml
+++ b/apps/shared/ResourceController.qml
@@ -1,7 +1,7 @@
 /****************************************************************************
 **
 ** Copyright (c) 2013 - 2019 Jolla Ltd.
-** Copyright (c) 2019 Open Mobile Platform LLC.
+** Copyright (c) 2019 - 2021 Open Mobile Platform LLC.
 ** Contact: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
 ** Contact: Raine Makelainen <raine.makelainen@jollamobile.com>
 **
@@ -107,17 +107,18 @@ Item {
 
     ConnectionHelper {
         id: connectionHelper
+        readonly property bool connected: status >= ConnectionHelper.Connected
 
         function notifyOfflineStatus() {
             if (WebEngine.initialized) {
                 WebEngine.notifyObservers("embed-network-link-status",
                                           {
-                                              "offline": !connectionHelper.online
+                                              "offline": !connectionHelper.connected
                                           })
             }
         }
 
-        onOnlineChanged: notifyOfflineStatus()
+        onConnectedChanged: notifyOfflineStatus()
     }
 
     DBusInterface {


### PR DESCRIPTION
This partially reverts changes made in 8014ee097530c4c902. In that
change, ConnectionHelper was introduced to allow the "Select Wifi
network" dialog to be triggered. In order to simplify the code, the
online status check was also switched to using ConnectionHelper.

It turns out this interferes with the captive portal, since this relies
on the "ready" state to be considered equivalent to "online". The
ConnectionHelper didn't respect this.

This change therefore switches back the online status check to using the
previous NetworkManager approach.

Setting as draft until I've tested the change.