### PR TITLE
[sailfish-browser] Replace clearing of "cookie" with "cookie and site data" in PrivacySettingsPage. JB#56151

### DIFF
--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -86,9 +86,10 @@ Page {
                  }
 
                 TextSwitch {
-                    id: clearCookies
-                    //% "Cookies"
-                    text: qsTrId("settings_browser-la-clear_cookies")
+                    id: clearCookiesAndSiteData
+
+                    //% "Cookies and site data"
+                    text: qsTrId("settings_browser-la-clear_cookies_and_site_data")
                     checked: true
                 }
 
@@ -133,7 +134,7 @@ Page {
                     text: qsTrId("settings_browser-bt-clear")
                     anchors.horizontalCenter: parent.horizontalCenter
                     enabled: clearHistory.checked
-                             || clearCookies.checked
+                             || clearCookiesAndSiteData.checked
                              || clearSavedPasswords.checked
                              || clearCache.checked
                              || clearBookmarks.checked
@@ -147,8 +148,8 @@ Page {
                                                      if (clearHistory.checked) {
                                                          Settings.clearHistory(historyErasingComboBox.currentItem.period)
                                                      }
-                                                     if (clearCookies.checked) {
-                                                         Settings.clearCookies()
+                                                     if (clearCookiesAndSiteData.checked) {
+                                                         Settings.clearCookiesAndSiteData()
                                                      }
                                                      if (clearSavedPasswords.checked) {
                                                          Settings.clearPasswords()

--- a/apps/core/settingmanager.cpp
+++ b/apps/core/settingmanager.cpp
@@ -62,9 +62,9 @@ void SettingManager::clearHistory(int period)
     DBManager::instance()->clearHistory(period);
 }
 
-void SettingManager::clearCookies()
+void SettingManager::clearCookiesAndSiteData()
 {
-    SailfishOS::WebEngine::instance()->notifyObservers(QString("clear-private-data"), QString("cookies"));
+    SailfishOS::WebEngine::instance()->notifyObservers(QString("clear-private-data"), QString("cookies-and-site-data"));
 }
 
 void SettingManager::clearPasswords()

--- a/apps/core/settingmanager.h
+++ b/apps/core/settingmanager.h
@@ -31,7 +31,7 @@ public:
     static SettingManager *instance();
 
     Q_INVOKABLE void clearHistory(int period);
-    Q_INVOKABLE void clearCookies();
+    Q_INVOKABLE void clearCookiesAndSiteData();
     Q_INVOKABLE void clearPasswords();
     Q_INVOKABLE void clearCache();
     Q_INVOKABLE void clearSitePermissions();


### PR DESCRIPTION
Change checkbox for clearing "cookies" to "cookies and site data".
Change clearCookies() method to clearCookieAndSiteData().