### PR TITLE
[browser] Show back button to close a child tab. Fixes JB#56975

### DIFF
--- a/apps/browser/qml/pages/components/ToolBar.qml
+++ b/apps/browser/qml/pages/components/ToolBar.qml
@@ -202,8 +202,14 @@ Column {
             id: backIcon
             expandedWidth: toolBarRow.iconWidth
             icon.source: "image://theme/icon-m-back"
-            active: webView.canGoBack && !findInPageActive
-            onTapped: webView.goBack()
+            active: (webView.canGoBack || webView.contentItem.parentId > 0) && !findInPageActive
+            onTapped: {
+                if (webView.canGoBack) {
+                    webView.goBack()
+                } else {
+                    webView.tabModel.closeActiveTab()
+                }
+            }
         }
 
         Shared.ExpandingButton {


### PR DESCRIPTION
Let's give a test rid with this and gather internal feedback.