### PR TITLE
Cleanup obsoloted user-agent overrides

### DIFF
--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -38,7 +38,6 @@
   "youtube.com": "Mozilla/5.0 (Android 8.1.0; U; Sailfish 4.0; rv:78.0) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Safari/538.1",
   // JB#39970, slashdot.org
   "slashdot.org": "Mozilla/5.0 (Android 8.1.0; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
-  "verkkokauppa.com": "Mozilla/5.0 (Android 8.1.0; U; Sailfish 4.0; rv:78.0) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Safari/538.1",
   // JB#48647, JB#45164 and JB#21093, google.com + some other country level domains
   "google.com": "Mozilla/5.0 (Android 8.1.0; U; Mobile; rv:78.0) Gecko/78.0 SailfishBrowser/1.0",
   "google.de": "Mozilla/5.0 (Android 8.1.0; U; Mobile; rv:78.0) Gecko/78.0 SailfishBrowser/1.0",

--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -96,7 +96,6 @@
   "ampparit.com": "Mozilla/5.0 (Linux; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "1tv.ru": "Mozilla/5.0 (Linux; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "sogou.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
-  "thomann.de": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "trueconf.rt.ru": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "trueconf.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "videomost.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Chrome/67.0.3396",

--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -93,8 +93,6 @@
   "ruutu.fi": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "iltalehti.fi": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   // JB#52587 alibi.fi, hymy.fi, ampparit.com, 1tv.ru
-  "alibi.fi": "Mozilla/5.0 (Linux; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
-  "hymy.fi": "Mozilla/5.0 (Linux; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "ampparit.com": "Mozilla/5.0 (Linux; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "1tv.ru": "Mozilla/5.0 (Linux; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "ask.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",

--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -36,14 +36,9 @@
   // JB#39351, tmall.com
   "tmall.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "youtube.com": "Mozilla/5.0 (Android 8.1.0; U; Sailfish 4.0; rv:78.0) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Safari/538.1",
-  "yahoo.com": "Mozilla/5.0 (Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
-  "yandex.com": "Mozilla/5.0 (Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
-  "yandex.net": "Mozilla/5.0 (Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
-  "yandex.ru": "Mozilla/5.0 (Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   // JB#39970, slashdot.org
   "slashdot.org": "Mozilla/5.0 (Android 8.1.0; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "verkkokauppa.com": "Mozilla/5.0 (Android 8.1.0; U; Sailfish 4.0; rv:78.0) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Safari/538.1",
-  "digicert.com": "Mozilla/5.0 (Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   // JB#48647, JB#45164 and JB#21093, google.com + some other country level domains
   "google.com": "Mozilla/5.0 (Android 8.1.0; U; Mobile; rv:78.0) Gecko/78.0 SailfishBrowser/1.0",
   "google.de": "Mozilla/5.0 (Android 8.1.0; U; Mobile; rv:78.0) Gecko/78.0 SailfishBrowser/1.0",

--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -95,7 +95,6 @@
   // JB#52587 alibi.fi, hymy.fi, ampparit.com, 1tv.ru
   "ampparit.com": "Mozilla/5.0 (Linux; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "1tv.ru": "Mozilla/5.0 (Linux; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
-  "ask.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "sogou.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "thomann.de": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "trueconf.rt.ru": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",


### PR DESCRIPTION
* [ua] Drop thomann.de user-agent override. Fixes JB#56016 OMP#JOLLA-461
  * For reference: JB#53530
* [ua] Drop ask.com user-agent override. JB#56016 OMP#JOLLA-461
  * For reference JB#51725
* [ua] Drop hymy.fi and alibi.fi user-agent overrides. JB#56016 OMP#JOLLA-461
* [ua] Drop verkkokauppa.com user-agent override. JB#56016 OMP#JOLLA-461
* [ua] Cleanup user-agent overrides that matches to default. JB#56016 OMP#JOLLA-461
