### PR TITLE
Fix url focus issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ moc_*.cpp
 Makefile
 *.so
 *.so.*
+*.ts
 RPMS/*
 sailfish-browser.pro.user

--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -121,8 +121,9 @@ Page {
         visible: webView.contentItem
         page: browserPage
         fadeTarget: overlay.animator.allowContentUse ? overlay : overlay.dragArea
-        color: webView.contentItem ? (webView.resourceController.videoActive &&
-                                      webView.contentItem.fullscreen ? "black" : webView.contentItem.backgroundColor)
+        color: webView.contentItem ? (webView.resourceController.videoActive
+                                      && webView.contentItem.fullscreen
+                                      ? "black" : webView.contentItem.backgroundColor)
                                    : "white"
 
         onApplyContentOrientation: webView.applyContentOrientation(browserPage.orientation)
@@ -254,7 +255,8 @@ Page {
                        : 0.9 - (overlay.y / (webView.fullscreenHeight - overlay.toolBar.rowHeight)) * 0.9
 
         MouseArea {
-            property bool inEmptyPrivateMode: webView.privateMode && webView.privateTabModel.count === 0 && webView.persistentTabModel.count > 0
+            property bool inEmptyPrivateMode: webView.privateMode && webView.privateTabModel.count === 0
+                                              && webView.persistentTabModel.count > 0
 
             anchors.fill: parent
             enabled: overlay.animator.atTop && (webView.tabModel.count > 0 || inEmptyPrivateMode)
@@ -270,6 +272,7 @@ Page {
 
         Browser.PrivateModeTexture {
             id: privateModeTexture
+
             anchors.fill: contentDimmer
             visible: webView.privateMode && !overlay.animator.allowContentUse
         }
@@ -298,7 +301,7 @@ Page {
     Browser.Overlay {
         id: overlay
 
-        active: browserPage.status == PageStatus.Active &&  webView.tabModel.loaded
+        active: browserPage.status == PageStatus.Active && webView.tabModel.loaded
         webView: webView
         historyModel: historyModel
         browserPage: browserPage
@@ -312,7 +315,9 @@ Page {
         onActiveChanged: {
             var isFullScreen = webView.contentItem && webView.contentItem.fullscreen
             if (!isFullScreen && active && !overlay.enteringNewTabUrl) {
-                if (webView.hasInitialUrl || webView.tabModel.count !== 0 || (WebUtils.homePage !== "about:blank" && WebUtils.homePage.length > 0)) {
+                if (webView.hasInitialUrl
+                        || webView.tabModel.count !== 0
+                        || (WebUtils.homePage !== "about:blank" && WebUtils.homePage.length > 0)) {
                     overlay.animator.showChrome()
                 } else {
                     overlay.startPage()
@@ -351,12 +356,12 @@ Page {
         }
 
         footer: Component {
-           Browser.PopUpMenuFooter {
-               height: Math.max(implicitHeight,
-                                (isPortrait ? overlay.toolBar.scaledPortraitHeight
-                                            : overlay.toolBar.scaledLandscapeHeight)
-                                - popupMenu.verticalMargin)
-           }
+            Browser.PopUpMenuFooter {
+                height: Math.max(implicitHeight,
+                                 (isPortrait ? overlay.toolBar.scaledPortraitHeight
+                                             : overlay.toolBar.scaledLandscapeHeight)
+                                 - popupMenu.verticalMargin)
+            }
         }
 
         onClosed: overlay.dismiss(true)

--- a/apps/browser/qml/pages/LoginsPage.qml
+++ b/apps/browser/qml/pages/LoginsPage.qml
@@ -14,13 +14,6 @@ import Sailfish.Browser 1.0
 import "components"
 
 Page {
-    LoginFilterModel {
-        id: loginFilterModel
-        sourceModel: LoginModel {
-            id: loginModel
-        }
-    }
-
     function stripPrefix(hostname) {
         if (hostname.length < 7) {
             return hostname
@@ -207,6 +200,14 @@ Page {
         id: secureAction
         //% "Unlock access to browser passwords"
         message: qsTrId("sailfish_browser-me-login_unlock_password_access")
+    }
+
+    LoginFilterModel {
+        id: loginFilterModel
+
+        sourceModel: LoginModel {
+            id: loginModel
+        }
     }
 
     Component {

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -102,6 +102,7 @@ Shared.Background {
 
     Private.VirtualKeyboardObserver {
         id: virtualKeyboardObserver
+
         active: overlay.active && !overlayAnimator.atBottom
         orientation: browserPage.orientation
     }
@@ -155,10 +156,8 @@ Shared.Background {
                 if (_showFindInPage || _showUrlEntry) {
                     toolBar.certOverlayActive = false
                 }
-            } else {
-                if (!toolBar.certOverlayActive) {
-                    dragArea.moved = true
-                }
+            } else if (!toolBar.certOverlayActive) {
+                dragArea.moved = true
             }
         }
     }
@@ -183,10 +182,11 @@ Shared.Background {
         id: dragArea
 
         property bool moved
-        property int dragThreshold: state === "fullscreenOverlay" ? toolBar.rowHeight * 1.5
-                                                                  : state === "certOverlay"
-                                                                    ? (overlayAnimator._infoHeight + toolBar.rowHeight * 0.5)
-                                                                    : (webView.fullscreenHeight - toolBar.rowHeight * 2)
+        property int dragThreshold: state === "fullscreenOverlay"
+                                    ? toolBar.rowHeight * 1.5
+                                    : state === "certOverlay"
+                                      ? (overlayAnimator._infoHeight + toolBar.rowHeight * 0.5)
+                                      : (webView.fullscreenHeight - toolBar.rowHeight * 2)
 
         width: parent.width
         height: historyContainer.height
@@ -233,10 +233,13 @@ Shared.Background {
         Item {
             id: historyContainer
 
-            readonly property bool showFavorites: !overlayAnimator.atBottom && !toolBar.findInPageActive && _showUrlEntry
-            readonly property bool showHistoryList: showFavorites && (searchField.edited
-                                                                      && searchField.text !== webView.url
-                                                                      && searchField.text)
+            readonly property bool showFavorites: !overlayAnimator.atBottom
+                                                  && !toolBar.findInPageActive
+                                                  && _showUrlEntry
+            readonly property bool showHistoryList: showFavorites
+                                                    && searchField.edited
+                                                    && searchField.text !== webView.url
+                                                    && searchField.text
             readonly property bool showHistoryButton: !toolBar.findInPageActive && (!searchField.edited
                                                                                     && searchField.text === webView.url
                                                                                     || !searchField.text)
@@ -248,7 +251,8 @@ Shared.Background {
                    || overlayAnimator.direction === "downwards"
                    || overlayAnimator.direction === "upwards"
                    || favoriteGrid.opacity != 0.0
-                   || historyList.opacity != 0.0) && searchField.y < 0
+                   || historyList.opacity != 0.0)
+                  && searchField.y < 0
 
             PrivateModeTexture {
                 opacity: toolBar.visible && webView.privateMode ? toolBar.opacity : 0.0
@@ -327,10 +331,11 @@ Shared.Background {
                 }
 
                 // Follow grid / list position.
-                y: -((!historyContainer.showHistoryList ? favoriteGrid.contentY
-                                                        : favoriteGrid.count > 0
-                                                          ? historyList.contentY + favoriteGrid.cellHeight + favoriteGrid.menuHeight
-                                                          : historyList.contentY)
+                y: -((historyContainer.showHistoryList
+                      ? (favoriteGrid.count > 0
+                         ? historyList.contentY + favoriteGrid.cellHeight + favoriteGrid.menuHeight
+                         : historyList.contentY)
+                      : favoriteGrid.contentY)
                      + favoriteGrid.headerItem.height + favoriteGrid.menuHeight)
 
                 // On top of HistoryList and FavoriteGrid
@@ -567,10 +572,10 @@ Shared.Background {
                 header: Browser.FavoriteGrid {
                     id: favoriteGrid
 
-                    height: !historyContainer.showHistoryList ? historyList.height
-                                                              : count > 0
+                    height: historyContainer.showHistoryList ? (count > 0
                                                                 ? cellHeight + headerItem.height + menuHeight
-                                                                : headerItem.height
+                                                                : headerItem.height)
+                                                             : historyList.height
                     opacity: visible && toolBar.opacity < 0.9 ? 1.0 : 0.0
                     enabled: overlayAnimator.atTop
                     visible: historyContainer.showFavorites

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -195,7 +195,7 @@ Shared.Background {
         drag.target: overlay
         drag.filterChildren: true
         drag.axis: Drag.YAxis
-        // Favorite grid first row offset is negative. So, increase minumumY drag by that.
+        // Favorite grid first row offset is negative. So, increase minimumY drag by that.
         drag.minimumY: _overlayHeight
         drag.maximumY: webView.fullscreenHeight - toolBar.rowHeight
 
@@ -330,6 +330,10 @@ Shared.Background {
                     edited = false
                 }
 
+                function hasMoved() {
+                    return y < -height && historyList.contentY !== favoriteGrid.contentY
+                }
+
                 // Follow grid / list position.
                 y: -((historyContainer.showHistoryList
                       ? (favoriteGrid.count > 0
@@ -383,8 +387,10 @@ Shared.Background {
                 visible: opacity > 0.0 && y >= -searchField.height
 
                 onYChanged: {
-                    if (y < -height && historyList.contentY !== favoriteGrid.contentY) {
-                        dragArea.moved = true
+                    if (hasMoved()) {
+                        // the binding evaluation order might result in unexpected temporary positions
+                        // redo the move check after all of them are handled
+                        moveCheckTimer.start()
                     }
                 }
 
@@ -417,6 +423,17 @@ Shared.Background {
                 onTextChanged: {
                     if (!edited && text !== webView.url) {
                         edited = true
+                    }
+                }
+
+                Timer {
+                    id: moveCheckTimer
+
+                    interval: 0
+                    onTriggered: {
+                        if (searchField.hasMoved()) {
+                            dragArea.moved = true
+                        }
                     }
                 }
             }

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -513,7 +513,7 @@ void DeclarativeWebContainer::reload(bool force)
 
 void DeclarativeWebContainer::goForward()
 {
-    if (m_webPage &&  m_webPage->canGoForward()) {
+    if (m_webPage && m_webPage->canGoForward()) {
         DBManager::instance()->goForward(m_webPage->tabId());
         m_webPage->goForward();
     }


### PR DESCRIPTION
Fixed a case when the binding evaluation temporarily made the text field y position something way out of the screen, and the logic assumed the focus should be removed. Added a timer to recheck the position when all the bindings have finished their evaluation.

Some cleanups and simplifications while at it, though the overlay code isn't the easiest to follow.