### PR TITLE
[browser] Use const QString reference in loop. JB#62204

### DIFF
--- a/apps/storage/dbworker.cpp
+++ b/apps/storage/dbworker.cpp
@@ -509,7 +509,7 @@ void DBWorker::clearHistory(int period)
         }
 
         QSet<QString>::iterator iconIterator;
-        for (const QString iconToRemove : historyIconsToRemove) {
+        for (const QString &iconToRemove : historyIconsToRemove) {
             FaviconManager::instance()->remove(QStringLiteral("history"), iconToRemove);
         }
 


### PR DESCRIPTION
Fixes build with gcc 11 or newer.