### PR TITLE
[sailfish-browser] Fix adding link to bookmarks if opening history page via popup menu. Fixes JB#55694

### DIFF
--- a/apps/browser/qml/pages/HistoryPage.qml
+++ b/apps/browser/qml/pages/HistoryPage.qml
@@ -21,7 +21,7 @@ Page {
     readonly property bool pendingRemorse: remorse ? remorse.pending : false
 
     signal loadPage(string url, bool newTab)
-    signal saveBookmark(string url, string title)
+    signal saveBookmark(string url, string title, string favicon)
 
     HistoryList {
         id: view
@@ -36,7 +36,7 @@ Page {
             root.loadPage(url, newTab)
         }
 
-        onSaveBookmark: root.saveBookmark(url, title)
+        onSaveBookmark: root.saveBookmark(url, title, favicon)
 
         Component.onCompleted: model.search("")
 

--- a/apps/browser/qml/pages/components/HistoryItem.qml
+++ b/apps/browser/qml/pages/components/HistoryItem.qml
@@ -54,7 +54,7 @@ ListItem {
             MenuItem {
                 //% "Add to bookmarks"
                 text: qsTrId("sailfish_browser-me-add-to-bookmarks")
-                onClicked: view.saveBookmark(model.url, model.title)
+                onClicked: view.saveBookmark(model.url, model.title, model.favicon)
             }
             MenuItem {
                 //: Delete history entry

--- a/apps/browser/qml/pages/components/HistoryList.qml
+++ b/apps/browser/qml/pages/components/HistoryList.qml
@@ -23,7 +23,7 @@ SilicaListView {
     property bool menuClosed
 
     signal load(string url, string title, bool newTab)
-    signal saveBookmark(string url, string title)
+    signal saveBookmark(string url, string title, string favicon)
 
     onLoad: if (newTab) webView.privateMode = !webView.privateMode
 

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -426,8 +426,8 @@ Shared.Background {
                 onClicked: {
                     var historyPage = pageStack.push("../HistoryPage.qml", { model: historyModel })
                     historyPage.loadPage.connect(loadPage)
-                    historyPage.saveBookmark.connect(function(url, title) {
-                        bookmarkModel.add(url, title || url, "", true)
+                    historyPage.saveBookmark.connect(function(url, title, favicon) {
+                        bookmarkModel.add(url, title || url, favicon, true)
                     })
                 }
             }
@@ -603,7 +603,7 @@ Shared.Background {
                 }
                 // necessary for correct display of context menu of FavoriteGrid
                 onContentHeightChanged: if (menuClosed) contentY = favoriteGrid.y
-                onSaveBookmark: bookmarkModel.add(url, title || url, "", true)
+                onSaveBookmark: bookmarkModel.add(url, title || url, favicon, true)
 
                 viewPlaceholder.enabled: historyList.model && !historyList.model.count
 

--- a/apps/browser/qml/pages/components/PopUpMenuItem.qml
+++ b/apps/browser/qml/pages/components/PopUpMenuItem.qml
@@ -158,8 +158,12 @@ Item {
 
                 onClicked: {
                     overlay.animator.showChrome()
+                    var bookmarkModel = overlay.bookmarkModel
                     var historyPage = pageStack.push("../HistoryPage.qml", { model: overlay.historyModel })
                     historyPage.loadPage.connect(overlay.toolBar.loadPage)
+                    historyPage.saveBookmark.connect(function(url, title, favicon) {
+                        bookmarkModel.add(url, title || url, favicon, true)
+                    })
                 }
             }
 


### PR DESCRIPTION
Add a call to function of saving bookmarks in the PopUpMenuItem element.
Add use of favicon when saving to bookmarks.