### PR TITLE
[user-agent] Update preprocessed user agent overrides for m.vk.com. Fixes JB#57309

### DIFF
--- a/data/ua-update.json
+++ b/data/ua-update.json
@@ -75,6 +75,7 @@
   "trueconf.rt.ru": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "trueconf.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "videomost.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
+  "m.vk.com": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
   "vk.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:78.0; Linux) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
   "ok.ru": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",

--- a/data/ua-update.json.in
+++ b/data/ua-update.json.in
@@ -99,6 +99,8 @@
   "trueconf.rt.ru": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "trueconf.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "videomost.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
+  // m.vk.com
+  "m.vk.com": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
   "vk.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:78.0; Linux) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
   "ok.ru": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",

--- a/data/ua/78.0/ua-update.json
+++ b/data/ua/78.0/ua-update.json
@@ -75,6 +75,7 @@
   "trueconf.rt.ru": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "trueconf.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "videomost.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
+  "m.vk.com": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
   "vk.com": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",
   "skype.com": "Mozilla/5.0 (Sailfish 4.0; Mobile; rv:78.0; Linux) Gecko/78.0 Firefox/78.0 SailfishBrowser/1.0 like Chrome/67.0.3396",
   "ok.ru": "Mozilla/5.0 (Android; Mobile; rv:78.0) Gecko/78.0 Firefox/78.0",


### PR DESCRIPTION
I found that changing user-agent to desktop Firefox one helps to fix the problem of constantly reloading m.vk.com page (it starts reloading after you log in). Looks like it is a site problem and we need to adjust our user-agent to overcome it.
I will add the JB task number later when I get my Jolla account.