### PR TITLE
[browser] Request new tab (page) before adding to the model. JB#56631 OMP#JOLLA-569

### DIFF
--- a/apps/history/declarativetabmodel.cpp
+++ b/apps/history/declarativetabmodel.cpp
@@ -215,9 +215,10 @@ int DeclarativeTabModel::newTab(const QString &url, int parentId)
     } else {
         index = m_tabs.count();
     }
-    addTab(tab, index);
 
     emit newTabRequested(tab, parentId);
+
+    addTab(tab, index);
 
     return tab.tabId();
 }


### PR DESCRIPTION
This commit fixes new tab creation with proper parent id when requested
by web content itself (for many cases). Problem that persists after this
is that there can be wrong parent browsing context passed to the created
child view causing nsWindowWatcher to assert.

There's one follow up change coming after this one.