### PR TITLE
[tests] Stabilize declarativehistorymodel test case. Fixes JB#57681

### DIFF
--- a/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.cpp
+++ b/tests/auto/tst_declarativehistorymodel/tst_declarativehistorymodel.cpp
@@ -279,7 +279,13 @@ void tst_declarativehistorymodel::removeHistoryEntries()
     // Reset search results.
     verifySearchResult("", entries.count());
 
-    historyModel->remove(index);
+    if (index >= 0 && index < entries.count()) {
+        // Remove by url rather than index, since the ordering may change
+        historyModel->remove(entries[index].url);
+    } else {
+        // Out of bounds test
+        historyModel->remove(index);
+    }
     verifySearchResult("", countWithEmptySearchIndexRemoved);
 
     historyModel->search(searchTerm);


### PR DESCRIPTION
The history model orders entries first by date descending, followed by url alphabetical ascending. Consequently if the time ticks over a second while the entries are added, the ordering can change.

Removing the entries by url rather than by index ensures the tests don't fail in case this happens.

As an alternative we could change the urls to force the correct order, but then the tests would rely on potentially brittle DBWorker behaviour (the returned ordering), so avoiding direct use of the index seemed preferable.

The tests successfully ran 100 cycles without failure after the change.