### PR TITLE
[sailfish-browser] Fix invalid thumbnail sizes for tabs being requested. JB#55754 OMP#JOLLA-417

### DIFF
--- a/apps/shared/WebView.qml
+++ b/apps/shared/WebView.qml
@@ -82,10 +82,13 @@ WebContainer {
     }
 
     function thumbnailCaptureSize() {
-        var ratio = browserPage.width / browserPage.thumbnailSize.width
+        var ratio = Math.min(
+                    browserPage.width / browserPage.thumbnailSize.width,
+                    browserPage.height / browserPage.thumbnailSize.height)
+        var width = browserPage.thumbnailSize.width * ratio
         var height = browserPage.thumbnailSize.height * ratio
 
-        return Qt.size(browserPage.width, height)
+        return Qt.size(width, height)
     }
 
     function grabActivePage() {


### PR DESCRIPTION
Scale the thumbnail size to fit the largest size that will fit the
window size rather scaling to fit the width which can produce heights
larger than the window in landscape.