### PR TITLE
UI fixes

### DIFF
--- a/apps/browser/qml/pages/BookmarkPage.qml
+++ b/apps/browser/qml/pages/BookmarkPage.qml
@@ -15,11 +15,11 @@ import "components"
 
 Page {
     property string searchText
-
     property BookmarkModel bookmarkModel
 
     BookmarkFilterModel {
         id: bookmarkFilterModel
+
         sourceModel: bookmarkModel
         search: searchText
     }

--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -41,6 +41,9 @@ Page {
     property alias webView: webView
     property alias inputRegion: inputRegion
 
+    // for time being make this fullscreen. TODO: avoid drawing over cutout and corner areas.
+    cutoutMode: CutoutMode.FullScreen
+
     function load(url, title) {
         webView.load(url, title)
     }

--- a/apps/browser/qml/pages/EditLoginPage.qml
+++ b/apps/browser/qml/pages/EditLoginPage.qml
@@ -15,6 +15,7 @@ import "components"
 
 Dialog {
     id: page
+
     property int uid: -1
     property LoginModel loginModel
     property SecureAction secureAction
@@ -32,6 +33,7 @@ Dialog {
 
         Column {
             id: column
+
             width: parent.width
 
             DialogHeader {
@@ -41,6 +43,7 @@ Dialog {
 
             Label {
                 id: hostnameField
+
                 x: Theme.horizontalPageMargin
                 width: parent.width - 2 * Theme.horizontalPageMargin
                 height: Theme.itemSizeSmall
@@ -51,6 +54,7 @@ Dialog {
 
             TextField {
                 id: usernameField
+
                 //% "Username"
                 label: qsTrId("sailfish_browser-me-login_edit_username")
                 inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
@@ -64,6 +68,7 @@ Dialog {
 
             PasswordField {
                 id: passwordField
+
                 EnterKey.onClicked: focus = false
                 showEchoModeToggle: secureAction.available
 

--- a/apps/browser/qml/pages/HistoryPage.qml
+++ b/apps/browser/qml/pages/HistoryPage.qml
@@ -18,7 +18,7 @@ Page {
 
     property QtObject model
     property var remorse
-    readonly property bool pendingRemorse: remorse ? remorse.pending : false
+    readonly property bool pendingRemorse: remorse && remorse.pending
 
     signal loadPage(string url, bool newTab)
     signal saveBookmark(string url, string title, string favicon)
@@ -48,6 +48,7 @@ Page {
             }
             SearchField {
                 id: searchField
+
                 width: parent.width
                 //% "Search"
                 placeholderText: qsTrId("sailfish_browser-ph-search")

--- a/apps/browser/qml/pages/LoginsPage.qml
+++ b/apps/browser/qml/pages/LoginsPage.qml
@@ -87,8 +87,8 @@ Page {
 
                 FavoriteIcon {
                     id: loginsIcon
-                    anchors.verticalCenter: parent.verticalCenter
 
+                    anchors.verticalCenter: parent.verticalCenter
                     icon: model.favicon
 
                     sourceSize.width: Theme.iconSizeMedium
@@ -99,6 +99,7 @@ Page {
 
                 Column {
                     id: column
+
                     anchors.verticalCenter: parent.verticalCenter
                     width: parent.width - parent.spacing - loginsIcon.width
                     Label {
@@ -120,6 +121,7 @@ Page {
             menu: Component {
                 ContextMenu {
                     id: contextMenu
+
                     MenuItem {
                         visible: !secureAction.available
                         //% "Copy username"
@@ -191,7 +193,9 @@ Page {
 
     Notice {
         id: notification
+
         property bool published
+
         duration: Notice.Short
         verticalOffset: -Theme.itemSizeMedium
     }
@@ -215,6 +219,7 @@ Page {
 
         Item {
             id: _copyOptions
+
             property Item menu
             property string username
             property string password

--- a/apps/browser/qml/pages/PermissionExceptionsPage.qml
+++ b/apps/browser/qml/pages/PermissionExceptionsPage.qml
@@ -22,10 +22,11 @@ Page {
     property string iconSource
 
     property var remorse
-    readonly property bool pendingRemorse: remorse ? remorse.pending : false
+    readonly property bool pendingRemorse: remorse && remorse.pending
 
     PermissionFilterProxyModel {
         id: proxyModel
+
         onlyPermanent: true
         sourceModel: page.model
     }

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -27,6 +27,7 @@ Page {
 
         Column {
             id: contentColumn
+
             width: parent.width
 
             PageHeader {
@@ -96,6 +97,7 @@ Page {
 
                 TextSwitch {
                     id: clearSavedPasswords
+
                     //% "Saved passwords"
                     text: qsTrId("settings_browser-la-clear_passwords")
                     checked: true
@@ -103,6 +105,7 @@ Page {
 
                 TextSwitch {
                     id: clearCache
+
                     //% "Cache"
                     text: qsTrId("settings_browser-la-clear_cache")
                     checked: true
@@ -110,6 +113,7 @@ Page {
 
                 TextSwitch {
                     id: clearBookmarks
+
                     //% "Bookmarks"
                     text: qsTrId("settings_browser-la-clear_bookmarks")
                     checked: true

--- a/apps/browser/qml/pages/SettingsPage.qml
+++ b/apps/browser/qml/pages/SettingsPage.qml
@@ -54,7 +54,8 @@ Page {
                 //% "Home Page"
                 label: qsTrId("settings_browser-la-home_page")
                 //% "Start view"
-                value: _homePageBlank ? qsTrId("sailfish_browser-la-start_view") : removeProtocolTypeFromUri(homePageConfig.value)
+                value: _homePageBlank ? qsTrId("sailfish_browser-la-start_view")
+                                      : removeProtocolTypeFromUri(homePageConfig.value)
 
                 currentIndex: _homePageBlank
                               ? 0 // For start view (blank)
@@ -111,7 +112,8 @@ Page {
                             text: title
                             //: Shown on Settings -> Search engine for user installable search services
                             //% "Tap to install"
-                            description: status == SearchEngineModel.Available ? qsTrId("settings_browser-la-tap_to_install") : ""
+                            description: status == SearchEngineModel.Available
+                                         ? qsTrId("settings_browser-la-tap_to_install") : ""
                             onClicked: {
                                 if (title !== searchEngineConfig.value) {
                                     if (status == SearchEngineModel.Available) {
@@ -349,6 +351,7 @@ Page {
 
     ConfigurationValue {
         id: closeAllTabsConfig
+
         key: "/apps/sailfish-browser/settings/close_all_tabs"
         defaultValue: false
     }
@@ -369,6 +372,7 @@ Page {
 
     Notice {
         id: searchInstalledNotice
+
         duration: 3000
         verticalOffset: -Theme.paddingLarge
     }

--- a/apps/browser/qml/pages/SitePermissionPage.qml
+++ b/apps/browser/qml/pages/SitePermissionPage.qml
@@ -82,6 +82,7 @@ Page {
 
     PermissionFilterProxyModel {
         id: permissionFilterProxyModel
+
         sourceModel: permissionModel
         onlyPermanent: true
 

--- a/apps/browser/qml/pages/components/AddHomePageDialog.qml
+++ b/apps/browser/qml/pages/components/AddHomePageDialog.qml
@@ -17,6 +17,7 @@ Dialog {
     id: dialog
 
     property ConfigurationValue homePageConfig
+
     canAccept: textField.text !== ""
     onAccepted: {
         homePageConfig.value = textField.text.trim() || "about:blank"
@@ -24,6 +25,7 @@ Dialog {
 
     DialogHeader {
         id: header
+
         //: Accept button text for adding a home page adress
         //% "OK"
         acceptText: qsTrId("sailfish_browser-he-ok")
@@ -31,6 +33,7 @@ Dialog {
 
     TextField {
         id: textField
+
         anchors.top: header.bottom
         text: homePageConfig.value === "about:blank" ? "" : homePageConfig.value
         //% "Shown when the browser is opened with no tabs to load."

--- a/apps/browser/qml/pages/components/BookmarkEditDialog.qml
+++ b/apps/browser/qml/pages/components/BookmarkEditDialog.qml
@@ -15,6 +15,7 @@ import Sailfish.WebView.Popups 1.0
 
 UserPromptDialog {
     id: root
+
     property string url
     property string title
     property int index
@@ -48,6 +49,7 @@ UserPromptDialog {
 
         Column {
             id: contentColumn
+
             width: parent.width
             spacing: Theme.paddingMedium
 
@@ -81,8 +83,8 @@ UserPromptDialog {
 
             TextField {
                 id: urlField
-                text: url
 
+                text: url
                 onActiveFocusChanged: if (!activeFocus) errorHighlight = !acceptableInput
                 onAcceptableInputChanged: if (acceptableInput) errorHighlight = false
 
@@ -96,7 +98,8 @@ UserPromptDialog {
                         var scheme = root.url.match(/^(https?):\/\/.+/)
 
                         //% "URL scheme (%1) missing"
-                        return qsTrId("sailfish_browser-la-missing_url_scheme").arg(scheme && scheme.length > 1 ? scheme[1] : "https")
+                        return qsTrId("sailfish_browser-la-missing_url_scheme").arg(scheme && scheme.length > 1
+                                                                                    ? scheme[1] : "https")
                     } else {
                         //% "URL is required"
                         return qsTrId("sailfish_browser-la-url_editor_error")

--- a/apps/browser/qml/pages/components/BookmarkItem.qml
+++ b/apps/browser/qml/pages/components/BookmarkItem.qml
@@ -52,6 +52,7 @@ ListItem {
 
     Column {
         id: column
+
         anchors {
             verticalCenter: parent.verticalCenter
             left: favoriteIcon.right

--- a/apps/browser/qml/pages/components/ConfigDialog.qml
+++ b/apps/browser/qml/pages/components/ConfigDialog.qml
@@ -79,7 +79,6 @@ Dialog {
 
         header: Column {
             DialogHeader {
-                id: dialogHeader
                 dialog: configDialog
                 title: "about:config"
                 _glassOnly: true

--- a/apps/browser/qml/pages/components/ConfigWarning.qml
+++ b/apps/browser/qml/pages/components/ConfigWarning.qml
@@ -18,7 +18,8 @@ ConfirmDialog {
     property Item browserPage
 
     //: Warning of changing browser configurations.
-    //% "Changing these advanced settings can cause issues with stability, security and performance of Sailfish Browser. Continue ?"
+    //% "Changing these advanced settings can cause issues with stability, "
+    //% "security and performance of Sailfish Browser. Continue ?"
     text: qsTrId("sailfish_browser-la-config-warning")
     acceptDestination: Component {
         ConfigDialog {

--- a/apps/browser/qml/pages/components/DebugOverlay.qml
+++ b/apps/browser/qml/pages/components/DebugOverlay.qml
@@ -24,6 +24,7 @@ Item {
 
     Rectangle {
         id: dumpOrange
+
         color: "orange"
         anchors.top: scaleIndicator.bottom
         width: dumpText.width + Theme.paddingLarge
@@ -35,6 +36,7 @@ Item {
 
         Text {
             id: dumpText
+
             anchors {
                 left: parent.left
                 leftMargin: Theme.paddingMedium
@@ -63,6 +65,7 @@ Item {
 
     Rectangle {
         id: cWidth
+
         color: "red"
         width: parent.width
         height: 50
@@ -78,6 +81,7 @@ Item {
 
     Rectangle {
         id: scaleIndicator
+
         color: "red"
         width: parent.width
         height: 50
@@ -95,6 +99,7 @@ Item {
 
     Timer {
         id: readTimer
+
         interval: 2000
         onTriggered: console.log("MEMORY DUMPPED")
     }

--- a/apps/browser/qml/pages/components/FavoriteGrid.qml
+++ b/apps/browser/qml/pages/components/FavoriteGrid.qml
@@ -19,13 +19,13 @@ IconGridViewBase {
 
     property real menuHeight: 0
 
-    pageHeight: Math.ceil(browserPage.height + pageStack.panelSize)
-    rows: Math.floor(pageHeight / minimumCellHeight)
-    columns: Math.floor(browserPage.width / minimumCellWidth)
-
     signal load(string url)
     signal newTab(string url)
     signal share(string url, string title)
+
+    pageHeight: Math.ceil(browserPage.height + pageStack.panelSize)
+    rows: Math.floor(pageHeight / minimumCellHeight)
+    columns: Math.floor(browserPage.width / minimumCellWidth)
 
     function fetchAndSaveBookmark() {
         var webPage = webView && webView.contentItem
@@ -60,7 +60,10 @@ IconGridViewBase {
         menu: favoriteContextMenu
         openMenuOnPressAndHold: false
 
-        onMenuOpenChanged: menuOpen && historyContainer.showHistoryList ? favoriteGrid.menuHeight = cellHeight : favoriteGrid.menuHeight = 0
+        onMenuOpenChanged: {
+            favoriteGrid.menuHeight = (menuOpen && historyContainer.showHistoryList)
+                                      ? cellHeight : 0
+        }
 
         onAddToLauncher: {
             // url, title, favicon
@@ -127,6 +130,7 @@ IconGridViewBase {
 
         DataFetcher {
             id: fetcher
+
             property url url
             property string title
             property var webPage

--- a/apps/browser/qml/pages/components/FavoriteItem.qml
+++ b/apps/browser/qml/pages/components/FavoriteItem.qml
@@ -33,6 +33,7 @@ GridItem {
 
     FavoriteIcon {
         id: favoriteIcon
+
         icon: favicon
         visible: hasTouchIcon
         anchors {
@@ -43,6 +44,7 @@ GridItem {
 
     Image {
         id: mask
+
         source: "icon_browser_favorites_mask00.png"
         anchors.fill: favoriteIcon
         visible: false
@@ -50,6 +52,7 @@ GridItem {
 
     ShaderEffect {
         id: shaderItem
+
         property variant source: favoriteIcon
         property variant maskSource: mask
 

--- a/apps/browser/qml/pages/components/HistoryItem.qml
+++ b/apps/browser/qml/pages/components/HistoryItem.qml
@@ -76,6 +76,7 @@ ListItem {
 
     Row {
         id: row
+
         x: Theme.horizontalPageMargin
         width: parent.width  - Theme.horizontalPageMargin * 2
         anchors.verticalCenter: parent.verticalCenter
@@ -83,6 +84,7 @@ ListItem {
 
         FavoriteIcon {
             id: websiteIcon
+
             icon: model.favicon
             sourceSize.width: Theme.iconSizeMedium
             sourceSize.height: Theme.iconSizeMedium
@@ -92,6 +94,7 @@ ListItem {
 
         Column {
             id: column
+
             width: parent.width - websiteIcon.width - (deleteButton.visible ? deleteButton.width : 0)
             Label {
                 text: Theme.highlightText(model.title, search, Theme.highlightColor)
@@ -114,6 +117,7 @@ ListItem {
 
         IconButton {
             id: deleteButton
+
             visible: showDeleteButton
             icon.source: "image://theme/icon-m-clear"
             onClicked: remove(model.url)

--- a/apps/browser/qml/pages/components/HistoryItem.qml
+++ b/apps/browser/qml/pages/components/HistoryItem.qml
@@ -15,6 +15,7 @@ import Sailfish.Browser 1.0
 ListItem {
     id: root
 
+    property alias horizontalMargin: row.x
     property string search
     property bool showDeleteButton
 
@@ -78,7 +79,7 @@ ListItem {
         id: row
 
         x: Theme.horizontalPageMargin
-        width: parent.width  - Theme.horizontalPageMargin * 2
+        width: parent.width - 2*x
         anchors.verticalCenter: parent.verticalCenter
         spacing: Theme.paddingMedium
 

--- a/apps/browser/qml/pages/components/HistoryItem.qml
+++ b/apps/browser/qml/pages/components/HistoryItem.qml
@@ -61,7 +61,7 @@ ListItem {
                 //: Delete history entry
                 //% "Delete"
                 text: qsTrId("sailfish_browser-me-delete")
-                onClicked: historyDelegate.remove(model.url)
+                onClicked: root.remove(model.url)
             }
         }
     }

--- a/apps/browser/qml/pages/components/HistoryList.qml
+++ b/apps/browser/qml/pages/components/HistoryList.qml
@@ -21,6 +21,7 @@ SilicaListView {
     property string search
     property bool showDeleteButton
     property bool menuClosed
+    property real horizontalMargin: Theme.horizontalPageMargin
 
     signal load(string url, string title, bool newTab)
     signal saveBookmark(string url, string title, string favicon)
@@ -38,6 +39,7 @@ SilicaListView {
     delegate: HistoryItem {
         id: historyDelegate
 
+        horizontalMargin: view.horizontalMargin
         search: view.search
         showDeleteButton: view.showDeleteButton
         onMenuOpenChanged: view.menuClosed = !menuOpen

--- a/apps/browser/qml/pages/components/HistoryList.qml
+++ b/apps/browser/qml/pages/components/HistoryList.qml
@@ -37,8 +37,6 @@ SilicaListView {
     }
 
     delegate: HistoryItem {
-        id: historyDelegate
-
         horizontalMargin: view.horizontalMargin
         search: view.search
         showDeleteButton: view.showDeleteButton

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -599,7 +599,7 @@ Shared.Background {
                     height: historyContainer.showHistoryList ? (count > 0
                                                                 ? cellHeight + headerItem.height + menuHeight
                                                                 : headerItem.height)
-                                                             : historyList.height
+                                                             : (historyList.height - historyList.footerItem.height)
                     opacity: visible && toolBar.opacity < 0.9 ? 1.0 : 0.0
                     enabled: overlayAnimator.atTop
                     visible: historyContainer.showFavorites

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -37,10 +37,19 @@ Shared.Background {
     property var favoriteGrid: historyList.headerItem
     property string enteredUrl
 
-    property real _overlayHeight: browserPage.isPortrait ? toolBar.rowHeight : 0
+    property real _overlayGap: browserPage.isPortrait ? toolBar.rowHeight : 0
     property bool _showFindInPage
     property bool _showUrlEntry
     readonly property bool _topGap: _showUrlEntry || _showFindInPage
+    property int _biggestCorner: Math.max(Screen.topLeftCorner.radius,
+                                          Screen.topRightCorner.radius,
+                                          Screen.bottomLeftCorner.radius,
+                                          Screen.bottomRightCorner.radius)
+    property int horizontalMargin: Math.max(Theme.paddingLarge,
+                                            _biggestCorner * 0.7,
+                                            browserPage.isLandscape
+                                            ? (Screen.topCutout.height + Theme.paddingSmall)
+                                            : 0)
 
     function loadPage(url, newTab) {
         if (url == "about:config") {
@@ -72,7 +81,7 @@ Shared.Background {
     function enterNewTabUrl(action) {
         searchField.enteringNewTabUrl = true
         _showUrlEntry = true
-        _overlayHeight = Qt.binding(function () { return overlayAnimator._fullHeight })
+        _overlayGap = Qt.binding(function () { return overlayAnimator.fullscreenGap })
         searchField.resetUrl("")
         overlayAnimator.showOverlay(action === PageStackAction.Immediate)
     }
@@ -80,7 +89,7 @@ Shared.Background {
     function startPage(action) {
         searchField.enteringNewTabUrl = true
         _showUrlEntry = true
-        _overlayHeight = Qt.binding(function () { return overlayAnimator._fullHeight })
+        _overlayGap = Qt.binding(function () { return overlayAnimator.fullscreenGap })
         searchField.resetUrl("")
         overlayAnimator.showStartPage(action !== PageStackAction.Animated)
     }
@@ -119,12 +128,10 @@ Shared.Background {
         overlay: overlay
         portrait: browserPage.isPortrait
         webView: overlay.webView
-
-        readonly property real _fullHeight: isPortrait ? overlay.toolBar.rowHeight : 0
-        readonly property real _infoHeight: Math.max(webView.fullscreenHeight
-                                                     - overlay.toolBar.certOverlayPreferedHeight
-                                                     - overlay.toolBar.rowHeight,
-                                                     0)
+        fullscreenGap: isPortrait ? (overlay.toolBar.rowHeight + Screen.topCutout.height) : 0
+        infoHeight: Math.max(0,
+                             webView.fullscreenHeight
+                             - overlay.toolBar.certOverlayPreferedHeight - overlay.toolBar.rowHeight)
 
         onAtBottomChanged: {
             if (atBottom) {
@@ -185,7 +192,7 @@ Shared.Background {
         property int dragThreshold: state === "fullscreenOverlay"
                                     ? toolBar.rowHeight * 1.5
                                     : state === "certOverlay"
-                                      ? (overlayAnimator._infoHeight + toolBar.rowHeight * 0.5)
+                                      ? (overlayAnimator.infoHeight + toolBar.rowHeight * 0.5)
                                       : (webView.fullscreenHeight - toolBar.rowHeight * 2)
 
         width: parent.width
@@ -196,7 +203,7 @@ Shared.Background {
         drag.filterChildren: true
         drag.axis: Drag.YAxis
         // Favorite grid first row offset is negative. So, increase minimumY drag by that.
-        drag.minimumY: _overlayHeight
+        drag.minimumY: _overlayGap
         drag.maximumY: webView.fullscreenHeight - toolBar.rowHeight
 
         drag.onActiveChanged: {
@@ -240,9 +247,9 @@ Shared.Background {
                                                     && searchField.edited
                                                     && searchField.text !== webView.url
                                                     && searchField.text
-            readonly property bool showHistoryButton: !toolBar.findInPageActive && (!searchField.edited
-                                                                                    && searchField.text === webView.url
-                                                                                    || !searchField.text)
+            readonly property bool showHistoryButton: !toolBar.findInPageActive
+                                                      && (!searchField.edited && searchField.text === webView.url
+                                                          || !searchField.text)
 
             width: parent.width
             height: toolBar.rowHeight + historyList.height
@@ -345,8 +352,8 @@ Shared.Background {
                 // On top of HistoryList and FavoriteGrid
                 z: 1
                 height: toolBar.rowHeight
-                textLeftMargin: Theme.paddingLarge
-                textRightMargin: Theme.paddingLarge
+                textLeftMargin: overlay.horizontalMargin
+                textRightMargin: overlay.horizontalMargin
                 focusOutBehavior: FocusBehavior.ClearPageFocus
                 font {
                     pixelSize: Theme.fontSizeLarge
@@ -443,9 +450,8 @@ Shared.Background {
 
                 height: historyContainer.showHistoryButton ? toolBar.rowHeight : 0
                 iconWidth: toolBar.iconWidth
-                horizontalOffset: toolBar.horizontalOffset
-                // Follow grid / list position.
-                y: -((historyContainer.showHistoryButton ? -searchField.y : historyList.contentY) - height)
+                leftMargin: overlay.horizontalMargin
+                anchors.top: searchField.bottom
                 // On top of HistoryList and FavoriteGrid
                 z: 1
 
@@ -517,12 +523,12 @@ Shared.Background {
                                               - overlay.toolBar.secondaryToolsHeight, 0)
 
                 certOverlayAnimPos: Math.min(Math.max((webView.fullscreenHeight - overlay.y - overlay.toolBar.rowHeight)
-                                                      / (webView.fullscreenHeight - overlayAnimator._infoHeight
+                                                      / (webView.fullscreenHeight - overlayAnimator.infoHeight
                                                          - overlay.toolBar.rowHeight), 0.0), 1.0)
 
                 onShowOverlay: {
                     _showUrlEntry = true
-                    _overlayHeight = Qt.binding(function() { return overlayAnimator._fullHeight })
+                    _overlayGap = Qt.binding(function() { return overlayAnimator.fullscreenGap })
                     searchField.resetUrl(webView.url)
                     overlayAnimator.showOverlay()
                 }
@@ -535,7 +541,7 @@ Shared.Background {
                 onShowSecondaryTools: overlayAnimator.showSecondaryTools()
                 onShowInfoOverlay: {
                     toolBar.certOverlayActive = true
-                    _overlayHeight = Qt.binding(function() { return overlayAnimator._infoHeight })
+                    _overlayGap = Qt.binding(function() { return overlayAnimator.infoHeight })
                     overlayAnimator.showInfoOverlay(false)
                 }
                 onShowChrome: overlayAnimator.showChrome()
@@ -545,7 +551,7 @@ Shared.Background {
                 onFindInPage: {
                     _showFindInPage = true
                     searchField.resetUrl("")
-                    _overlayHeight = Qt.binding(function () { return overlayAnimator._fullHeight })
+                    _overlayGap = Qt.binding(function () { return overlayAnimator.fullscreenGap })
                     overlayAnimator.showOverlay()
                 }
                 onShareActivePage: webShareAction.shareLink(webView.url, webView.title)
@@ -583,12 +589,13 @@ Shared.Background {
                                         ? 0 : virtualKeyboardObserver.panelSize
 
                 width: parent.width
-                height: webView.tabModel.count !== 0 || webView.privateMode ? browserPage.height - _overlayHeight - panelSize
-                                                                            : browserPage.height - panelSize
+                height: browserPage.height - _overlayGap - panelSize
+                horizontalMargin: overlay.horizontalMargin
 
                 header: Browser.FavoriteGrid {
                     id: favoriteGrid
 
+                    // horizontalMargin omitted, favoriteGrid has it internally good enough
                     height: historyContainer.showHistoryList ? (count > 0
                                                                 ? cellHeight + headerItem.height + menuHeight
                                                                 : headerItem.height)

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -662,6 +662,7 @@ Shared.Background {
             id: tabPage
 
             onStatusChanged: browserPage.tabPageActive = (status == PageStatus.Active)
+            cutoutMode: CutoutMode.FullScreen
 
             Browser.TabView {
                 id: tabViewItem
@@ -672,6 +673,8 @@ Shared.Background {
 
                 scaledPortraitHeight: toolBar.scaledPortraitHeight
                 scaledLandscapeHeight: toolBar.scaledLandscapeHeight
+                horizontalMargin: Math.max(Theme.horizontalPageMargin,
+                                           tabPage.isLandscape ? (Screen.topCutout.height + Theme.paddingSmall) : 0)
 
                 onHide: pageStack.pop()
 

--- a/apps/browser/qml/pages/components/OverlayListItem.qml
+++ b/apps/browser/qml/pages/components/OverlayListItem.qml
@@ -60,6 +60,7 @@ BackgroundItem {
     }
     Switch {
         id: toggle
+
         anchors {
             right: parent.right
             verticalCenter: parent.verticalCenter

--- a/apps/browser/qml/pages/components/OverlayListItem.qml
+++ b/apps/browser/qml/pages/components/OverlayListItem.qml
@@ -20,6 +20,7 @@ BackgroundItem {
     property bool checkable
     property int horizontalOffset
     property int iconWidth
+    property alias leftMargin: iconContainer.x
 
     width: parent.width
 

--- a/apps/browser/qml/pages/components/PopUpMenuFooter.qml
+++ b/apps/browser/qml/pages/components/PopUpMenuFooter.qml
@@ -67,7 +67,6 @@ Rectangle {
         }
 
         Shared.IconButton {
-            id: reloadButton
             width: Theme.itemSizeLarge
             icon.source: webView.loading ? "image://theme/icon-m-reset" : "image://theme/icon-m-refresh"
             icon.opacity: enabled ? 1.0 : Theme.opacityLow

--- a/apps/browser/qml/pages/components/PrivacySettingsConfirmDialog.qml
+++ b/apps/browser/qml/pages/components/PrivacySettingsConfirmDialog.qml
@@ -13,7 +13,6 @@ import Sailfish.Silica 1.0
 import Sailfish.Browser 1.0
 
 Dialog {
-
     property alias historyEnabled: historyItem.visible
     property alias cookieAndSiteDataEnabled: cookieAndSiteDataItem.visible
     property alias passwordsEnabled: passwordsItem.visible
@@ -36,7 +35,6 @@ Dialog {
             id: column
 
             width: parent.width
-
             spacing: Theme.paddingMedium
 
             DialogHeader {

--- a/apps/browser/qml/pages/components/SearchBar.qml
+++ b/apps/browser/qml/pages/components/SearchBar.qml
@@ -18,6 +18,7 @@ import QtQuick 2.0
 
 Item {
     id: searchBar
+
     width: parent.width
     height: isPortrait ? Settings.toolbarLarge : Settings.toolbarSmall
 
@@ -29,7 +30,6 @@ Item {
         spacing: Theme.paddingMedium
 
         Shared.IconButton {
-            id: backIcon
             width: Theme.iconSizeMedium + 2 * Theme.paddingMedium
             height: searchBar.height
             icon.source: "image://theme/icon-m-left"
@@ -41,6 +41,7 @@ Item {
 
         MouseArea {
             id: touchArea
+
             height: parent.height
             width: textLabel.width
             property bool down: pressed && containsMouse
@@ -56,7 +57,6 @@ Item {
         }
 
         Shared.IconButton {
-            id: forwardIcon
             width: Theme.iconSizeMedium + 2 * Theme.paddingMedium
             height: searchBar.height
             icon.source: "image://theme/icon-m-right"

--- a/apps/browser/qml/pages/components/SearchEngineMenuItem.qml
+++ b/apps/browser/qml/pages/components/SearchEngineMenuItem.qml
@@ -33,6 +33,7 @@ SilicaItem {
 
         MenuItem {
             id: title
+
             height: implicitHeight
             down: root.down
             highlighted: root.highlighted
@@ -40,6 +41,7 @@ SilicaItem {
 
         MenuItem {
             id: description
+
             height: text ? implicitHeight : 0
             font.pixelSize: Theme.fontSizeExtraSmall
             down: root.down

--- a/apps/browser/qml/pages/components/TabButton.qml
+++ b/apps/browser/qml/pages/components/TabButton.qml
@@ -16,12 +16,14 @@ import "../../shared" as Shared
 Shared.IconButton {
     property alias label: label
     property int horizontalOffset
+
     // Don't pass touch events through if opaque
     enabled: opacity === 1.0
     icon.anchors.horizontalCenterOffset: horizontalOffset
 
     Label {
         id: label
+
         anchors {
             centerIn: parent
             horizontalCenterOffset: horizontalOffset

--- a/apps/browser/qml/pages/components/TabGridView.qml
+++ b/apps/browser/qml/pages/components/TabGridView.qml
@@ -27,7 +27,8 @@ SilicaGridView {
                                         ? portrait ? 2 : 3
                                         : parent.width < 2 * parent.height
                                           ? parent.width <= height ? 1 : 2 : 3
-    readonly property real thumbnailWidth: (parent.width - Theme.horizontalPageMargin * 2 - (Theme.paddingLarge * (columns - 1))) / columns
+    readonly property real thumbnailWidth: (parent.width - Theme.horizontalPageMargin * 2
+                                            - (Theme.paddingLarge * (columns - 1))) / columns
 
     signal hide
     signal enterNewTabUrl
@@ -93,7 +94,6 @@ SilicaGridView {
             onClicked: hide()
         }
     ]
-
 
     Item {
         height: parent.height

--- a/apps/browser/qml/pages/components/TabGridView.qml
+++ b/apps/browser/qml/pages/components/TabGridView.qml
@@ -19,6 +19,7 @@ SilicaGridView {
     property bool closingAllTabs
 
     property var remorsePopup
+    property int horizontalMargin: Theme.horizontalPageMargin
     readonly property bool largeScreen: Screen.sizeCategory > Screen.Medium
     readonly property real thumbnailHeight: largeScreen
                                             ? Screen.width / 3
@@ -27,7 +28,7 @@ SilicaGridView {
                                         ? portrait ? 2 : 3
                                         : parent.width < 2 * parent.height
                                           ? parent.width <= height ? 1 : 2 : 3
-    readonly property real thumbnailWidth: (parent.width - Theme.horizontalPageMargin * 2
+    readonly property real thumbnailWidth: (parent.width - horizontalMargin * 2
                                             - (Theme.paddingLarge * (columns - 1))) / columns
 
     signal hide
@@ -60,9 +61,9 @@ SilicaGridView {
     onCountChanged: if (count > 0) closingAllTabs = false
     onClosingAllTabsChanged: if (closingAllTabs) closeAllPending()
 
-    width: parent.width - Theme.horizontalPageMargin
+    width: parent.width - x
     height: parent.height
-    x: Theme.horizontalPageMargin
+    x: tabGridView.horizontalMargin
     currentIndex: model.activeTabIndex
     cellWidth: thumbnailWidth + Theme.paddingLarge
     cellHeight: thumbnailHeight + Theme.paddingLarge

--- a/apps/browser/qml/pages/components/TabItem.qml
+++ b/apps/browser/qml/pages/components/TabItem.qml
@@ -75,11 +75,13 @@ BackgroundItem {
 
             Item {
                 id: header
+
                 width: root.implicitWidth
                 height: iconHeader.height + Theme.paddingMedium * 2
 
                 Image {
                     id: iconHeader
+
                     anchors {
                         left: parent.left
                         leftMargin: Theme.paddingMedium
@@ -155,6 +157,7 @@ BackgroundItem {
         },
         Timer {
             id: removeTimer
+
             interval: 16
             onTriggered: view.closeTab(index)
         }

--- a/apps/browser/qml/pages/components/TabView.qml
+++ b/apps/browser/qml/pages/components/TabView.qml
@@ -23,6 +23,7 @@ SilicaControl {
     property var tabModel
     property alias scaledPortraitHeight: tabsToolBar.scaledPortraitHeight
     property alias scaledLandscapeHeight: tabsToolBar.scaledLandscapeHeight
+    property int horizontalMargin: Theme.horizontalPageMargin
 
     signal hide
     signal enterNewTabUrl
@@ -112,6 +113,7 @@ SilicaControl {
             TabGridView {
                 id: _tabView
 
+                horizontalMargin: tabView.horizontalMargin
                 portrait: tabView.portrait
                 model: TabFilterModel {
                     sourceModel: tabItem.privateMode ? webView.privateTabModel : webView.persistentTabModel

--- a/apps/browser/qml/pages/components/TabView.qml
+++ b/apps/browser/qml/pages/components/TabView.qml
@@ -260,6 +260,7 @@ SilicaControl {
 
     ConfigurationValue {
         id: showCloseAllAction
+
         key: "/apps/sailfish-browser/settings/show_close_all"
         defaultValue: true
     }

--- a/apps/captiveportal/qml/pages/CaptivePortalPage.qml
+++ b/apps/captiveportal/qml/pages/CaptivePortalPage.qml
@@ -29,6 +29,9 @@ Page {
     property alias title: webView.title
     property alias webView: webView
 
+    // for time being make this fullscreen. TODO: avoid drawing over cutout and corner areas.
+    cutoutMode: CutoutMode.FullScreen
+
     function load(url, title) {
         webView.load(url, title)
     }

--- a/apps/captiveportal/qml/pages/components/CaptivePortalOverlay.qml
+++ b/apps/captiveportal/qml/pages/components/CaptivePortalOverlay.qml
@@ -47,17 +47,17 @@ Shared.Background {
     }
 
     y: webView.fullscreenHeight - toolBar.height
-
-    Private.VirtualKeyboardObserver {
-        id: virtualKeyboardObserver
-        active: overlay.active && !overlayAnimator.atBottom
-        orientation: containerPage.orientation
-    }
-
     width: parent.width
     height: toolBar.height + virtualKeyboardObserver.panelSize
     // `visible` is controlled by Browser.OverlayAnimator
     enabled: visible
+
+    Private.VirtualKeyboardObserver {
+        id: virtualKeyboardObserver
+
+        active: overlay.active && !overlayAnimator.atBottom
+        orientation: containerPage.orientation
+    }
 
     // This is an invisible object responsible to hide/show Overlay in an animated way
     Shared.OverlayAnimator {
@@ -74,6 +74,7 @@ Shared.Background {
 
     Shared.ProgressBar {
         id: progressBar
+
         width: parent.width
         height: toolBar.height
         opacity: webView.loading ? 1.0 : 0.0

--- a/apps/captiveportal/qml/pages/components/CaptivePortalOverlay.qml
+++ b/apps/captiveportal/qml/pages/components/CaptivePortalOverlay.qml
@@ -67,9 +67,8 @@ Shared.Background {
         portrait: containerPage.isPortrait
         webView: overlay.webView
 
-        readonly property real _fullHeight: overlay.toolBar.height
-        // Referred from OverlayAnimator
-        readonly property real _infoHeight: 0
+        fullscreenGap: overlay.toolBar.height
+        infoHeight: 0
     }
 
     Shared.ProgressBar {

--- a/apps/captiveportal/qml/pages/components/CaptivePortalToolBar.qml
+++ b/apps/captiveportal/qml/pages/components/CaptivePortalToolBar.qml
@@ -21,10 +21,14 @@ Column {
     readonly property int maxRowCount: 1
 
     readonly property int horizontalOffset: largeScreen ? Theme.paddingLarge : Theme.paddingSmall
-    readonly property int buttonPadding: largeScreen || orientation === Orientation.Landscape || orientation === Orientation.LandscapeInverted
+    readonly property int buttonPadding: largeScreen
+                                         || orientation === Orientation.Landscape
+                                         || orientation === Orientation.LandscapeInverted
                                          ? Theme.paddingMedium : Theme.paddingSmall
-    readonly property int iconWidth: largeScreen ? (Theme.iconSizeLarge + 3 * buttonPadding) : (Theme.iconSizeMedium + 2 * buttonPadding)
-    readonly property int smallIconWidth: largeScreen ? (Theme.iconSizeMedium + 3 * buttonPadding) : (Theme.iconSizeSmall + 2 * buttonPadding)
+    readonly property int iconWidth: largeScreen ? (Theme.iconSizeLarge + 3 * buttonPadding)
+                                                 : (Theme.iconSizeMedium + 2 * buttonPadding)
+    readonly property int smallIconWidth: largeScreen ? (Theme.iconSizeMedium + 3 * buttonPadding)
+                                                      : (Theme.iconSizeSmall + 2 * buttonPadding)
     // Height of toolbar should be such that viewport height is
     // even number both chrome and fullscreen modes. For instance
     // height of 110px for toolbar would result 1px rounding
@@ -64,11 +68,13 @@ Column {
 
     Row {
         id: toolsRow
+
         width: parent.width
         height: browserPage.isPortrait ? scaledPortraitHeight : scaledLandscapeHeight
 
         Shared.ExpandingButton {
             id: backIcon
+
             expandedWidth: toolBarRow.iconWidth
             icon.source: "image://theme/icon-m-back"
             active: webView.canGoBack
@@ -96,6 +102,7 @@ Column {
 
         Shared.ExpandingButton {
             id: reloadButton
+
             expandedWidth: toolBarRow.iconWidth
             icon.source: webView.loading ? "image://theme/icon-m-reset" : "image://theme/icon-m-refresh"
             active: webView.contentItem

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -47,7 +47,7 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     Q_PROPERTY(bool enabled MEMBER m_enabled NOTIFY enabledChanged FINAL)
     Q_PROPERTY(bool foreground READ foreground WRITE setForeground NOTIFY foregroundChanged FINAL)
     Q_PROPERTY(int maxLiveTabCount READ maxLiveTabCount WRITE setMaxLiveTabCount NOTIFY maxLiveTabCountChanged FINAL)
-    // This property should cover all possible popus
+    // This property should cover all possible popups
     Q_PROPERTY(bool touchBlocked MEMBER m_touchBlocked NOTIFY touchBlockedChanged FINAL)
     Q_PROPERTY(bool selectionActive MEMBER m_selectionActive NOTIFY selectionActiveChanged FINAL)
     Q_PROPERTY(bool portrait READ portrait WRITE setPortrait NOTIFY portraitChanged FINAL)

--- a/apps/shared/BrowserWindow.qml
+++ b/apps/shared/BrowserWindow.qml
@@ -40,8 +40,6 @@ ApplicationWindow {
     _mainWindow: webView
     _backgroundVisible: false
     _opaque: false
-    // for time being make this fullscreen. TODO: avoid drawing over cutout and corner areas.
-    defaultPageCutoutMode: CutoutMode.FullScreen
 
     cover: null
 

--- a/apps/shared/OverlayAnimator.qml
+++ b/apps/shared/OverlayAnimator.qml
@@ -70,7 +70,10 @@ Item {
     }
 
     function isOpenedState() {
-        return state !== _fullscreenOverlay && state !== _fullscreenWebPage && state !== _startPage && state !== _noOverlay
+        return state !== _fullscreenOverlay
+                && state !== _fullscreenWebPage
+                && state !== _startPage
+                && state !== _noOverlay
     }
 
     // Wrapper from updating the state. Handy for debugging.
@@ -259,12 +262,15 @@ Item {
 
     transitions: [
         Transition {
-            id: overlayTransition
-
             to: "fullscreenWebPage,chromeVisible,loadProgressOverlay,fullscreenOverlay,noOverlay,secondaryTools,certOverlay,startPage"
 
             SequentialAnimation {
-                NumberAnimation { target: webView; property: "height"; duration: transitionDuration; easing.type: Easing.InOutQuad }
+                NumberAnimation {
+                    target: webView
+                    property: "height"
+                    duration: transitionDuration
+                    easing.type: Easing.InOutQuad
+                }
                 ScriptAction {
                     script: {
                         if (animator.state === _chromeVisible
@@ -294,13 +300,28 @@ Item {
                     }
                 }
             }
-            NumberAnimation { target: overlay; property: "y"; duration: transitionDuration; easing.type: Easing.InOutQuad }
-            NumberAnimation { target: overlay.toolBar; property: "secondaryToolsHeight"; duration: transitionDuration; easing.type: Easing.InOutQuad }        
+            NumberAnimation {
+                target: overlay
+                property: "y"
+                duration: transitionDuration
+                easing.type: Easing.InOutQuad
+            }
+            NumberAnimation {
+                target: overlay.toolBar
+                property: "secondaryToolsHeight"
+                duration: transitionDuration
+                easing.type: Easing.InOutQuad
+            }
         }
         ,
         Transition {
             to: _draggingOverlay
-            NumberAnimation { target: overlay.toolBar; property: "secondaryToolsHeight"; duration: transitionDuration; easing.type: Easing.InOutQuad }
+            NumberAnimation {
+                target: overlay.toolBar
+                property: "secondaryToolsHeight"
+                duration: transitionDuration
+                easing.type: Easing.InOutQuad
+            }
         }
     ]
 }

--- a/apps/shared/OverlayAnimator.qml
+++ b/apps/shared/OverlayAnimator.qml
@@ -40,6 +40,8 @@ Item {
     readonly property string _noOverlay: "noOverlay"
     property var _previousYs
     property int proportionalDuration: 400
+    property real fullscreenGap
+    property real infoHeight
 
     function showSecondaryTools() {
         updateState(_secondaryTools)
@@ -89,7 +91,7 @@ Item {
         // Update the animation time to suit the type of overlay
         if ((newState !== _noOverlay) && (newState !== _chromeVisible)) {
             if (newState === _certOverlay) {
-                proportionalDuration = 600 * (1.0 - (_infoHeight / webView.fullscreenHeight))
+                proportionalDuration = 600 * (1.0 - (infoHeight / webView.fullscreenHeight))
             } else {
                 proportionalDuration = 400
             }
@@ -217,7 +219,7 @@ Item {
             changes: [
                 PropertyChanges {
                     target: overlay
-                    y: _fullHeight
+                    y: fullscreenGap
                 }
             ]
         },
@@ -227,8 +229,7 @@ Item {
             changes: [
                 PropertyChanges {
                     target: overlay
-                    y: webView.privateMode ? _fullHeight : 0
-                    height: webView.fullscreenHeight
+                    y: fullscreenGap
                 },
                 PropertyChanges {
                     target: overlay.toolBar
@@ -254,7 +255,7 @@ Item {
             changes: [
                 PropertyChanges {
                     target: overlay
-                    y: _infoHeight
+                    y: infoHeight
                 }
             ]
         }

--- a/apps/shared/ProgressBar.qml
+++ b/apps/shared/ProgressBar.qml
@@ -20,6 +20,7 @@ Item {
 
     Rectangle {
         id: progressRect
+
         height: parent.height
         width: progressBar.progress * parent.width
         gradient: Gradient {

--- a/apps/shared/ResourceController.qml
+++ b/apps/shared/ResourceController.qml
@@ -114,6 +114,7 @@ Item {
 
     ConnectionHelper {
         id: connectionHelper
+
         readonly property bool connected: status >= ConnectionHelper.Connected
 
         function notifyOfflineStatus() {
@@ -162,6 +163,7 @@ Item {
 
     Timer {
         id: delayedSuspend
+
         property bool suspendIntention
 
         // 1000ms was not enough to always allow buffering start of next song via 3G


### PR DESCRIPTION
Bunch of UI glitches fixed in separate commits:
- On overlay avoid flicking favorites on top of the history button
- Avoid notch area on generic settings type UI. Only the webview and tab view to use really fullscreen mode.
- Avoid notch area on overlay. Small UI change: avoid special case (add extra display cutout avoidance padding on text field) on special case (no tabs && no private mode && portrait orientation). Instead now this case opens with the small gap on top. Simplifies the logic and makes the logic saner.
- More style adjustments and removal of some unnecessary ids, etc.

More details in commit messages.