### PR TITLE
[sailfish-browser] Use pulley menu for actions in tab page.

### DIFF
--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -626,9 +626,6 @@ Shared.Background {
                 portrait: tabPage.isPortrait
                 privateMode: webView.privateMode
 
-                scaledPortraitHeight: toolBar.scaledPortraitHeight
-                scaledLandscapeHeight: toolBar.scaledLandscapeHeight
-
                 onHide: pageStack.pop()
 
                 onPrivateModeChanged: {

--- a/apps/browser/qml/pages/components/TabGridView.qml
+++ b/apps/browser/qml/pages/components/TabGridView.qml
@@ -19,6 +19,7 @@ SilicaGridView {
     property bool closingAllTabs
 
     property var remorsePopup
+    readonly property int _spacing: Theme.paddingLarge
     readonly property bool largeScreen: Screen.sizeCategory > Screen.Medium
     readonly property real thumbnailHeight: largeScreen
                                             ? Screen.width / 3
@@ -27,10 +28,9 @@ SilicaGridView {
                                         ? portrait ? 2 : 3
                                         : parent.width < 2 * parent.height
                                           ? parent.width <= height ? 1 : 2 : 3
-    readonly property real thumbnailWidth: (parent.width - Theme.horizontalPageMargin * 2 - (Theme.paddingLarge * (columns - 1))) / columns
+    readonly property real thumbnailWidth: (parent.width - Theme.horizontalPageMargin * 2 - (_spacing * (columns - 1))) / columns
 
     signal hide
-    signal enterNewTabUrl
     signal activateTab(int index)
     signal closeTab(int index)
     signal closeAll
@@ -59,12 +59,17 @@ SilicaGridView {
     onCountChanged: if (count > 0) closingAllTabs = false
     onClosingAllTabsChanged: if (closingAllTabs) closeAllPending()
 
-    width: parent.width - Theme.horizontalPageMargin
-    height: parent.height
-    x: Theme.horizontalPageMargin
+    anchors.fill: parent
     currentIndex: model.activeTabIndex
-    cellWidth: thumbnailWidth + Theme.paddingLarge
-    cellHeight: thumbnailHeight + Theme.paddingLarge
+    cellWidth: thumbnailWidth + _spacing
+    cellHeight: thumbnailHeight + _spacing
+    contentItem.anchors.left: tabGridView.left
+    contentItem.anchors.leftMargin: Theme.horizontalPageMargin
+
+    header: Item {
+        width: 1
+        height: _spacing
+    }
 
     delegate: TabItem {
         id: tabItem
@@ -94,25 +99,15 @@ SilicaGridView {
         }
     ]
 
-
-    Item {
-        height: parent.height
-        anchors.right: parent.right
-        width: Math.round(Theme.paddingSmall/2)
-
-        VerticalScrollDecorator {
-            _forcedParent: parent
-            flickable: tabGridView
-        }
-    }
+    VerticalScrollDecorator {}
 
     ViewPlaceholder {
         x: -Theme.horizontalPageMargin
         width: parent.width + Theme.horizontalPageMargin
         enabled: !model.count || closingAllTabs
         //: Hint to create a new tab via button new tab.
-        //% "Push button plus to create a new tab"
-        text: qsTrId("sailfish_browser-la-push_button_plus_to_create_tab_hint")
+        //% "Pull down menu to create a new tab"
+        text: qsTrId("sailfish_browser-la-pull_menu_to_create_tab_hint")
     }
 
     Timer {


### PR DESCRIPTION
This is a suggestion to use a pulley menu instead of a toolbar with a menu in the tab list page.

There are three actions in the menu of this page at the moment :
- open a new tab,
- open a new private tab
- and close all tabs.
I've transfered these actions into a pulley menu. The only difference is that the first action opens a new tab in the current mode and the second action opens one in the other mode while the menu is using a fixed layout whatever the mode.

I've removed the toolbar since the action of the add button is in the pulley, and the back action is a normal LtoR swipe. This allows more screen estate for the tab list without loosing actions, keeping consistency with the rest of the OS.

I've moved the tab bar switching the mode to the bottom, so it can be accessed easily one handed with the thumb. Its position at the bottom is quite consistent with the toolbar of the main page view from which we are coming from to arrive on the tab list page.

As discussed in the forum (https://forum.sailfishos.org/t/browser-redesign-in-sailfish-4-2-feedback-thread/7867/68), I guess the design decision to use a toolbar with buttons and a menu was already taken. So I hope this PR will be the occasion to discuss advantages and shortcomings of both approaches and make improvements to the tab list page design in general, whatever directions they go in. In term of raw number of lines (and maintainance), this PR simplify `TabGridView.qml` and `TabView.qml` a bit already ; -)

@rainemak , @atatarov , @jpetrell and @mkenttala, I would appreciate your comments and views on this matter and thank you in advance for the time you may spend looking at it.