### PR TITLE
[browser] Do not show pad lock for about:-pages. Fixes JB#59799

### DIFF
--- a/apps/browser/qml/pages/components/ToolBar.qml
+++ b/apps/browser/qml/pages/components/ToolBar.qml
@@ -241,6 +241,7 @@ Column {
                                                  Theme.errorColor.b, glow))
                                : Theme.primaryColor
             enabled: webView.security
+            visible: !(webView.url.indexOf("about:") === 0)
             onTapped: {
                 if (certOverlayActive) {
                     showChrome()


### PR DESCRIPTION
Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>