### PR TITLE
[sailfish-browser] Use a press and hold scheme in tab list to switch …

### DIFF
--- a/apps/browser/qml/pages/components/TabItem.qml
+++ b/apps/browser/qml/pages/components/TabItem.qml
@@ -17,9 +17,7 @@ import Sailfish.Silica 1.0
 BackgroundItem {
     id: root
 
-    // Expose GridView for all items
-    property Item view: GridView.view
-    property bool destroying
+    property bool showClose: true
     property color highlightColor: Theme.colorScheme == Theme.LightOnDark
                                    ? Theme.highlightColor
                                    : Theme.highlightFromColor(Theme.highlightColor, Theme.LightOnDark)
@@ -27,7 +25,15 @@ BackgroundItem {
     implicitWidth: width
     implicitHeight: height
 
-    enabled: !destroying
+    signal closeClicked()
+
+    function markClosed() {
+        // Break binding, so that texture size would not change when
+        // closing tab (animating height).
+        implicitHeight = height
+        implicitWidth = width
+        enabled = false
+    }
 
     layer.enabled: true
     layer.effect: OpacityMask {
@@ -43,8 +49,6 @@ BackgroundItem {
     // thumbnail image.
     contentItem.width: root.implicitWidth
     contentItem.height: root.implicitHeight
-
-    onClicked: view.activateTab(index)
 
     // contentItem is hidden so this cannot be children of the contentItem.
     // So, making them as siblings of the contentItem.
@@ -100,7 +104,7 @@ BackgroundItem {
                     anchors {
                         left: iconHeader.right
                         leftMargin: Theme.paddingMedium
-                        right: close.left
+                        right: root.showClose ? close.left : root.right
                         rightMargin: Theme.paddingMedium
                         verticalCenter: iconHeader.verticalCenter
                     }
@@ -119,6 +123,7 @@ BackgroundItem {
                         top: parent.top
                         verticalCenter: iconHeader.verticalCenter
                     }
+                    visible: root.showClose
                     icon.color: Theme.primaryColor
                     icon.highlightColor: root.highlightColor
                     icon.highlighted: down
@@ -126,13 +131,8 @@ BackgroundItem {
 
                     icon.source: "image://theme/icon-s-clear-opaque-cross"
                     onClicked: {
-                        // Break binding, so that texture size would not change when
-                        // closing tab (animating height).
-                        root.implicitHeight = root.height
-                        root.implicitWidth = root.width
-
-                        destroying = true
-                        removeTimer.running = true
+                        markClosed()
+                        closeClicked()
                     }
                 }
             }
@@ -152,11 +152,6 @@ BackgroundItem {
                 Behavior on opacity { FadeAnimation {} }
 
             }
-        },
-        Timer {
-            id: removeTimer
-            interval: 16
-            onTriggered: view.closeTab(index)
         }
     ]
 }


### PR DESCRIPTION
…to close mode.

Coming from a discussion in the forum (https://forum.sailfishos.org/t/browser-redesign-in-sailfish-4-2-feedback-thread/7867/78 and later posts), it was proposed to use a press and hold behaviour to activate a close tab mode in the tab list view. Like in the home screen (Lipstick switcher).

I've investigated the possibility and created a PR to test the idea. It's using the same metrics (animation duration, scaling factor...) than in the Lipstick switcher.

Here is a screen shot :
![close](https://user-images.githubusercontent.com/5889532/145176826-c03c96b4-2cc6-493e-849b-39c6a31c74f7.png)

Entering this mode would allow later to implement a tab reordering capability, like in the Lipstick switcher.

@rainemak or @jpetrell , what do you think ?

PS : @rainemak , I've removed the timer in `TabItem.qml` that you added in 2014 commit bab080154 when the tabs were using shader effects and textures. I think it's safe to remove it now that we're using images. Do you agree ?
