### PR TITLE
Initialise SettingManager at start up. Fixes JB#56200 OMP#JOLLA-507

### DIFF
--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -21,6 +21,7 @@
 #include "logging.h"
 #include "declarativehistorymodel.h"
 #include "closeeventfilter.h"
+#include "settingmanager.h"
 
 #include <webengine.h>
 #include <QTimerEvent>

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -10,8 +10,6 @@
 #ifndef DECLARATIVEWEBCONTAINER_H
 #define DECLARATIVEWEBCONTAINER_H
 
-#include "settingmanager.h"
-
 #include <qmozcontext.h>
 #include <qmozsecurity.h>
 #include <QtGui/QWindow>

--- a/apps/core/settingmanager.cpp
+++ b/apps/core/settingmanager.cpp
@@ -23,11 +23,12 @@ static SettingManager *gSingleton = 0;
 
 SettingManager::SettingManager(QObject *parent)
     : QObject(parent)
-    , m_initialized(false)
     , m_searchEnginesInitialized(false)
     , m_addedSearchEngines(0)
 {
     m_searchEngineConfItem = new MGConfItem("/apps/sailfish-browser/settings/search_engine", this);
+    connect(m_searchEngineConfItem, &MGConfItem::valueChanged,
+            this, &SettingManager::setSearchEngine);
 
     // Look and feel related settings
     m_toolbarSmall = new MGConfItem("/apps/sailfish-browser/settings/toolbar_small", this);
@@ -36,21 +37,6 @@ SettingManager::SettingManager(QObject *parent)
     connect(m_toolbarLarge, &MGConfItem::valueChanged, this, &SettingManager::toolbarLargeChanged);
     connect(SailfishOS::WebEngine::instance(), &SailfishOS::WebEngine::recvObserve,
             this, &SettingManager::handleObserve);
-}
-
-bool SettingManager::initialize()
-{
-    if (m_initialized) {
-        return false;
-    }
-
-    setSearchEngine();
-
-    connect(m_searchEngineConfItem, &MGConfItem::valueChanged,
-            this, &SettingManager::setSearchEngine);
-
-    m_initialized = true;
-    return m_initialized;
 }
 
 int SettingManager::toolbarSmall()

--- a/apps/core/settingmanager.h
+++ b/apps/core/settingmanager.h
@@ -52,7 +52,6 @@ private:
     MGConfItem *m_toolbarSmall;
     MGConfItem *m_toolbarLarge;
 
-    bool m_initialized;
     bool m_searchEnginesInitialized;
 
     QStringList *m_addedSearchEngines;

--- a/tests/auto/tst_logins/tst_logins.cpp
+++ b/tests/auto/tst_logins/tst_logins.cpp
@@ -27,6 +27,7 @@
 #include "datafetcher.h"
 #include "inputregion.h"
 #include "searchenginemodel.h"
+#include "settingmanager.h"
 
 #include "declarativewebutils.h"
 #include "webpages.h"

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -32,6 +32,7 @@
 #include "datafetcher.h"
 #include "inputregion.h"
 #include "searchenginemodel.h"
+#include "settingmanager.h"
 
 #include "declarativewebutils.h"
 #include "webpages.h"


### PR DESCRIPTION
The initialisation is needed to connect up change signals from the Search Provider DConf value. Hence prior to this change, if the user switched Search Provider, it wasn't applied until the next browser restart. This change fixes this.

This is a small regression from 68b52fef7fd89c12ddfe423 which removed the code initialising the `SettingManager` (for valid reasons, but it left it uninitialised).