### PR TITLE
Update browser cover on tab changes. Fixes JB#56224 OMP#JOLLA-513

### DIFF
--- a/apps/browser/qml/browser.qml
+++ b/apps/browser/qml/browser.qml
@@ -17,7 +17,7 @@ BrowserWindow {
     id: window
 
     function setBrowserCover(model) {
-        if (!model || model.count === 0) {
+        if (!model || model.count === 0 || !WebUtils.firstUseDone) {
             cover = Qt.resolvedUrl("cover/NoTabsCover.qml")
         } else {
             if (cover != null && window.webView) {

--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -200,8 +200,6 @@ Page {
                 overlay.startPage(openOverlayImmediately ? PageStackAction.Immediate
                                                          : PageStackAction.Animated)
             }
-
-            window.setBrowserCover(webView.tabModel)
         }
     }
 
@@ -214,6 +212,7 @@ Page {
             if (webView.tabModel.count === 0) {
                 webView.handleModelChanges(false)
             }
+            window.setBrowserCover(webView.tabModel)
         }
         onWaitingForNewTabChanged: window.opaqueBackground = webView.tabModel.waitingForNewTab
     }
@@ -417,13 +416,11 @@ Page {
             bringToForeground(webView.chromeWindow)
             window.activate()
         }
+        onFirstUseDoneChanged: window.setBrowserCover(webView.tabModel)
     }
 
     Component.onCompleted: {
-        if (!WebUtils.firstUseDone) {
-            window.setBrowserCover(webView.tabModel)
-        }
-
+        window.setBrowserCover(webView.tabModel)
         if (Qt.application.arguments.indexOf("-debugMode") > 0) {
             var component = Qt.createComponent(Qt.resolvedUrl("components/DebugOverlay.qml"))
             if (component.status === Component.Ready) {

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -668,12 +668,6 @@ Shared.Background {
                     webView.tabModel.clear()
                     overlay.startPage()
                 }
-
-                Component.onCompleted: {
-                    window.setBrowserCover(webView.tabModel)
-                }
-
-                Component.onDestruction: window.setBrowserCover(webView.tabModel)
             }
         }
     }


### PR DESCRIPTION
Adds a connection to ensure that the browser cover always gets updated whenever the number of tabs changes. Previously the switch from zero to one tabs (which triggers a cover change) wasn't being picked up, leaving the cover in an incorrect state.