### PR TITLE
Check unique id from WebPageEntry instead of live page

### DIFF
--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -1023,9 +1023,9 @@ void DeclarativeWebContainer::releasePage(int tabId)
 void DeclarativeWebContainer::closeWindow()
 {
     DeclarativeWebPage *webPage = qobject_cast<DeclarativeWebPage *>(sender());
-    if (webPage && m_model) {
-        int parentPageTabId = findParentTabId(webPage->tabId());
-        // Closing only allowed if window was created by script
+    // Closing only allowed if window was created by script i.e. has parent.
+    if (webPage && webPage->parentId() > 0 && m_model) {
+        int parentPageTabId = findTabId(webPage->parentId());
         if (parentPageTabId > 0) {
             m_model->activateTabById(parentPageTabId);
             m_model->removeTabById(webPage->tabId(), isActiveTab(webPage->tabId()));

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -575,14 +575,6 @@ bool DeclarativeWebContainer::activatePage(const Tab& tab, bool force)
     return false;
 }
 
-int DeclarativeWebContainer::findParentTabId(int tabId) const
-{
-    if (m_webPages) {
-        return m_webPages->parentTabId(tabId);
-    }
-    return 0;
-}
-
 int DeclarativeWebContainer::findTabId(uint32_t uniqueId) const
 {
     if (m_webPages) {

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -138,7 +138,6 @@ public:
 
     bool isActiveTab(int tabId);
     bool activatePage(const Tab& tab, bool force = false);
-    int findParentTabId(int tabId) const;
     int findTabId(uint32_t uniqueId) const;
     // For D-Bus interfaces
     uint tabOwner(int tabId) const;

--- a/apps/core/webpagequeue.cpp
+++ b/apps/core/webpagequeue.cpp
@@ -172,7 +172,7 @@ int WebPageQueue::tabId(uint32_t uniqueId) const
 {
     for (int i = 0; i < m_queue.count(); ++i) {
         WebPageEntry *pageEntry = m_queue.at(i);
-        if (pageEntry && pageEntry->webPage && pageEntry->webPage->uniqueId() == uniqueId) {
+        if (pageEntry && (quint32)pageEntry->uniqueId == uniqueId) {
             return pageEntry->tabId;
         }
     }

--- a/apps/core/webpagequeue.cpp
+++ b/apps/core/webpagequeue.cpp
@@ -160,7 +160,7 @@ int WebPageQueue::parentTabId(int tabId) const
         int parentId = childPageEntry->parentId;
         for (int i = 0; i < m_queue.count(); ++i) {
             WebPageEntry *parentPageEntry = m_queue.at(i);
-            if (parentPageEntry && (int)parentPageEntry->uniqueId == parentId) {
+            if (parentPageEntry && parentPageEntry->uniqueId == parentId) {
                 return parentPageEntry->tabId;
             }
         }

--- a/apps/core/webpagequeue.cpp
+++ b/apps/core/webpagequeue.cpp
@@ -148,26 +148,6 @@ void WebPageQueue::clear()
     m_queue.clear();
 }
 
-int WebPageQueue::parentTabId(int tabId) const
-{
-    // TODO: This should be stored to the declarativewebpage to avoid loops.
-    // This guarantees that child-parent relationship exists and it should
-    // be taken into account if/when moved to declarativewebpage.
-    // Ported from webpages.cpp.
-    int index = 0;
-    WebPageEntry *childPageEntry = find(tabId, index);
-    if (childPageEntry) {
-        int parentId = childPageEntry->parentId;
-        for (int i = 0; i < m_queue.count(); ++i) {
-            WebPageEntry *parentPageEntry = m_queue.at(i);
-            if (parentPageEntry && parentPageEntry->uniqueId == parentId) {
-                return parentPageEntry->tabId;
-            }
-        }
-    }
-    return 0;
-}
-
 int WebPageQueue::tabId(uint32_t uniqueId) const
 {
     for (int i = 0; i < m_queue.count(); ++i) {

--- a/apps/core/webpagequeue.h
+++ b/apps/core/webpagequeue.h
@@ -32,7 +32,6 @@ public :
     void release(int tabId, bool virtualize = false);
     void prepend(int tabId, DeclarativeWebPage *webPage);
     void clear();
-    int parentTabId(int tabId) const;
     int tabId(uint32_t id) const;
 
     bool setMaxLivePages(int count);

--- a/apps/core/webpages.cpp
+++ b/apps/core/webpages.cpp
@@ -188,11 +188,6 @@ void WebPages::clear()
     m_activePages.clear();
 }
 
-int WebPages::parentTabId(int tabId) const
-{
-    return m_activePages.parentTabId(tabId);
-}
-
 int WebPages::tabId(uint32_t uniqueId) const
 {
     return m_activePages.tabId(uniqueId);

--- a/apps/core/webpages.h
+++ b/apps/core/webpages.h
@@ -54,7 +54,6 @@ public:
     WebPageActivationData page(const Tab& tab);
     void release(int tabId);
     void clear();
-    int parentTabId(int tabId) const;
     int tabId(uint32_t uniqueId) const;
     void dumpPages() const;
 

--- a/apps/history/declarativetabmodel.cpp
+++ b/apps/history/declarativetabmodel.cpp
@@ -461,13 +461,19 @@ bool DeclarativeTabModel::matches(const QUrl &inputUrl, QString urlStr) const
 
 int DeclarativeTabModel::nextActiveTabIndex(int index)
 {
-    if (m_webContainer && m_webContainer->webPage() && m_webContainer->webPage()->parentId() > 0) {
-        int newActiveTabId = m_webContainer->findParentTabId(m_webContainer->webPage()->tabId());
-        index = findTabIndex(newActiveTabId);
+    if (!m_tabs.isEmpty() && index >= 0 && index < m_tabs.count()) {
+        uint32_t parentId = m_tabs.at(index).parentId();
+        if (parentId > 0) {
+            int parentTabId = m_webContainer->findTabId(parentId);
+            index = findTabIndex(parentTabId);
+        } else {
+            --index;
+        }
     } else {
         --index;
     }
-    return index;
+
+    return std::clamp(index, 0, std::max(0, m_tabs.count() - 1));
 }
 
 void DeclarativeTabModel::updateThumbnailPath(int tabId, const QString &path)

--- a/common/opensearchconfigs.pri
+++ b/common/opensearchconfigs.pri
@@ -12,8 +12,6 @@ isEmpty(USER_OPENSEARCH_PATH) {
 
 INCLUDEPATH += $$PWD
 
-CONFIG += c++11
-
 # C++ sources
 SOURCES += \
     $$PWD/opensearchconfigs.cpp

--- a/defaults.pri
+++ b/defaults.pri
@@ -8,3 +8,5 @@ isEmpty(DEFAULT_COMPONENT_PATH) {
 
 DEFINES += BASE64_IMAGE=\\\"data\:image\/png\;base64,%1\\\"
 DEFINES += DEFAULT_DESKTOP_BOOKMARK_ICON=\\\"icon-launcher-bookmark\\\"
+
+CONFIG += c++1z

--- a/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.cpp
+++ b/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.cpp
@@ -20,8 +20,3 @@ int DeclarativeWebContainer::findTabId(uint32_t) const
 {
     return 0;
 }
-
-int DeclarativeWebContainer::findParentTabId(int) const
-{
-    return 0;
-}

--- a/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
+++ b/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
@@ -26,7 +26,6 @@ public:
     explicit DeclarativeWebContainer(QObject *parent = 0);
 
     int findTabId(uint32_t uniqueId) const;
-    int findParentTabId(int) const;
     MOCK_CONST_METHOD0(webPage, DeclarativeWebPage*());
     MOCK_CONST_METHOD0(privateMode, bool());
 

--- a/tests/auto/test_common.pri
+++ b/tests/auto/test_common.pri
@@ -2,7 +2,7 @@
 
 QT += testlib
 
-CONFIG += c++11
+CONFIG += c++1z
 
 include(../../defaults.pri)
 


### PR DESCRIPTION
This makes sure that an OOM killed parent tab is activated
when a child tab is closed.

Might be easier to review per commit.