### PR TITLE
[browser] Quick copy url to clipboard by press-and-hold url from toolbar. Fixes JB#58623

### DIFF
--- a/apps/browser/qml/pages/components/ToolBar.qml
+++ b/apps/browser/qml/pages/components/ToolBar.qml
@@ -277,7 +277,7 @@ Column {
             }
         }
 
-        MouseArea {
+        BackgroundItem {
             id: touchArea
 
             readonly property bool down: pressed && containsMouse
@@ -285,6 +285,7 @@ Column {
             height: parent.height
             width: toolBarRow.width - (tabButton.width + stopButton.width + padlockIcon.width + backIcon.width + menuButton.width)
             enabled: !showFindButtons
+            _showPress: false
 
             onClicked: {
                 if (findInPageActive) {
@@ -294,10 +295,27 @@ Column {
                 }
             }
 
+            onPressAndHold: {
+                var url = webView.url
+                if (url) {
+                    Clipboard.text = url
+                    urlCopyNotice.show()
+                }
+            }
+
+            Notice {
+                id: urlCopyNotice
+                duration: Notice.Short
+                verticalOffset: -Theme.itemSizeMedium
+                //: Url copied to clipboard from toolbar (long press).
+                //% "Url copied to clipboard"
+                text: qsTrId("sailfish_browser-la-url_copied_to_clipboard")
+            }
+
             Label {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width + Theme.paddingMedium
-                color: touchArea.down ? Theme.highlightColor : Theme.primaryColor
+                color: touchArea.highlighted ? Theme.highlightColor : Theme.primaryColor
 
                 text: {
                     if (findInPageActive) {


### PR DESCRIPTION
This commit adds a way to quickly copy current url to clipboard
with long press. Before one would need to go via url text field
to copy the url to the clipboard. As all apps do not provide sharing
this simplifies sharing of the current url via clipboard.

Toolbar mouse area is changed to background item to take benefit of
cancelling of the action (among others). Platform defaults to 800ms
on long press action.

Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>