### PR TITLE
Use common lib for browser and captiveportal.  JB#59794 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ moc_*.cpp
 *.qm
 Makefile
 *.so
+*.so.*
 RPMS/*
 sailfish-browser.pro.user

--- a/apps/apps.pro
+++ b/apps/apps.pro
@@ -1,2 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += browser captiveportal
+SUBDIRS += lib browser captiveportal
+
+browser.depends = lib
+captiveportal.depends = lib

--- a/apps/browser/browser.pri
+++ b/apps/browser/browser.pri
@@ -1,4 +1,4 @@
-INCLUDEPATH += $$PWD
+INCLUDEPATH += $$PWD $$PWD/../core
 
 # C++ sources
 SOURCES += \

--- a/apps/browser/browser.pro
+++ b/apps/browser/browser.pro
@@ -1,4 +1,4 @@
-QT += qml quick gui gui-private dbus concurrent sql
+QT += qml quick gui dbus concurrent
 # The name of your app
 TARGET = sailfish-browser
 
@@ -10,6 +10,7 @@ target.path = $$TARGETPATH
 INSTALLS += target
 PKGCONFIG +=  mlite5 sailfishwebengine
 INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
+INCLUDEPATH += $$PWD/../core $$PWD/../storage $$PWD/../history $$PWD/../qtmozembed $$PWD/../../common
 
 DEPLOYMENT_PATH = /usr/share/$$TARGET
 DEFINES += DEPLOYMENT_PATH=\"\\\"\"$${DEPLOYMENT_PATH}/\"\\\"\"
@@ -22,6 +23,8 @@ packagesExist(qdeclarative5-boostable) {
     warning("qdeclarative5-boostable not available; startup times will be slower")
 }
 
+LIBS += -L../lib -lsailfishbrowser
+
 # Translations
 TS_PATH = $$PWD
 # Shared translations in browser.pro should be skipped from other subprojects
@@ -32,13 +35,7 @@ EE_QM = $$OUT_PWD/sailfish-browser_eng_en.qm
 include(../../translations/translations.pri)
 
 include(../../defaults.pri)
-include(../../common/browserapp.pri)
-include(../../common/opensearchconfigs.pri)
-include(../core/core.pri)
 include(../browser/browser.pri)
-include(../history/history.pri)
-include(../qtmozembed/qtmozembed.pri)
-include(../factories/factories.pri)
 include(../shared/shared.pri)
 include(settings/settings.pri)
 include(bookmarks/bookmarks.pri)

--- a/apps/browser/browser.pro
+++ b/apps/browser/browser.pro
@@ -8,8 +8,7 @@ TARGETPATH = /usr/bin
 target.path = $$TARGETPATH
 
 INSTALLS += target
-PKGCONFIG +=  mlite5 sailfishwebengine
-INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
+PKGCONFIG += mlite5 sailfishwebengine
 INCLUDEPATH += $$PWD/../core $$PWD/../storage $$PWD/../history $$PWD/../qtmozembed $$PWD/../../common
 
 DEPLOYMENT_PATH = /usr/share/$$TARGET

--- a/apps/browser/browser.pro
+++ b/apps/browser/browser.pro
@@ -11,6 +11,9 @@ INSTALLS += target
 PKGCONFIG +=  mlite5 sailfishwebengine
 INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
 
+DEPLOYMENT_PATH = /usr/share/$$TARGET
+DEFINES += DEPLOYMENT_PATH=\"\\\"\"$${DEPLOYMENT_PATH}/\"\\\"\"
+
 packagesExist(qdeclarative5-boostable) {
     message("Building with qdeclarative-boostable support")
     DEFINES += HAS_BOOSTER

--- a/apps/browser/main.cpp
+++ b/apps/browser/main.cpp
@@ -152,8 +152,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterUncreatableType<DeclarativeTabModel>(uri, 1, 0, "TabModel", "TabModel is abstract!");
     qmlRegisterUncreatableType<PrivateTabModel>(uri, 1, 0, "PrivateTabModel", "");
 
-    if (!BrowserApp::captivePortal())
-    {
+    if (!BrowserApp::captivePortal()) {
         qmlRegisterType<DeclarativeBookmarkModel>(uri, 1, 0, "BookmarkModel");
         qmlRegisterUncreatableType<PersistentTabModel>(uri, 1, 0, "PersistentTabModel", "");
         qmlRegisterType<DeclarativeHistoryModel>(uri, 1, 0, "HistoryModel");
@@ -162,6 +161,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         qmlRegisterType<LoginFilterModel>(uri, 1, 0, "LoginFilterModel");
         qmlRegisterSingletonType<BookmarkManager>(uri, 1, 0, "BookmarkManager", bookmarkmanager_factory);
     }
+
     qmlRegisterSingletonType<FaviconManager>(uri, 1, 0, "FaviconManager", faviconmanager_factory);
     qmlRegisterUncreatableType<DownloadStatus>(uri, 1, 0, "DownloadStatus", "");
     qmlRegisterType<DeclarativeWebContainer>(uri, 1, 0, "WebContainer");
@@ -181,8 +181,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     browser->connect(service, &BrowserService::dumpMemoryInfoRequested,
                      browser, &Browser::dumpMemoryInfo);
 
-    if (uiService)
-    {
+    if (uiService) {
         browser->connect(uiService, &BrowserUIService::openUrlRequested,
                         browser, &Browser::openUrl);
         browser->connect(uiService, &BrowserUIService::openSettingsRequested,

--- a/apps/browser/main.cpp
+++ b/apps/browser/main.cpp
@@ -173,7 +173,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterType<SecureAction>(uri, 1, 0, "SecureAction");
     qmlRegisterSingletonType<SearchEngineModel>(uri, 1, 0, "SearchEngineModel", search_model_factory);
 
-    Browser *browser = new Browser(view.data(), app.data());
+    Browser *browser = new Browser(view.data(), DEPLOYMENT_PATH, app.data());
     browser->connect(service, &BrowserService::openUrlRequested,
                      browser, &Browser::openUrl);
     browser->connect(service, &BrowserService::activateNewTabViewRequested,

--- a/apps/captiveportal/captiveportal.pro
+++ b/apps/captiveportal/captiveportal.pro
@@ -11,8 +11,7 @@ DEPLOYMENT_PATH = /usr/share/$$TARGET
 DEFINES += DEPLOYMENT_PATH=\"\\\"\"$${DEPLOYMENT_PATH}/\"\\\"\"
 
 INSTALLS += target
-PKGCONFIG +=  mlite5 sailfishwebengine
-INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
+PKGCONFIG += mlite5 sailfishwebengine
 INCLUDEPATH += $$PWD/../core $$PWD/../storage $$PWD/../history $$PWD/../qtmozembed $$PWD/../../common
 
 LIBS += -L../lib -lsailfishbrowser

--- a/apps/captiveportal/captiveportal.pro
+++ b/apps/captiveportal/captiveportal.pro
@@ -7,6 +7,9 @@ CONFIG += link_pkgconfig
 TARGETPATH = /usr/bin
 target.path = $$TARGETPATH
 
+DEPLOYMENT_PATH = /usr/share/$$TARGET
+DEFINES += DEPLOYMENT_PATH=\"\\\"\"$${DEPLOYMENT_PATH}/\"\\\"\"
+
 INSTALLS += target
 PKGCONFIG +=  mlite5 sailfishwebengine
 INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)

--- a/apps/captiveportal/captiveportal.pro
+++ b/apps/captiveportal/captiveportal.pro
@@ -1,4 +1,4 @@
-QT += qml quick gui gui-private dbus sql
+QT += qml quick gui dbus
 # The name of your app
 TARGET = sailfish-captiveportal
 
@@ -13,6 +13,9 @@ DEFINES += DEPLOYMENT_PATH=\"\\\"\"$${DEPLOYMENT_PATH}/\"\\\"\"
 INSTALLS += target
 PKGCONFIG +=  mlite5 sailfishwebengine
 INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
+INCLUDEPATH += $$PWD/../core $$PWD/../storage $$PWD/../history $$PWD/../qtmozembed $$PWD/../../common
+
+LIBS += -L../lib -lsailfishbrowser
 
 packagesExist(qdeclarative5-boostable) {
     message("Building with qdeclarative-boostable support")
@@ -32,12 +35,6 @@ EE_QM = $$OUT_PWD/sailfish-captiveportal_eng_en.qm
 include(../../translations/translations.pri)
 
 include(../../defaults.pri)
-include(../../common/browserapp.pri)
-include(../../common/opensearchconfigs.pri)
-include(../core/core.pri)
-include(../history/history.pri)
-include(../qtmozembed/qtmozembed.pri)
-include(../factories/factories.pri)
 include(../shared/shared.pri)
 
 # QML files and folders of captiveportal

--- a/apps/captiveportal/main.cpp
+++ b/apps/captiveportal/main.cpp
@@ -106,7 +106,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterType<DeclarativeWebPageCreator>(uri, 1, 0, "WebPageCreator");
     qmlRegisterType<InputRegion>(uri, 1, 0, "InputRegion");
 
-    Browser *browser = new Browser(view.data(), app.data());
+    Browser *browser = new Browser(view.data(), DEPLOYMENT_PATH, app.data());
     browser->connect(service, &CaptivePortalService::openUrlRequested,
                      browser, &Browser::openUrl);
     browser->load();

--- a/apps/core/browser.cpp
+++ b/apps/core/browser.cpp
@@ -69,11 +69,12 @@ void BrowserPrivate::initUserData()
         QFile::copy(MOZILLA_DATA_PREFS_SOURCE, mozillaDir + MOZILLA_DATA_PREFS);
 }
 
-Browser::Browser(QQuickView *view, QObject *parent)
+Browser::Browser(QQuickView *view, const QString &dataPath, QObject *parent)
     : QObject(parent)
     , d_ptr(new BrowserPrivate(view))
 {
     Q_D(Browser);
+    d->m_dataPath = dataPath;
 
     Q_ASSERT(view);
     Q_ASSERT(qGuiApp);
@@ -112,11 +113,12 @@ void Browser::load()
 
 QString Browser::applicationFilePath()
 {
+    Q_D(Browser);
     Q_ASSERT_X(qGuiApp, Q_FUNC_INFO, "There should always be a QGuiApplication running.");
     if (qGuiApp->arguments().contains("-desktop")) {
         return qGuiApp->applicationDirPath() + QDir::separator();
     } else {
-        return QString(DEPLOYMENT_PATH);
+        return QString(d->m_dataPath);
     }
 }
 

--- a/apps/core/browser.h
+++ b/apps/core/browser.h
@@ -23,11 +23,11 @@ class Browser : public QObject
     Q_OBJECT
 
 public:
-    explicit Browser(QQuickView *view, QObject *parent = nullptr);
+    Browser(QQuickView *view, const QString &dataPath, QObject *parent = nullptr);
 
     void load();
 
-    static QString applicationFilePath();
+    QString applicationFilePath();
 
 public slots:
     void openUrl(const QString &url);

--- a/apps/core/browser_p.h
+++ b/apps/core/browser_p.h
@@ -23,6 +23,7 @@ public:
 
 private:
     void initUserData();
+    QString m_dataPath;
 
 protected:
     QQuickView *view;

--- a/apps/core/core.pri
+++ b/apps/core/core.pri
@@ -3,9 +3,6 @@ INCLUDEPATH += $$PWD
 CONFIG += link_pkgconfig
 PKGCONFIG += sailfishpolicy nemotransferengine-qt5 dsme_dbus_if
 
-DEPLOYMENT_PATH = /usr/share/$$TARGET
-DEFINES += DEPLOYMENT_PATH=\"\\\"\"$${DEPLOYMENT_PATH}/\"\\\"\"
-
 # C++ sources
 SOURCES += \
     $$PWD/browser.cpp \

--- a/apps/lib/lib.pro
+++ b/apps/lib/lib.pro
@@ -8,7 +8,6 @@ CONFIG += link_pkgconfig
 target.path = $$[QT_INSTALL_LIBS]
 
 PKGCONFIG += mlite5 sailfishwebengine
-INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
 
 include(../../defaults.pri)
 include(../../common/browserapp.pri)

--- a/apps/lib/lib.pro
+++ b/apps/lib/lib.pro
@@ -1,0 +1,21 @@
+TEMPLATE = lib
+TARGET = sailfishbrowser
+
+QT += qml quick gui gui-private dbus concurrent sql
+
+CONFIG += link_pkgconfig
+
+target.path = $$[QT_INSTALL_LIBS]
+
+PKGCONFIG += mlite5 sailfishwebengine
+INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
+
+include(../../defaults.pri)
+include(../../common/browserapp.pri)
+include(../../common/opensearchconfigs.pri)
+include(../core/core.pri)
+include(../history/history.pri)
+include(../qtmozembed/qtmozembed.pri)
+include(../factories/factories.pri)
+
+INSTALLS += target

--- a/apps/shared/OverlayAnimator.qml
+++ b/apps/shared/OverlayAnimator.qml
@@ -99,7 +99,10 @@ Item {
         // Animation end changes to true state. Hence not like atTop = state !== _fullscreenOverlay
         var wasAtMiddle = (!atBottom && !atTop) || _midPos
         var goingUp = (atBottom || wasAtMiddle) && (state === _fullscreenOverlay || state === _startPage)
-        var goingDown = (atTop || wasAtMiddle) && (state === _chromeVisible || state === _fullscreenWebPage || state === _doubleToolBar || state === _noOverlay || state === _draggingOverlay || state === _certOverlay || state === _startPage )
+        var goingDown = (atTop || wasAtMiddle)
+                && (state === _chromeVisible || state === _fullscreenWebPage || state === _doubleToolBar
+                    || state === _noOverlay || state === _draggingOverlay || state === _certOverlay
+                    || state === _startPage)
 
         if ((state !== _fullscreenOverlay && state !== _certOverlay && state !== _startPage) || _midPos) {
             atTop = false

--- a/common/browserpaths.cpp
+++ b/common/browserpaths.cpp
@@ -19,7 +19,8 @@
 #include <grp.h>
 #include <unistd.h>
 
-static QString getLocation(QStandardPaths::StandardLocation locationType) {
+static QString getLocation(QStandardPaths::StandardLocation locationType)
+{
     QString location(QStandardPaths::writableLocation(locationType));
     QDir dir(location);
     if (!dir.exists()) {

--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -2,7 +2,6 @@
 %global min_qtmozembed_version 1.53.8
 %global min_embedlite_components_version 1.20.0
 %global min_sailfishwebengine_version 1.5.9
-%global min_systemsettings_version 0.5.25
 
 %global captiveportal sailfish-captiveportal
 
@@ -19,7 +18,6 @@ BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(qt5embedwidget) >= %{min_qtmozembed_version}
-BuildRequires:  pkgconfig(systemsettings) >= %{min_systemsettings_version}
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Concurrent)
 BuildRequires:  pkgconfig(Qt5Sql)
@@ -57,7 +55,6 @@ Requires: jolla-settings-system >= 1.0.70
 Requires: libkeepalive >= 1.7.0
 Requires: sailfish-components-pickers-qt5 >= 0.1.7
 Requires: nemo-qml-plugin-notifications-qt5 >= 1.0.12
-Requires: nemo-qml-plugin-systemsettings >= %{min_systemsettings_version}
 Requires: mapplauncherd-booster-browser
 Requires: nemo-qml-plugin-connectivity
 Requires: connman-qt5-declarative >= 1.3.0

--- a/rpm/sailfish-browser.spec
+++ b/rpm/sailfish-browser.spec
@@ -112,7 +112,7 @@ mkdir -p %{buildroot}/%{_sharedstatedir}/environment/nemo/
 cp -f data/70-browser.conf %{buildroot}/%{_sharedstatedir}/environment/nemo/
 
 %post
-/usr/bin/update-desktop-database -q || :
+/sbin/ldconfig || :
 
 # Upgrade, count is 2 or higher (depending on the number of versions installed)
 if [ "$1" -ge 2 ]; then
@@ -122,6 +122,9 @@ if [ "$1" -ge 2 ]; then
     %{_bindir}/add-oneshot --all-users browser-move-data-to-new-location || :
     %{_bindir}/add-oneshot --all-users browser-deprecate-dconf-keys || :
 fi
+
+%postun
+/sbin/ldconfig || :
 
 %files
 %defattr(-,root,root,-)
@@ -139,6 +142,8 @@ fi
 %{_userunitdir}/user-session.target.d/50-sailfish-browser.conf
 # Let main package own import root level
 %dir %{_libdir}/qt5/qml/org/sailfishos/browser
+%{_libdir}/libsailfishbrowser.so.*
+%exclude %{_libdir}/libsailfishbrowser.so
 %{_sharedstatedir}/environment/nemo/*
 %{_libexecdir}/jolla-vault/units/vault-browser
 %{_datadir}/jolla-vault/units/Browser.json

--- a/tests/auto/mocks/opensearchconfigs/opensearchconfigs.h
+++ b/tests/auto/mocks/opensearchconfigs/opensearchconfigs.h
@@ -14,8 +14,8 @@
 
 typedef QMap<QString, QString> StringMap;
 
-class OpenSearchConfigs : public QObject {
-
+class OpenSearchConfigs : public QObject
+{
 public:
     static const StringMap getAvailableOpenSearchConfigs();
     static const QStringList getSearchEngineList();

--- a/tests/auto/tst_logins/tst_logins.pro
+++ b/tests/auto/tst_logins/tst_logins.pro
@@ -2,7 +2,7 @@ TARGET = tst_logins
 
 CONFIG += link_pkgconfig
 
-PKGCONFIG += nemotransferengine-qt5 mlite5 sailfishwebengine systemsettings
+PKGCONFIG += nemotransferengine-qt5 mlite5 sailfishwebengine
 
 QT += quick concurrent sql gui-private
 

--- a/tests/auto/tst_logins/tst_logins.pro
+++ b/tests/auto/tst_logins/tst_logins.pro
@@ -3,7 +3,6 @@ TARGET = tst_logins
 CONFIG += link_pkgconfig
 
 PKGCONFIG += nemotransferengine-qt5 mlite5 sailfishwebengine systemsettings
-INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
 
 QT += quick concurrent sql gui-private
 

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -3,7 +3,6 @@ TARGET = tst_webview
 CONFIG += link_pkgconfig
 
 PKGCONFIG += nemotransferengine-qt5 mlite5 sailfishwebengine systemsettings
-INCLUDEPATH += $$system(pkg-config --cflags sailfishwebengine)
 
 QT += quick concurrent sql gui-private
 

--- a/tests/auto/tst_webview/tst_webview.pro
+++ b/tests/auto/tst_webview/tst_webview.pro
@@ -2,7 +2,7 @@ TARGET = tst_webview
 
 CONFIG += link_pkgconfig
 
-PKGCONFIG += nemotransferengine-qt5 mlite5 sailfishwebengine systemsettings
+PKGCONFIG += nemotransferengine-qt5 mlite5 sailfishwebengine
 
 QT += quick concurrent sql gui-private
 


### PR DESCRIPTION
Saves on build time, disk space, memory consumption. Build time saving especially nice as this is often the last thing building in obs. Should be room for further optimization if using the lib on unit tests too.

Bunch of other adjustments in separate commits for things I noticed while doing this.