### PR TITLE
Enable dialog element

### DIFF
--- a/data/prefs.js
+++ b/data/prefs.js
@@ -5,3 +5,4 @@ user_pref("embedlite.compositor.external_gl_context", true);
 user_pref("apz.allow_zooming", true);
 user_pref("dom.meta-viewport.enabled", true);
 user_pref("intl.locale.requested", "");
+user_pref("dom.dialog_element.enabled", true);


### PR DESCRIPTION
The dialog element is now standard, so this is one tiny thing that can be done to make the browser feel less dated.
It was apparently in testing/incubation for a very long time, but should work since Firefox 53, if enabled. See https://caniuse.com/dialog

Only tested with locally modified setting.