### PR TITLE
Encode URL string before copying to clipboard

### DIFF
--- a/apps/browser/qml/pages/components/ToolBar.qml
+++ b/apps/browser/qml/pages/components/ToolBar.qml
@@ -298,7 +298,9 @@ Column {
             onPressAndHold: {
                 var url = webView.url
                 if (url) {
-                    Clipboard.text = url
+                    // encode the string if it looks like it has query or fragment parts
+                    // FIXME: could be improved with *proper* matching.
+                    Clipboard.text = ( (url.indexOf('?') > -1) || (url.indexOf('#') > -1) ) ? encodeURI(url) : url
                     urlCopyNotice.show()
                 }
             }


### PR DESCRIPTION
Proposed fix for: https://forum.sailfishos.org/t/4-4-0-72-browser-url-copy-does-not-encode-uri-string/13152

I believe it improves usability if strings pasted after copying from browser are valid URLs, not beautified strings.