### PR TITLE
[browser] Activate recently used tab when closing the active tab. Fixes JB#56968

### DIFF
--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -583,6 +583,14 @@ int DeclarativeWebContainer::findTabId(uint32_t uniqueId) const
     return 0;
 }
 
+int DeclarativeWebContainer::previouslyUsedTabId() const
+{
+    if (m_webPages) {
+        return m_webPages->previouslyUsedTabId();
+    }
+    return 0;
+}
+
 void DeclarativeWebContainer::updateMode()
 {
     setTabModel((BrowserApp::captivePortal() || m_privateMode) ? m_privateTabModel.data() : m_persistentTabModel.data());

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -575,7 +575,7 @@ bool DeclarativeWebContainer::activatePage(const Tab& tab, bool force)
     return false;
 }
 
-int DeclarativeWebContainer::findTabId(uint32_t uniqueId) const
+int DeclarativeWebContainer::tabId(uint32_t uniqueId) const
 {
     if (m_webPages) {
         return m_webPages->tabId(uniqueId);
@@ -1025,7 +1025,7 @@ void DeclarativeWebContainer::closeWindow()
     DeclarativeWebPage *webPage = qobject_cast<DeclarativeWebPage *>(sender());
     // Closing only allowed if window was created by script i.e. has parent.
     if (webPage && webPage->parentId() > 0 && m_model) {
-        int parentPageTabId = findTabId(webPage->parentId());
+        int parentPageTabId = tabId(webPage->parentId());
         if (parentPageTabId > 0) {
             m_model->activateTabById(parentPageTabId);
             m_model->removeTabById(webPage->tabId(), isActiveTab(webPage->tabId()));

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -139,6 +139,7 @@ public:
     bool isActiveTab(int tabId);
     bool activatePage(const Tab& tab, bool force = false);
     int findTabId(uint32_t uniqueId) const;
+    int previouslyUsedTabId() const;
     // For D-Bus interfaces
     uint tabOwner(int tabId) const;
     int requestTabWithOwner(int tabId, const QString &url, uint ownerPid);

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -138,7 +138,7 @@ public:
 
     bool isActiveTab(int tabId);
     bool activatePage(const Tab& tab, bool force = false);
-    int findTabId(uint32_t uniqueId) const;
+    int tabId(uint32_t uniqueId) const;
     int previouslyUsedTabId() const;
     // For D-Bus interfaces
     uint tabOwner(int tabId) const;

--- a/apps/core/webpagequeue.cpp
+++ b/apps/core/webpagequeue.cpp
@@ -159,6 +159,17 @@ int WebPageQueue::tabId(uint32_t uniqueId) const
     return 0;
 }
 
+int WebPageQueue::previouslyUsedTabId() const
+{
+    if (m_queue.count() > 1) {
+        WebPageEntry *pageEntry = m_queue.at(1);
+        if (pageEntry) {
+            return pageEntry->tabId;
+        }
+    }
+    return 0;
+}
+
 bool WebPageQueue::setMaxLivePages(int count)
 {
     if (m_maxLiveCount != count && count > 0) {

--- a/apps/core/webpagequeue.cpp
+++ b/apps/core/webpagequeue.cpp
@@ -202,6 +202,10 @@ void WebPageQueue::dumpPages() const
         WebPageEntry *pageEntry = m_queue.at(i);
         qDebug() << "tabId: " << pageEntry->tabId;
         qDebug() << "    page: " << pageEntry->webPage;
+        if (pageEntry->webPage) {
+            qDebug() << "    page title:" << pageEntry->webPage->title();
+            qDebug() << "    page title:" << pageEntry->webPage->url();
+        }
         qDebug() << "    cssContentRect:" << pageEntry->cssContentRect;
     }
     qDebug() << "---- end ------";

--- a/apps/core/webpagequeue.h
+++ b/apps/core/webpagequeue.h
@@ -33,6 +33,7 @@ public :
     void prepend(int tabId, DeclarativeWebPage *webPage);
     void clear();
     int tabId(uint32_t id) const;
+    int previouslyUsedTabId() const;
 
     bool setMaxLivePages(int count);
     int maxLivePages() const;

--- a/apps/core/webpages.cpp
+++ b/apps/core/webpages.cpp
@@ -193,6 +193,11 @@ int WebPages::tabId(uint32_t uniqueId) const
     return m_activePages.tabId(uniqueId);
 }
 
+int WebPages::previouslyUsedTabId() const
+{
+    return m_activePages.previouslyUsedTabId();
+}
+
 void WebPages::updateStates(DeclarativeWebPage *oldActivePage, DeclarativeWebPage *newActivePage)
 {
     if (oldActivePage) {

--- a/apps/core/webpages.h
+++ b/apps/core/webpages.h
@@ -55,6 +55,7 @@ public:
     void release(int tabId);
     void clear();
     int tabId(uint32_t uniqueId) const;
+    int previouslyUsedTabId() const;
     void dumpPages() const;
 
 private slots:

--- a/apps/history/declarativetabmodel.cpp
+++ b/apps/history/declarativetabmodel.cpp
@@ -217,7 +217,7 @@ int DeclarativeTabModel::newTab(const QString &url, int parentId, uintptr_t brow
     int index = 0;
 
     if (parentId > 0) {
-        int parentTabId = m_webContainer->findTabId((uint32_t)parentId);
+        int parentTabId = m_webContainer->tabId((uint32_t)parentId);
         index = findTabIndex(parentTabId) + 1;
         if (index == 0) {
             index = m_tabs.count();
@@ -465,7 +465,7 @@ int DeclarativeTabModel::nextActiveTabIndex(int index)
         uint32_t parentId = m_tabs.at(index).parentId();
         int tabId = 0;
         if (parentId > 0) {
-            tabId = m_webContainer->findTabId(parentId);
+            tabId = m_webContainer->tabId(parentId);
             // Parent tab has been closed, active previously used tab instead.
             if (tabId == 0) {
                 tabId = m_webContainer->previouslyUsedTabId();

--- a/apps/history/declarativetabmodel.cpp
+++ b/apps/history/declarativetabmodel.cpp
@@ -463,12 +463,17 @@ int DeclarativeTabModel::nextActiveTabIndex(int index)
 {
     if (!m_tabs.isEmpty() && index >= 0 && index < m_tabs.count()) {
         uint32_t parentId = m_tabs.at(index).parentId();
+        int tabId = 0;
         if (parentId > 0) {
-            int parentTabId = m_webContainer->findTabId(parentId);
-            index = findTabIndex(parentTabId);
+            tabId = m_webContainer->findTabId(parentId);
+            // Parent tab has been closed, active previously used tab instead.
+            if (tabId == 0) {
+                tabId = m_webContainer->previouslyUsedTabId();
+            }
         } else {
-            --index;
+            tabId = m_webContainer->previouslyUsedTabId();
         }
+        index = findTabIndex(tabId);
     } else {
         --index;
     }

--- a/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.cpp
+++ b/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.cpp
@@ -20,3 +20,8 @@ int DeclarativeWebContainer::findTabId(uint32_t) const
 {
     return 0;
 }
+
+int DeclarativeWebContainer::previouslyUsedTabId() const
+{
+    return 0;
+}

--- a/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.cpp
+++ b/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.cpp
@@ -16,7 +16,7 @@ DeclarativeWebContainer::DeclarativeWebContainer(QObject *parent)
 {
 }
 
-int DeclarativeWebContainer::findTabId(uint32_t) const
+int DeclarativeWebContainer::tabId(uint32_t) const
 {
     return 0;
 }

--- a/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
+++ b/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
@@ -26,6 +26,7 @@ public:
     explicit DeclarativeWebContainer(QObject *parent = 0);
 
     int findTabId(uint32_t uniqueId) const;
+    int previouslyUsedTabId() const;
     MOCK_CONST_METHOD0(webPage, DeclarativeWebPage*());
     MOCK_CONST_METHOD0(privateMode, bool());
 

--- a/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
+++ b/tests/auto/mocks/declarativewebcontainer/declarativewebcontainer.h
@@ -25,7 +25,7 @@ class DeclarativeWebContainer : public QObject
 public:
     explicit DeclarativeWebContainer(QObject *parent = 0);
 
-    int findTabId(uint32_t uniqueId) const;
+    int tabId(uint32_t uniqueId) const;
     int previouslyUsedTabId() const;
     MOCK_CONST_METHOD0(webPage, DeclarativeWebPage*());
     MOCK_CONST_METHOD0(privateMode, bool());


### PR DESCRIPTION
When closing the active tab that was not created
by JavaScript, activate the tab that was used before the tab
that got closed.

If tab was created by JavaScript, the parent tab of the child
is activated.

From user point of view this should result more understandable activation
as user likely remembers the tab that she was using before current
active tab.