### PR TITLE
[browser] Pass back browsing context when web content requested new window. Fixes JB#56631 OMP#JOLLA-569

### DIFF
--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -551,7 +551,7 @@ void DeclarativeWebContainer::releaseActiveTabOwnership()
     }
 }
 
-bool DeclarativeWebContainer::activatePage(const Tab& tab, bool force, int parentId)
+bool DeclarativeWebContainer::activatePage(const Tab& tab, bool force)
 {
     if (!m_initialized) {
         m_initialUrl = tab.requestedUrl();
@@ -560,7 +560,7 @@ bool DeclarativeWebContainer::activatePage(const Tab& tab, bool force, int paren
 
     m_webPages->initialize(this);
     if ((m_model->loaded() || force) && tab.tabId() > 0 && m_webPages->isInitialized() && m_webPageComponent) {
-        WebPageActivationData activationData = m_webPages->page(tab, parentId);
+        WebPageActivationData activationData = m_webPages->page(tab);
         setWebPage(activationData.webPage);
         // Reset always height so that orentation change is taken into account.
         m_webPage->forceChrome(false);
@@ -1036,9 +1036,9 @@ void DeclarativeWebContainer::onDownloadStarted()
     }
 }
 
-void DeclarativeWebContainer::onNewTabRequested(const Tab &tab, int parentId)
+void DeclarativeWebContainer::onNewTabRequested(const Tab &tab)
 {
-    if (activatePage(tab, false, parentId)) {
+    if (activatePage(tab, false)) {
         m_webPage->loadTab(tab.requestedUrl(), false);
     }
 }

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -138,7 +138,7 @@ public:
     QString thumbnailPath() const;
 
     bool isActiveTab(int tabId);
-    bool activatePage(const Tab& tab, bool force = false, int parentId = 0);
+    bool activatePage(const Tab& tab, bool force = false);
     int findParentTabId(int tabId) const;
     // For D-Bus interfaces
     uint tabOwner(int tabId) const;
@@ -225,7 +225,7 @@ private slots:
     void initialize();
     void onActiveTabChanged(int activeTabId);
     void onDownloadStarted();
-    void onNewTabRequested(const Tab &tab, int parentId);
+    void onNewTabRequested(const Tab &tab);
     void releasePage(int tabId);
     void closeWindow();
     void updateLoadProgress();

--- a/apps/core/webpages.cpp
+++ b/apps/core/webpages.cpp
@@ -137,7 +137,7 @@ bool WebPages::alive(int tabId) const
     return m_activePages.alive(tabId);
 }
 
-WebPageActivationData WebPages::page(const Tab& tab, int parentId)
+WebPageActivationData WebPages::page(const Tab& tab)
 {
     const int tabId = tab.tabId();
 
@@ -154,7 +154,7 @@ WebPageActivationData WebPages::page(const Tab& tab, int parentId)
     DeclarativeWebPage *webPage = 0;
     DeclarativeWebPage *oldActiveWebPage = m_activePages.activeWebPage();
     if (!m_activePages.alive(tabId)) {
-        webPage = m_pageFactory->createWebPage(m_webContainer, tab, parentId);
+        webPage = m_pageFactory->createWebPage(m_webContainer, tab);
         if (webPage) {
             m_activePages.prepend(tabId, webPage);
         } else {

--- a/apps/core/webpages.h
+++ b/apps/core/webpages.h
@@ -51,7 +51,7 @@ public:
 
     bool alive(int tabId) const;
 
-    WebPageActivationData page(const Tab& tab, int parentId = 0);
+    WebPageActivationData page(const Tab& tab);
     void release(int tabId);
     void clear();
     int parentTabId(int tabId) const;

--- a/apps/factories/webpagefactory.cpp
+++ b/apps/factories/webpagefactory.cpp
@@ -23,8 +23,7 @@
 #define DEBUG_LOGS 0
 
 DeclarativeWebPage* WebPageFactory::createWebPage(DeclarativeWebContainer *webContainer,
-                                                  const Tab &initialTab,
-                                                  int parentId)
+                                                  const Tab &initialTab)
 {
     if (!m_qmlComponent) {
         qWarning() << "WebPageContainer not initialized!";
@@ -39,10 +38,8 @@ DeclarativeWebPage* WebPageFactory::createWebPage(DeclarativeWebContainer *webCo
         object->setParent(webContainer);
         DeclarativeWebPage* webPage = qobject_cast<DeclarativeWebPage *>(object);
         if (webPage) {
-            webPage->setParentId(parentId);
-            webPage->setPrivateMode(webContainer->privateMode());
-            webPage->setInitialTab(initialTab);
             webPage->setContainer(webContainer);
+            webPage->setInitialState(initialTab, webContainer->privateMode());
             emit aboutToInitialize(webPage);
             webPage->initialize();
             m_qmlComponent->completeCreate();

--- a/apps/factories/webpagefactory.h
+++ b/apps/factories/webpagefactory.h
@@ -27,8 +27,7 @@ public:
     WebPageFactory(QObject *parent = 0) : QObject(parent) {};
 
     DeclarativeWebPage* createWebPage(DeclarativeWebContainer *webContainer,
-                                      const Tab &initialTab,
-                                      int parentId);
+                                      const Tab &initialTab);
 
 signals:
     void aboutToInitialize(DeclarativeWebPage *webPage);

--- a/apps/history/declarativetabmodel.cpp
+++ b/apps/history/declarativetabmodel.cpp
@@ -188,7 +188,12 @@ void DeclarativeTabModel::closeActiveTab()
     }
 }
 
-int DeclarativeTabModel::newTab(const QString &url, int parentId)
+int DeclarativeTabModel::newTab(const QString &url)
+{
+    return newTab(url, 0, 0);
+}
+
+int DeclarativeTabModel::newTab(const QString &url, int parentId, uintptr_t browsingContext)
 {
     // When browser opens without tabs
     if ((url.isEmpty() || url == QStringLiteral("about:blank")) && m_tabs.isEmpty())
@@ -206,6 +211,8 @@ int DeclarativeTabModel::newTab(const QString &url, int parentId)
     Tab tab;
     tab.setTabId(nextTabId());
     tab.setRequestedUrl(url);
+    tab.setBrowsingContext(browsingContext);
+    tab.setParentId(parentId);
 
     int index = 0;
 
@@ -216,7 +223,7 @@ int DeclarativeTabModel::newTab(const QString &url, int parentId)
         index = m_tabs.count();
     }
 
-    emit newTabRequested(tab, parentId);
+    emit newTabRequested(tab);
 
     addTab(tab, index);
 

--- a/apps/history/declarativetabmodel.h
+++ b/apps/history/declarativetabmodel.h
@@ -47,7 +47,7 @@ public:
     Q_INVOKABLE bool activateTab(const QString &url, bool reload = false);
     Q_INVOKABLE void activateTab(int index, bool reload = false);
     Q_INVOKABLE void closeActiveTab();
-    Q_INVOKABLE int newTab(const QString &url, int parentId = 0);
+    Q_INVOKABLE int newTab(const QString &url);
     Q_INVOKABLE QString url(int tabId) const;
 
     Q_INVOKABLE void dumpTabs() const;
@@ -57,6 +57,8 @@ public:
     int count() const;
     bool activateTabById(int tabId);
     void removeTabById(int tabId, bool activeTab);
+    // C++ only: parentId and browsingContext better not to leak to QML side.
+    int newTab(const QString &url, int parentId, uintptr_t browsingContext);
 
     // From QAbstractListModel
     int rowCount(const QModelIndex & parent = QModelIndex()) const;
@@ -86,7 +88,7 @@ signals:
     void tabAdded(int tabId);
     void tabClosed(int tabId);
     void loadedChanged();
-    void newTabRequested(const Tab& tab, int parentId = 0);
+    void newTabRequested(const Tab& tab);
 
 protected:
     void addTab(const Tab &tab, int index);

--- a/apps/qtmozembed/declarativewebpage.cpp
+++ b/apps/qtmozembed/declarativewebpage.cpp
@@ -127,9 +127,13 @@ int DeclarativeWebPage::tabId() const
     return m_initialTab.tabId();
 }
 
-void DeclarativeWebPage::setInitialTab(const Tab& tab)
+void DeclarativeWebPage::setInitialState(const Tab& tab, bool privateMode)
 {
     Q_ASSERT(m_initialTab.tabId() == 0);
+
+    setParentId(tab.parentId());
+    setPrivateMode(privateMode);
+    setParentBrowsingContext(tab.browsingContext());
 
     m_initialTab = tab;
     setDesktopMode(m_initialTab.desktopMode());

--- a/apps/qtmozembed/declarativewebpage.h
+++ b/apps/qtmozembed/declarativewebpage.h
@@ -44,7 +44,7 @@ public:
     void setContainer(DeclarativeWebContainer *container);
 
     int tabId() const;
-    void setInitialTab(const Tab& tab);
+    void setInitialState(const Tab& tab, bool privateMode);
 
     QVariant resurrectedContentRect() const;
     void setResurrectedContentRect(QVariant resurrectedContentRect);

--- a/apps/qtmozembed/declarativewebpagecreator.cpp
+++ b/apps/qtmozembed/declarativewebpagecreator.cpp
@@ -1,7 +1,6 @@
 /****************************************************************************
 **
 ** Copyright (c) 2014 Jolla Ltd.
-** Contact: Raine Makelainen <raine.makelainen@jolla.com>
 **
 ****************************************************************************/
 
@@ -12,6 +11,7 @@
 #include <webengine.h>
 #include "declarativewebpage.h"
 #include "declarativewebpagecreator.h"
+#include "declarativetabmodel.h"
 
 DeclarativeWebPageCreator::DeclarativeWebPageCreator(QObject *parent)
     : QMozViewCreator(parent)
@@ -38,10 +38,24 @@ void DeclarativeWebPageCreator::setActiveWebPage(DeclarativeWebPage *activeWebPa
     }
 }
 
-quint32 DeclarativeWebPageCreator::createView(const quint32 &parentId)
+DeclarativeTabModel *DeclarativeWebPageCreator::model() const
+{
+    return m_model;
+}
+
+void DeclarativeWebPageCreator::setModel(DeclarativeTabModel *model)
+{
+    if (m_model != model) {
+        m_model = model;
+        emit modelChanged();
+    }
+}
+
+quint32 DeclarativeWebPageCreator::createView(const quint32 &parentId, const uintptr_t &parentBrowsingContext)
 {
     QPointer<DeclarativeWebPage> oldPage = m_activeWebPage;
-    emit newWindowRequested(parentId);
+    m_model->newTab(QString(), parentId, parentBrowsingContext);
+
     if (m_activeWebPage && oldPage != m_activeWebPage) {
         return m_activeWebPage->uniqueId();
     }

--- a/apps/qtmozembed/declarativewebpagecreator.h
+++ b/apps/qtmozembed/declarativewebpagecreator.h
@@ -16,11 +16,13 @@
 #include <qmozviewcreator.h>
 
 class DeclarativeWebPage;
+class DeclarativeTabModel;
 
 class DeclarativeWebPageCreator : public QMozViewCreator {
     Q_OBJECT
 
     Q_PROPERTY(DeclarativeWebPage *activeWebPage READ activeWebPage WRITE setActiveWebPage NOTIFY activeWebPageChanged FINAL)
+    Q_PROPERTY(DeclarativeTabModel *model READ model WRITE setModel NOTIFY modelChanged FINAL)
 
 public:
     DeclarativeWebPageCreator(QObject *parent = 0);
@@ -29,14 +31,18 @@ public:
     DeclarativeWebPage *activeWebPage() const;
     void setActiveWebPage(DeclarativeWebPage *activeWebPage);
 
-    virtual quint32 createView(const quint32 &parentId);
+    DeclarativeTabModel *model() const;
+    void setModel(DeclarativeTabModel *model);
+
+    virtual quint32 createView(const quint32 &parentId, const uintptr_t &parentBrowsingContext) override;
 
 signals:
     void activeWebPageChanged();
-    void newWindowRequested(const quint32 &parentId);
+    void modelChanged();
 
 private:
     QPointer<DeclarativeWebPage> m_activeWebPage;
+    QPointer<DeclarativeTabModel> m_model;
 };
 
 #endif // DECLARATIVEWEBPAGECREATOR_H

--- a/apps/shared/WebView.qml
+++ b/apps/shared/WebView.qml
@@ -39,8 +39,7 @@ WebContainer {
 
     property var _webPageCreator: WebPageCreator {
         activeWebPage: contentItem
-        // onNewWindowRequested is always handled as synchronous operation (not through newTab).
-        onNewWindowRequested: tabModel.newTab("", parentId)
+        model: tabModel
     }
 
     property Component textSelectionControllerComponent: Component {

--- a/apps/storage/tab.cpp
+++ b/apps/storage/tab.cpp
@@ -18,12 +18,16 @@ Tab::Tab(int tabId, const QString &url, const QString &title, const QString &thu
     , m_title(title)
     , m_thumbPath(thumbPath)
     , m_desktopMode(false)
+    , m_browsingContext(0)
+    , m_parentId(0)
 {
 }
 
 Tab::Tab()
     : m_tabId(0)
     , m_desktopMode(false)
+    , m_browsingContext(0)
+    , m_parentId(0)
 {
 }
 
@@ -92,6 +96,28 @@ void Tab::setDesktopMode(bool desktopMode)
     m_desktopMode = desktopMode;
 }
 
+void Tab::setBrowsingContext(uintptr_t browsingContext)
+{
+    Q_ASSERT_X(m_browsingContext == 0, Q_FUNC_INFO, "Browsing context can be set only once.");
+    m_browsingContext = browsingContext;
+}
+
+uintptr_t Tab::browsingContext() const
+{
+    return m_browsingContext;
+}
+
+void Tab::setParentId(uint32_t parentId)
+{
+    Q_ASSERT_X(m_parentId == 0, Q_FUNC_INFO, "Parent id can be set only once.");
+    m_parentId = parentId;
+}
+
+uint32_t Tab::parentId() const
+{
+    return m_parentId;
+}
+
 bool Tab::isValid() const
 {
     return m_tabId > 0;
@@ -115,7 +141,8 @@ QDebug operator<<(QDebug dbg, const Tab *tab) {
         return dbg << "Tab (this = 0x0)";
     }
 
-    dbg.nospace() << "Tab(tabId = " << tab->tabId() << ", isValid = " << tab->isValid()
+    dbg.nospace() << "Tab(tabId = " << tab->tabId() << ", parentId = " << tab->parentId()
+                  << ", isValid = " << tab->isValid()
                   << ", url = " << tab->url() << ", requested url = " << tab->requestedUrl()
                   << ", url resolved: " << tab->hasResolvedUrl() << ", title = " << tab->title()
                   << ", thumbnailPath = " << tab->thumbnailPath()

--- a/apps/storage/tab.h
+++ b/apps/storage/tab.h
@@ -41,6 +41,12 @@ public:
     bool desktopMode() const;
     void setDesktopMode(bool desktopMode);
 
+    void setBrowsingContext(uintptr_t browsingContext);
+    uintptr_t browsingContext() const;
+
+    void setParentId(uint32_t parentId);
+    uint32_t parentId() const;
+
     bool isValid() const;
 
     bool operator==(const Tab &other) const;
@@ -53,6 +59,8 @@ private:
     QString m_title;
     QString m_thumbPath;
     bool m_desktopMode;
+    uintptr_t m_browsingContext;
+    uint32_t m_parentId;
 };
 
 Q_DECLARE_METATYPE(Tab)

--- a/tests/auto/mocks/declarativewebpage/declarativewebpage.h
+++ b/tests/auto/mocks/declarativewebpage/declarativewebpage.h
@@ -66,13 +66,15 @@ public:
     MOCK_CONST_METHOD0(resolution, float());
     MOCK_METHOD2(sendAsyncMessage, void(const QString&, const QVariant&));
     MOCK_METHOD1(setParentId, void(unsigned));
+    MOCK_METHOD1(setParentBrowsingContext, void(uintptr_t));
+
     MOCK_CONST_METHOD0(active, bool());
     MOCK_METHOD1(setActive, void(bool));
 
     MOCK_METHOD1(setContainer, void(DeclarativeWebContainer *));
 
     MOCK_METHOD1(setResurrectedContentRect, void(QVariant));
-    MOCK_METHOD1(setInitialTab, void(const Tab&));
+    MOCK_METHOD2(setInitialState, void(const Tab&, bool privateMode));
 
     MOCK_METHOD1(forceChrome, void(bool));
     MOCK_CONST_METHOD0(domContentLoaded, bool());

--- a/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
+++ b/tests/auto/tst_persistenttabmodel/tst_persistenttabmodel.cpp
@@ -189,7 +189,7 @@ void tst_persistenttabmodel::newTabInvalidInput()
     QSignalSpy activeTabChangedSpy(tabModel, SIGNAL(activeTabChanged(int)));
 
     QFETCH(QString, url);
-    tabModel->newTab(url, 0);
+    tabModel->newTab(url);
 
     QCOMPARE(tabModel->count(), 0);
     QCOMPARE(countChangeSpy.count(), 0);
@@ -571,8 +571,8 @@ void tst_persistenttabmodel::data()
 
 void tst_persistenttabmodel::newTabRequested()
 {
-    QSignalSpy newTabRequestedSpy(tabModel, SIGNAL(newTabRequested(Tab, int)));
-    tabModel->newTab(QLatin1String("http://example.com"), 0);
+    QSignalSpy newTabRequestedSpy(tabModel, SIGNAL(newTabRequested(Tab)));
+    tabModel->newTab(QLatin1String("http://example.com"));
     QCOMPARE(newTabRequestedSpy.count(), 1);
 }
 

--- a/tests/auto/tst_webpagefactory/tst_webpagefactory.cpp
+++ b/tests/auto/tst_webpagefactory/tst_webpagefactory.cpp
@@ -96,14 +96,14 @@ void tst_webpagefactory::createWebPage()
     if (isSuccessExpected) {
         EXPECT_CALL(webContainer, privateMode());
     }
-    page = m_pageFactory->createWebPage(&webContainer, Tab(1, "http://example.com", "Title", ""), 0);
+    page = m_pageFactory->createWebPage(&webContainer, Tab(1, "http://example.com", "Title", ""));
     QCOMPARE(!!page, isSuccessExpected);
 }
 
 void tst_webpagefactory::createWebPageUninitialized()
 {
     DeclarativeWebContainer webContainer;
-    QVERIFY(!m_pageFactory->createWebPage(&webContainer, Tab(1, "http://example.com", "Title", ""), 0));
+    QVERIFY(!m_pageFactory->createWebPage(&webContainer, Tab(1, "http://example.com", "Title", "")));
 }
 
 QTEST_MAIN(tst_webpagefactory)


### PR DESCRIPTION
This commit renames webpage's setInitialTab to setInitialState and
sets all initial state related attributes there.
Setting initial state happens right before initialize() is called.

Browsing context is added to the tab and parent id has been moved to
the tab so that those get carried to the initialization. This implies
that parentId got removed from the methods and signals. Further, to QML
side we only expose newTab(url) and only from C++ side we're calling
newTab with parent id and browsing context.

This change requires https://github.com/sailfishos/qtmozembed/pull/30
