### PR TITLE
Ensure browser uses fullscreen pages. JB#61618

### DIFF
--- a/apps/shared/BrowserWindow.qml
+++ b/apps/shared/BrowserWindow.qml
@@ -39,6 +39,8 @@ ApplicationWindow {
     _mainWindow: webView
     _backgroundVisible: false
     _opaque: false
+    // for time being make this fullscreen. TODO: avoid drawing over cutout and corner areas.
+    defaultPageCutoutMode: CutoutMode.FullScreen
 
     cover: null
 
@@ -46,6 +48,7 @@ ApplicationWindow {
 
     DisabledByMdmView {
         id: mdmView
+
         enabled: !AccessPolicy.browserEnabled
         onEnabledChanged: {
             if (enabled) {


### PR DESCRIPTION
We should really rather avoid the cutout areas, but browser is a bit more complicated with the separate window for web content etc.