### PR TITLE
[sailfish-browser] Fix error reading tab thumbnails from cache. Fixes  JB#56298 OMP#JOLLA-533

### DIFF
--- a/apps/qtmozembed/declarativewebpage.cpp
+++ b/apps/qtmozembed/declarativewebpage.cpp
@@ -301,9 +301,12 @@ void DeclarativeWebPage::forceChrome(bool forcedChrome)
 
 void DeclarativeWebPage::grabResultReady()
 {
-    if (active()) {
-        QImage image = m_grabResult->image();
-        m_grabWritter.setFuture(QtConcurrent::run(this, &DeclarativeWebPage::saveToFile, image));
+    QImage image = m_grabResult->image();
+    if (!image.isNull() && active()) {
+        m_grabWritter.setFuture(QtConcurrent::run(
+                &DeclarativeWebPage::saveToFile,
+                image,
+                QStringLiteral("%1/tab-%2-thumb.jpg").arg(BrowserPaths::cacheLocation()).arg(tabId())));
     }
     m_grabResult.clear();
 }
@@ -344,15 +347,20 @@ void DeclarativeWebPage::updateViewMargins()
     setMargins(margins);
 }
 
-QString DeclarativeWebPage::saveToFile(QImage image)
+QString DeclarativeWebPage::saveToFile(const QImage &image, const QString &path)
 {
-    if (image.isNull() || !active()) {
-        return "";
+    if (allBlack(image)) {
+        return QString();
     }
 
-    // 75% quality jpg produces small and good enough capture.
-    QString path = QString("%1/tab-%2-thumb.jpg").arg(BrowserPaths::cacheLocation()).arg(tabId());
-    return !allBlack(image) && image.save(path, "jpg", 75) ? path : "";
+    QSaveFile saveFile(path);
+    if (image.save(&saveFile, "jpg", 75)) {
+        saveFile.commit();
+
+        return path;
+    } else {
+        return QString();
+    }
 }
 
 void DeclarativeWebPage::onRecvAsyncMessage(const QString& message, const QVariant& data)

--- a/apps/qtmozembed/declarativewebpage.h
+++ b/apps/qtmozembed/declarativewebpage.h
@@ -91,7 +91,7 @@ private slots:
     void updateViewMargins();
 
 private:
-    QString saveToFile(QImage image);
+    static QString saveToFile(const QImage &image, const QString &path);
     void restoreHistory();
 
     QPointer<DeclarativeWebContainer> m_container;


### PR DESCRIPTION
QImage (Qt 5.6) writes directly to the target file when saving, so if an
Image item happens to try and read from it at the same file then that
may fail because the file is incomplete.

The concurrent read/write may happen because an existing tab is being
updated, or because saveToFile() was dispatched to a thread and the user
could have switched tabs in the interim leading to the data being
written to the thumbnail of a different tab.