### PR TITLE
[browser] Webview test crash fix. Fixes JB#57619

### DIFF
--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -890,7 +890,6 @@ int main(int argc, char *argv[])
     QString path = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
     qDebug() << "Profile path: " << path;
     SailfishOS::WebEngine::initialize(path);
-    SailfishOS::WebEngineSettings::initialize();
 
     tst_webview *testcase = new tst_webview;
 
@@ -938,11 +937,7 @@ int main(int argc, char *argv[])
         if (testcase->running) {
             return;
         }
-
         contextDestroyed = true;
-        delete testcase;
-        testcase = nullptr;
-        QTest::waitForEvents();
     });
 
     int ret = QTest::qExec(testcase, argc, argv);
@@ -961,6 +956,8 @@ int main(int argc, char *argv[])
         QEventLoop::ProcessEventsFlags flags = QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents;
         QCoreApplication::processEvents(flags, 500);
     }
+    delete testcase;
+    testcase = nullptr;
 
     QString dbFileName = QString("%1/%2")
             .arg(BrowserPaths::dataLocation())


### PR DESCRIPTION
This fixes the most frequent crashes for me, didn't manage to fully debug root cause but looks like the context during cleanup was the issue. Dropped WebEngineSettings as well because it caused similar problems.