### PR TITLE
[sailfish-browser] Fix browser termination when all downloads are completed. Fixes to JB#55836

### DIFF
--- a/apps/core/closeeventfilter.cpp
+++ b/apps/core/closeeventfilter.cpp
@@ -26,7 +26,7 @@ CloseEventFilter::CloseEventFilter(DownloadManager *dlMgr, QObject *parent)
     connect(&m_shutdownWatchdog, &QTimer::timeout,
             this, &CloseEventFilter::onWatchdogTimeout);
     connect(m_downloadManager, &DownloadManager::allTransfersCompleted,
-            this, &CloseEventFilter::closeApplication);
+            this, &CloseEventFilter::allTransfersCompleted);
 }
 
 void CloseEventFilter::applicationClosingStarted()


### PR DESCRIPTION
Terminate the browser process after all downloads have finished, only if it is being closed.