### PR TITLE
[browser] Delay external tab requests at startup. Fixes JB#57763

### DIFF
--- a/apps/browser/browserservice.h
+++ b/apps/browser/browserservice.h
@@ -66,6 +66,7 @@ public slots:
     void activateNewTabView();
     void requestTab(int id, const QString &url);
     void closeTab(int id);
+    void requestTabReturned(int tabId, void* context);
 
 signals:
     void openUrlRequested(const QString &url);

--- a/apps/browser/browserservice.h
+++ b/apps/browser/browserservice.h
@@ -75,8 +75,6 @@ signals:
     void showChrome();
 
 private:
-    bool isPrivileged() const;
-    bool callerMatchesService(const QString &serviceName) const;
     uint getCallerPid() const;
     bool matchesOwner(uint pid) const;
 

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -146,6 +146,7 @@ public:
     // For D-Bus interfaces
     uint tabOwner(int tabId) const;
     int requestTabWithOwner(int tabId, const QString &url, uint ownerPid);
+    void requestTabWithOwnerAsync(int tabId, const QString &url, uint ownerPid, void *context);
     Q_INVOKABLE void releaseActiveTabOwnership();
 
     Q_INVOKABLE void load(const QString &url = QString(), bool force = false);
@@ -211,6 +212,7 @@ signals:
     void applicationClosing();
 
     void hasInitialUrlChanged();
+    void requestTabWithOwnerAsyncResult(int tabId, void *context);
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);


### PR DESCRIPTION
Makes two changes:

First, when the browser is started it loads the persistent tab model
asynchronously. Consequently if an external request to open a tab via
D-Bus triggered the browser to load (i.e. it wasn't already running),
the tab could be created before the tab model was loaded. This caused
the PID associated with the created tab to be wiped, and prevented the
external process that opened the tab from closing it again (used e.g. in
OAuth flows).

This change avoids this by delaying creation of tabs requested
externally until after the tab model has completed loading.

Second, when the browser runs inside the sandbox it's not able to check 
whether the sender is in the privileged group, so the check is guaranteed 
to fail.

This change removes the check.

It leaves it in for the case of dumpMemoryInfo() as this may be useful
when running the browser unsandboxed for debugging purposes, and without
the check there would be no other restrictions on processes calling it.
