### PR TITLE
[browser] Add memory leak test pages. Contributes to JB#56707

### DIFF
--- a/tests/manual/leak-test/cycle.js
+++ b/tests/manual/leak-test/cycle.js
@@ -1,0 +1,48 @@
+var sections = [
+  '#first'
+];
+var initialDelay = 5000;
+var switchDelay = 5000;
+var count = 0;
+
+// Used to switch tabs periodically
+function autoSwitchTab(sectionIndex) {
+  var section = $(sections[sectionIndex]);
+  var index = parseInt(section.find('.placeholder .panel').attr('class').split(' ')[1]);
+
+  // Switch to the next panel
+  index = (index + 1) % 1;
+  count += 1;
+
+  console.log("Count: " + count);
+
+  let visible = section.find('.placeholder .panel')[0];
+  let replacement = section.find('.panels .panel').clone()[index];
+  $(replacement).find('.caption').text('Count ' + count);
+
+  $(replacement).fadeOut('slow');
+  
+  $(visible).fadeOut('slow', function() {
+    visible.replaceWith(replacement);
+    var replaced = section.find('.placeholder .panel')[0];
+    $(replaced).fadeIn('slow');
+  });
+  
+  setTimeout(function() {
+    autoSwitchTab(sectionIndex);
+  }, switchDelay);
+}
+
+// Initialisation
+$(document).ready(function() {
+  console.log("Applying click events");
+
+  for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+    var delay = initialDelay + ((switchDelay / sections.length) * sectionIndex);
+    console.log('Initialising section ' + sectionIndex + ' with delay ' + delay);
+    setTimeout(function() {
+      autoSwitchTab(sectionIndex);
+    }, delay);
+  }
+});
+

--- a/tests/manual/leak-test/styles.css
+++ b/tests/manual/leak-test/styles.css
@@ -1,0 +1,34 @@
+.leak {
+  width: 300px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.videobox {
+  width: 100%;
+  height: 174px;
+}
+
+.imagebox {
+  width: 100%;
+  height: 212px;
+}
+
+.panels {
+  display: none;
+}
+
+.caption {
+  padding-top: 16px;
+  text-align: center;
+  width: 100%;
+  display: block;
+  font-family: "sans-serif";
+}
+
+.title {
+  padding-bottom: 32px;
+  font-weight: bold;
+}
+

--- a/tests/manual/manual.pro
+++ b/tests/manual/manual.pro
@@ -8,6 +8,7 @@ testdata.files = *.txt \
                  *.css \
                  mix-blend-mode/*.png \
                  mix-blend-mode/*.svg \
+                 leak-test/* \
                  icon-launcher-testbrowser.png
 testdata.path = /opt/tests/sailfish-browser/manual/
 

--- a/tests/manual/test-leaky-image.html
+++ b/tests/manual/test-leaky-image.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<!-- 
+  This attempts to trigger a memory leak by repeatedly cloning and replacing
+  a multimedia file displayed on the page.
+
+  The issue is triggered by cloning videos, but not images or other elements.
+  
+  This is the image version, so shouldn't trigger the leak.
+
+  On an Xperia 10 II with 2.5Gb free RAM, gecko ESR78, it takes about 10 mins 
+  to exhaust the memory of the device.
+  
+  See JB#56707.
+ -->
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Memory Leak Test</title>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+  <script src="leak-test/cycle.js"></script>
+  <link rel="stylesheet" href="leak-test/styles.css" type="text/css" />
+</head>
+<body>
+  <div class="title caption">Image Memory Leak Test</div>
+  <div id="first">
+    <div class="panels">
+      <div class="panel 0">
+        <div class="imagebox">
+          <img class="leak" src="https://web.archive.org/web/20200913085418if_/https://images.pexels.com/photos/3560168/pexels-photo-3560168.jpeg?cs=srgb&dl=pexels-matt-hardy-3560168.jpg&fm=jpg" alt="Test image" />
+        </div>
+        <div class="caption">1</div>
+      </div>
+    </div>
+    <div class="placeholder">
+      <div class="panel -1">
+        <div class="imagebox">
+          <img class="leak" src="https://web.archive.org/web/20200913085418if_/https://images.pexels.com/photos/3560168/pexels-photo-3560168.jpeg?cs=srgb&dl=pexels-matt-hardy-3560168.jpg&fm=jpg" alt="Test image" />
+        </div>
+        <div class="caption">Initialising</div>
+      </div>
+    </div>
+    </div>
+  </div>
+</body>
+</html>
+

--- a/tests/manual/test-leaky-video.html
+++ b/tests/manual/test-leaky-video.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<!-- 
+  This attempts to trigger a memory leak by repeatedly cloning and replacing
+  a multimedia file displayed on the page.
+
+  The issue is triggered by cloning videos, but not images or other elements.
+  
+  This is the video version, so should trigger the leak.
+
+  On an Xperia 10 II with 2.5Gb free RAM, gecko ESR78, it takes about 10 mins 
+  to exhaust the memory of the device.
+  
+  See JB#56707.
+ -->
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Video Memory Leak Test</title>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+  <script src="leak-test/cycle.js"></script>
+  <link rel="stylesheet" href="leak-test/styles.css" type="text/css" />
+</head>
+<body>
+  <div class="title caption">Video Memory Leak Test</div>
+  <div id="first">
+    <div class="panels">
+      <div class="panel 0">
+        <div class="videobox">
+          <video class="leak" preload="metadata" playsinline="" muted="" loop="" autoplay="autoplay" src="https://web.archive.org/web/20210910214658/https://www.logitech.com/content/dam/logitech/en/products/video-conferencing/logi-dock/logi-dock-one-touch-join.mp4" data-video-ended="false" />
+        </div>
+        <div class="caption">1</div>
+      </div>
+    </div>
+    <div class="placeholder">
+      <div class="panel -1">
+        <div class="videobox">
+          <video class="leak"  preload="metadata" playsinline="" muted="" loop="" autoplay="autoplay" src="https://web.archive.org/web/20210910214658/https://www.logitech.com/content/dam/logitech/en/products/video-conferencing/logi-dock/logi-dock-one-touch-join.mp4" data-video-ended="false" />
+          </video>
+        </div>
+        <div class="caption">Initialising</div>
+      </div>
+    </div>
+    </div>
+  </div>
+</body>
+</html>
+

--- a/tests/manual/testpage.html
+++ b/tests/manual/testpage.html
@@ -205,6 +205,14 @@
       <a href="test-svg-rendering.html">svg rendering test page</a>
     </div>
 
+    <div class="header"><h2>Memory Management</h2></div>
+    <div>
+      <a href="test-leaky-video.html">Test for memory leaks cloning videos</a>
+    </div>
+    <div>
+      <a href="test-leaky-image.html">Test for memory leaks cloning images</a>
+    </div>
+
     <div class="header"><h2>Misc</h2></div>
     <div>
       <a href="http://www.quirksmode.org/css/tests/mediaqueries/devicepixelratio.html">QuirksMode's MediaQueries DevicePixelRatio test page</a>


### PR DESCRIPTION
Adds two pages for testing memory leaks when cloning videos and images respectively.

Image cloning doesn't exhibit any memory leaks on ESR78, whereas video cloning clearly does.