### PR TITLE
Webview refactoring

### DIFF
--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -41,9 +41,6 @@ Page {
     property alias webView: webView
     property alias inputRegion: inputRegion
 
-    // for time being make this fullscreen. TODO: avoid drawing over cutout and corner areas.
-    cutoutMode: CutoutMode.FullScreen
-
     function load(url, title) {
         webView.load(url, title)
     }
@@ -95,8 +92,9 @@ Page {
         return mask
     }
 
+    // for time being make this fullscreen. TODO: avoid drawing over cutout and corner areas.
+    cutoutMode: CutoutMode.FullScreen
     background: null
-
     onStatusChanged: {
         if (overlay.enteringNewTabUrl || webView.tabModel.count === 0) {
             return

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -98,7 +98,7 @@ Shared.Background {
         toolBar.resetFind()
         if (webView.contentItem && webView.contentItem.fullscreen) {
             // Web content is in fullscreen mode thus we don't show chrome
-            overlay.animator.updateState("fullscreenWebPage")
+            overlay.animator.showFullscreen()
         } else if (canShowChrome) {
             overlay.animator.showChrome(immediate)
         } else {

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -108,6 +108,10 @@ Shared.Background {
     }
 
     y: webView.fullscreenHeight - toolBar.rowHeight
+    width: parent.width
+    height: historyContainer.height + virtualKeyboardObserver.panelSize
+    // `visible` is controlled by Browser.OverlayAnimator
+    enabled: visible
 
     Private.VirtualKeyboardObserver {
         id: virtualKeyboardObserver
@@ -115,11 +119,6 @@ Shared.Background {
         active: overlay.active && !overlayAnimator.atBottom
         orientation: browserPage.orientation
     }
-
-    width: parent.width
-    height: historyContainer.height + virtualKeyboardObserver.panelSize
-    // `visible` is controlled by Browser.OverlayAnimator
-    enabled: visible
 
     // This is an invisible object responsible to hide/show Overlay in an animated way
     Shared.OverlayAnimator {

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -65,7 +65,6 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     , m_fullScreenHeight(0.0)
     , m_imOpened(false)
     , m_toolbarHeight(0.0)
-    , m_loading(false)
     , m_loadProgress(0)
     , m_completed(false)
     , m_initialized(false)
@@ -479,7 +478,7 @@ void DeclarativeWebContainer::load(const QString &url, bool force, bool fromExte
         m_initialUrl = tmpUrl;
         m_fromExternal = fromExternal;
     } else if (m_webPage && m_webPage->completed()) {
-        if (m_loading) {
+        if (loading()) {
             m_webPage->stop();
         }
         m_webPage->loadTab(tmpUrl, force, fromExternal);

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -57,14 +57,8 @@ DeclarativeWebContainer::DeclarativeWebContainer(QWindow *parent)
     , m_webPageComponent(0)
     , m_enabled(true)
     , m_foreground(true)
-    , m_allowHiding(true)
     , m_touchBlocked(false)
     , m_selectionActive(false)
-    , m_portrait(true)
-    , m_fullScreenMode(false)
-    , m_fullScreenHeight(0.0)
-    , m_imOpened(false)
-    , m_toolbarHeight(0.0)
     , m_loadProgress(0)
     , m_completed(false)
     , m_initialized(false)
@@ -313,19 +307,6 @@ void DeclarativeWebContainer::setMaxLiveTabCount(int count)
     }
 }
 
-bool DeclarativeWebContainer::portrait() const
-{
-    return m_portrait;
-}
-
-void DeclarativeWebContainer::setPortrait(bool portrait)
-{
-    if (m_portrait != portrait) {
-        m_portrait = portrait;
-        emit portraitChanged();
-    }
-}
-
 QQmlComponent* DeclarativeWebContainer::webPageComponent() const
 {
     return m_webPageComponent;
@@ -378,11 +359,6 @@ void DeclarativeWebContainer::setLoadProgress(int loadProgress)
         m_loadProgress = loadProgress;
         emit loadProgressChanged();
     }
-}
-
-bool DeclarativeWebContainer::imOpened() const
-{
-    return m_imOpened;
 }
 
 bool DeclarativeWebContainer::canGoForward() const

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -50,14 +50,6 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     // This property should cover all possible popups
     Q_PROPERTY(bool touchBlocked MEMBER m_touchBlocked NOTIFY touchBlockedChanged FINAL)
     Q_PROPERTY(bool selectionActive MEMBER m_selectionActive NOTIFY selectionActiveChanged FINAL)
-    Q_PROPERTY(bool portrait READ portrait WRITE setPortrait NOTIFY portraitChanged FINAL)
-    Q_PROPERTY(bool fullscreenMode MEMBER m_fullScreenMode NOTIFY fullscreenModeChanged FINAL)
-    Q_PROPERTY(qreal fullscreenHeight MEMBER m_fullScreenHeight NOTIFY fullscreenHeightChanged FINAL)
-    Q_PROPERTY(bool imOpened MEMBER m_imOpened NOTIFY imOpenedChanged FINAL)
-    Q_PROPERTY(qreal toolbarHeight MEMBER m_toolbarHeight NOTIFY toolbarHeightChanged FINAL)
-    Q_PROPERTY(bool allowHiding MEMBER m_allowHiding NOTIFY allowHidingChanged FINAL)
-
-    Q_PROPERTY(QString favicon MEMBER m_favicon NOTIFY faviconChanged)
 
     Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged FINAL)
     Q_PROPERTY(int loadProgress READ loadProgress NOTIFY loadProgressChanged FINAL)
@@ -105,9 +97,6 @@ public:
     int maxLiveTabCount() const;
     void setMaxLiveTabCount(int count);
 
-    bool portrait() const;
-    void setPortrait(bool portrait);
-
     QQmlComponent* webPageComponent() const;
     void setWebPageComponent(QQmlComponent* qmlComponent);
 
@@ -120,8 +109,6 @@ public:
 
     int loadProgress() const;
     void setLoadProgress(int loadProgress);
-
-    bool imOpened() const;
 
     bool canGoForward() const;
     bool canGoBack() const;
@@ -178,17 +165,10 @@ signals:
     void completedChanged();
     void enabledChanged();
     void foregroundChanged();
-    void allowHidingChanged();
     void maxLiveTabCountChanged();
     void touchBlockedChanged();
     void selectionActiveChanged();
-    void portraitChanged();
-    void fullscreenModeChanged();
-    void fullscreenHeightChanged();
-    void imOpenedChanged();
-    void toolbarHeightChanged();
 
-    void faviconChanged();
     void loadingChanged();
     void loadProgressChanged();
 
@@ -291,16 +271,8 @@ private:
 
     bool m_enabled;
     bool m_foreground;
-    bool m_allowHiding;
     bool m_touchBlocked;
     bool m_selectionActive;
-    bool m_portrait;
-    bool m_fullScreenMode;
-    qreal m_fullScreenHeight;
-    bool m_imOpened;
-    qreal m_toolbarHeight;
-
-    QString m_favicon;
 
     // See DeclarativeWebContainer::load (line 283) as load need to "work" even if engine, model,
     // or qml component is not yet completed (completed property is still false). So cache url/title for later use.

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -311,7 +311,6 @@ private:
     QString m_initialUrl;
     bool m_fromExternal;
 
-    bool m_loading;
     int m_loadProgress;
 
     bool m_completed;

--- a/apps/core/webpagequeue.cpp
+++ b/apps/core/webpagequeue.cpp
@@ -112,7 +112,6 @@ void WebPageQueue::release(int tabId, bool virtualize)
 #endif
 }
 
-
 void WebPageQueue::prepend(int tabId, DeclarativeWebPage *webPage)
 {
     int index = -1;

--- a/apps/core/webpages.cpp
+++ b/apps/core/webpages.cpp
@@ -236,15 +236,17 @@ void WebPages::handleMemNotify(const QString &memoryLevel)
 
     if (m_memoryLevel == MemWarning || m_memoryLevel == MemCritical) {
 
-        if (!m_activePages.virtualizeInactive() && m_activePages.activeWebPage() && !m_activePages.activeWebPage()->completed()) {
+        if (!m_activePages.virtualizeInactive()
+                && m_activePages.activeWebPage()
+                && !m_activePages.activeWebPage()->completed()) {
             connect(m_activePages.activeWebPage(), &DeclarativeWebPage::completedChanged,
                     this, &WebPages::delayVirtualization, Qt::UniqueConnection);
         }
 
         SailfishOS::WebEngine *webEngine = SailfishOS::WebEngine::instance();
         webEngine->notifyObservers(QString("memory-pressure"), QString("low-memory"));
-        if (!m_webContainer->foreground() &&
-                (QDateTime::currentMSecsSinceEpoch() - m_backgroundTimestamp) > gMemoryPressureTimeout) {
+        if (!m_webContainer->foreground()
+                && (QDateTime::currentMSecsSinceEpoch() - m_backgroundTimestamp) > gMemoryPressureTimeout) {
             m_backgroundTimestamp = QDateTime::currentMSecsSinceEpoch();
             webEngine->notifyObservers(QString("memory-pressure"), QString("heap-minimize"));
         }

--- a/apps/qtmozembed/declarativewebpage.cpp
+++ b/apps/qtmozembed/declarativewebpage.cpp
@@ -16,9 +16,10 @@
 
 #include <webenginesettings.h>
 #include <qmozwindow.h>
+#include <qmozsecurity.h>
+
 #include <QGuiApplication>
 #include <QtConcurrent>
-#include <qmozsecurity.h>
 
 #define FULLSCREEN_MESSAGE "embed:fullscreenchanged"
 #define DOM_CONTENT_LOADED_MESSAGE "chrome:contentloaded"
@@ -61,7 +62,6 @@ DeclarativeWebPage::DeclarativeWebPage(QObject *parent)
     , m_fullScreenHeight(0.f)
     , m_toolbarHeight(0.f)
 {
-
     // subscribe to gecko messages
     std::vector<std::string> messages = { FULLSCREEN_MESSAGE,
                                           DOM_CONTENT_LOADED_MESSAGE,
@@ -418,7 +418,8 @@ QDebug operator<<(QDebug dbg, const DeclarativeWebPage *page)
     }
 
     QSize size = page->mozWindow()->size();
-    dbg.nospace() << "DeclarativeWebPage(tabId = " << page->tabId() << " url = " << page->url() << ", title = " << page->title() << ", width = " << size.width()
+    dbg.nospace() << "DeclarativeWebPage(tabId = " << page->tabId() << " url = " << page->url()
+                  << ", title = " << page->title() << ", width = " << size.width()
                   << ", height = " << size.height() << ", completed = " << page->completed()
                   << ", active = " << page->active() << ", enabled = " << page->enabled() << ")";
     return dbg.space();

--- a/apps/qtmozembed/declarativewebpage.cpp
+++ b/apps/qtmozembed/declarativewebpage.cpp
@@ -80,7 +80,6 @@ DeclarativeWebPage::DeclarativeWebPage(QObject *parent)
             this, &DeclarativeWebPage::onRecvAsyncMessage);
     connect(&m_grabWritter, &QFutureWatcher<QString>::finished, this, &DeclarativeWebPage::grabWritten);
     connect(this, &DeclarativeWebPage::urlChanged, this, &DeclarativeWebPage::onUrlChanged);
-    connect(this, &QMozOpenGLWebPage::virtualKeyboardHeightChanged, this, &DeclarativeWebPage::updateViewMargins);
     connect(this, &QMozOpenGLWebPage::domContentLoadedChanged, [this]() {
         if (domContentLoaded()) {
             qCDebug(lcCoreLog) << "WebPage: loaded";
@@ -228,6 +227,20 @@ void DeclarativeWebPage::setResurrectedContentRect(QVariant resurrectedContentRe
 qreal DeclarativeWebPage::toolbarHeight() const
 {
     return m_toolbarHeight;
+}
+
+int DeclarativeWebPage::virtualKeyboardHeight() const
+{
+    return m_virtualKeyboardHeight;
+}
+
+void DeclarativeWebPage::setVirtualKeyboardHeight(int height)
+{
+    if (m_virtualKeyboardHeight != height) {
+        m_virtualKeyboardHeight = height;
+        updateViewMargins();
+        emit virtualKeyboardHeightChanged();
+    }
 }
 
 void DeclarativeWebPage::setToolbarHeight(qreal toolbarHeight)

--- a/apps/qtmozembed/declarativewebpage.cpp
+++ b/apps/qtmozembed/declarativewebpage.cpp
@@ -53,13 +53,11 @@ static bool allBlack(const QImage &image)
 DeclarativeWebPage::DeclarativeWebPage(QObject *parent)
     : QMozOpenGLWebPage(parent)
     , m_container(0)
-    , m_userHasDraggedWhileLoading(false)
     , m_fullscreen(false)
     , m_forcedChrome(false)
     , m_tabHistoryReady(false)
     , m_urlReady(false)
     , m_restoredCurrentLinkId(-1)
-    , m_fullScreenHeight(0.f)
     , m_toolbarHeight(0.f)
 {
     // subscribe to gecko messages

--- a/apps/qtmozembed/declarativewebpage.h
+++ b/apps/qtmozembed/declarativewebpage.h
@@ -73,7 +73,6 @@ signals:
 
     void virtualKeyboardHeightChanged();
     void toolbarHeightChanged();
-    void securityChanged();
     void neterror();
 
     void updateUrl();

--- a/apps/qtmozembed/declarativewebpage.h
+++ b/apps/qtmozembed/declarativewebpage.h
@@ -31,7 +31,7 @@ class DeclarativeWebPage : public QMozOpenGLWebPage
     Q_PROPERTY(bool fullscreen READ fullscreen NOTIFY fullscreenChanged FINAL)
     Q_PROPERTY(bool forcedChrome READ forcedChrome NOTIFY forcedChromeChanged FINAL)
     Q_PROPERTY(QVariant resurrectedContentRect READ resurrectedContentRect WRITE setResurrectedContentRect NOTIFY resurrectedContentRectChanged)
-
+    Q_PROPERTY(int virtualKeyboardHeight READ virtualKeyboardHeight WRITE setVirtualKeyboardHeight NOTIFY virtualKeyboardHeightChanged FINAL)
     Q_PROPERTY(qreal toolbarHeight READ toolbarHeight WRITE setToolbarHeight NOTIFY toolbarHeightChanged FINAL)
 
 public:
@@ -46,6 +46,9 @@ public:
 
     QVariant resurrectedContentRect() const;
     void setResurrectedContentRect(QVariant resurrectedContentRect);
+
+    int virtualKeyboardHeight() const;
+    void setVirtualKeyboardHeight(int height);
 
     qreal toolbarHeight() const;
     void setToolbarHeight(qreal);
@@ -68,6 +71,7 @@ signals:
     void grabResult(const QString &fileName);
     void thumbnailResult(const QString &data);
 
+    void virtualKeyboardHeightChanged();
     void toolbarHeightChanged();
     void securityChanged();
     void neterror();
@@ -102,6 +106,7 @@ private:
     QList<Link> m_restoredTabHistory;
     int m_restoredCurrentLinkId;
 
+    int m_virtualKeyboardHeight = 0;
     qreal m_toolbarHeight;
 
     QMozSecurity m_security;

--- a/apps/qtmozembed/declarativewebpage.h
+++ b/apps/qtmozembed/declarativewebpage.h
@@ -28,13 +28,10 @@ class DeclarativeWebPage : public QMozOpenGLWebPage
     Q_OBJECT
     Q_PROPERTY(DeclarativeWebContainer* container READ container NOTIFY containerChanged FINAL)
     Q_PROPERTY(int tabId READ tabId NOTIFY tabIdChanged FINAL)
-    Q_PROPERTY(bool userHasDraggedWhileLoading MEMBER m_userHasDraggedWhileLoading NOTIFY userHasDraggedWhileLoadingChanged FINAL)
     Q_PROPERTY(bool fullscreen READ fullscreen NOTIFY fullscreenChanged FINAL)
     Q_PROPERTY(bool forcedChrome READ forcedChrome NOTIFY forcedChromeChanged FINAL)
-    Q_PROPERTY(QString favicon MEMBER m_favicon NOTIFY faviconChanged FINAL)
     Q_PROPERTY(QVariant resurrectedContentRect READ resurrectedContentRect WRITE setResurrectedContentRect NOTIFY resurrectedContentRectChanged)
 
-    Q_PROPERTY(qreal fullscreenHeight MEMBER m_fullScreenHeight NOTIFY fullscreenHeightChanged FINAL)
     Q_PROPERTY(qreal toolbarHeight READ toolbarHeight WRITE setToolbarHeight NOTIFY toolbarHeightChanged FINAL)
 
 public:
@@ -65,15 +62,12 @@ signals:
     void contentOrientationChanged(Qt::ScreenOrientation orientation);
     void containerChanged();
     void tabIdChanged();
-    void userHasDraggedWhileLoadingChanged();
     void fullscreenChanged();
     void forcedChromeChanged();
-    void faviconChanged();
     void resurrectedContentRectChanged();
     void grabResult(const QString &fileName);
     void thumbnailResult(const QString &data);
 
-    void fullscreenHeightChanged();
     void toolbarHeightChanged();
     void securityChanged();
     void neterror();
@@ -97,12 +91,10 @@ private:
     QPointer<DeclarativeWebContainer> m_container;
     // Tab data fetched upon web page initialization. It never changes afterwards.
     Tab m_initialTab;
-    bool m_userHasDraggedWhileLoading;
     bool m_fullscreen;
     bool m_forcedChrome;
     bool m_tabHistoryReady;
     bool m_urlReady;
-    QString m_favicon;
     QVariant m_resurrectedContentRect;
     QSharedPointer<QMozGrabResult> m_grabResult;
     QSharedPointer<QMozGrabResult> m_thumbnailResult;
@@ -110,7 +102,6 @@ private:
     QList<Link> m_restoredTabHistory;
     int m_restoredCurrentLinkId;
 
-    qreal m_fullScreenHeight;
     qreal m_toolbarHeight;
 
     QMozSecurity m_security;

--- a/apps/shared/OverlayAnimator.qml
+++ b/apps/shared/OverlayAnimator.qml
@@ -63,6 +63,10 @@ Item {
         updateState(_certOverlay, immediate || false)
     }
 
+    function showFullscreen() {
+        updateState(_fullscreenWebPage)
+    }
+
     function drag() {
         updateState(_draggingOverlay)
     }

--- a/apps/shared/OverlayAnimator.qml
+++ b/apps/shared/OverlayAnimator.qml
@@ -133,10 +133,11 @@ Item {
                 _previousYs = []
 
             if (_previousYs.length > 0) {
-                var lastPos = _previousYs[_previousYs.length-1]
+                var lastPos = _previousYs[_previousYs.length - 1]
                 // Filter out movement a bit, padding medium as a hysteresis
                 var hasMoved = Math.abs(lastPos - overlay.y) > Theme.paddingMedium
-                if (hasMoved) _previousYs.push(overlay.y)
+                if (hasMoved)
+                    _previousYs.push(overlay.y)
             } else {
                 _previousYs.push(overlay.y)
             }
@@ -147,7 +148,7 @@ Item {
             var tmpDirection = ""
             var directionChanged = false
             for (var i = 1; i < _previousYs.length && _previousYs.length > 2; ++i) {
-                var dir = _previousYs[i-1] > _previousYs[i] ? "upwards" : "downwards"
+                var dir = _previousYs[i - 1] > _previousYs[i] ? "upwards" : "downwards"
                 if (tmpDirection !== "" && dir !== tmpDirection) {
                     directionChanged = true
                     break

--- a/apps/shared/WebView.qml
+++ b/apps/shared/WebView.qml
@@ -24,6 +24,12 @@ WebContainer {
     id: webView
 
     readonly property bool moving: contentItem && contentItem.moving
+    property bool portrait: true
+    property bool fullscreenMode: contentItem && (!contentItem.chrome || contentItem.fullscreen)
+    property real fullscreenHeight
+    property bool imOpened
+    property real toolbarHeight
+    property string favicon: contentItem ? contentItem.favicon : ""
     property bool findInPageHasResult
     property bool canShowSelectionMarkers: true
 
@@ -107,13 +113,10 @@ WebContainer {
                                                  : webView.visible && webView.contentItem
                                                    && (webView.contentItem.domContentLoaded
                                                        || webView.contentItem.painted)
-    allowHiding: !resourceController.videoActive && !resourceController.audioActive
-    fullscreenMode: contentItem && (!contentItem.chrome || contentItem.fullscreen)
 
     selectionActive: webView.contentItem && webView.contentItem.textSelectionActive
     touchBlocked: contentItem && contentItem.popupOpener && contentItem.popupOpener.active
                   || !AccessPolicy.browserEnabled || false
-    favicon: contentItem ? contentItem.favicon : ""
 
     onSelectionActiveChanged: {
         if (!selectionActive && webView.contentItem && webView.contentItem.textSelectionController) {

--- a/apps/shared/WebView.qml
+++ b/apps/shared/WebView.qml
@@ -136,6 +136,8 @@ WebContainer {
             readonly property bool textSelectionActive: textSelectionController && textSelectionController.active
             property Item textSelectionController: null
             readonly property bool activeWebPage: container.tabId == tabId
+            property bool userHasDraggedWhileLoading
+            property string favicon
 
             property QtObject pickerOpener: Pickers.PickerOpener {
                 pageStack: window.pageStack
@@ -191,7 +193,6 @@ WebContainer {
                 }
             }
 
-            fullscreenHeight: container.fullscreenHeight
             toolbarHeight: container.toolbarHeight
             throttlePainting: !foreground && !resourceController.videoActive && webView.visible || !webView.visible
             enabled: webView.enabled

--- a/settings/plugin.cpp
+++ b/settings/plugin.cpp
@@ -53,7 +53,8 @@ public:
     void registerTypes(const char *uri)
     {
         Q_ASSERT(QLatin1String(uri) == QLatin1String("org.sailfishos.browser.settings"));
-        qmlRegisterUncreatableType<AppTranslator>(uri, 1, 0, "BrowserSettingsTranslations", "Browser settings translations loaded by import");
+        qmlRegisterUncreatableType<AppTranslator>(uri, 1, 0, "BrowserSettingsTranslations",
+                                                  "Browser settings translations loaded by import");
 
     }
 };

--- a/tests/auto/tst_logins/tst_logins.cpp
+++ b/tests/auto/tst_logins/tst_logins.cpp
@@ -69,10 +69,8 @@ void tst_logins::initTestCase()
 void tst_logins::init()
 {
     removeAllLogins();
-    if (loginModel) {
-        delete loginModel;
-        loginModel = nullptr;
-    }
+    delete loginModel;
+    loginModel = nullptr;
 }
 
 void tst_logins::cleanupTestCase()

--- a/tests/auto/tst_webview/tst_webview.cpp
+++ b/tests/auto/tst_webview/tst_webview.cpp
@@ -108,8 +108,8 @@ void tst_webview::initTestCase()
 {
     init(QUrl("qrc:///tst_webview.qml"));
     webContainer = TestObject::qmlObject<DeclarativeWebContainer>("webView");
-    QQmlEngine::setObjectOwnership(webContainer, QQmlEngine::CppOwnership);
     QVERIFY(webContainer);
+    QQmlEngine::setObjectOwnership(webContainer, QQmlEngine::CppOwnership);
     QSignalSpy completedChanged(webContainer, SIGNAL(completedChanged()));
     QSignalSpy loadingChanged(webContainer, SIGNAL(loadingChanged()));
     QSignalSpy urlChanged(webContainer, SIGNAL(urlChanged()));
@@ -117,8 +117,8 @@ void tst_webview::initTestCase()
     QSignalSpy testSetupReadyChanged(rootObject(), SIGNAL(testSetupReadyChanged()));
 
     tabModel = TestObject::qmlObject<DeclarativeTabModel>("tabModel");
-    tabModel->m_unittestMode = true;
     QVERIFY(tabModel);
+    tabModel->m_unittestMode = true;
     tabModel->clear();
     QSignalSpy tabAddedSpy(tabModel, SIGNAL(tabAdded(int)));
 

--- a/tests/auto/tst_webview/tst_webview.qml
+++ b/tests/auto/tst_webview/tst_webview.qml
@@ -47,9 +47,7 @@ ApplicationWindow {
         WebView {
             id: webView
 
-            portrait: true
             toolbarHeight: 0
-            fullscreenHeight: Screen.height
             width: window.width
             height: window.height
             privateMode: false


### PR DESCRIPTION
Different changes in different commits. Such as:
- Moving properties to qml which where unnecessarily declared in c++, but not used there.
- Removing dead member variable that made stop() never called based on loading() state
- Extra security signal which I wonder if it was breaking some cases

Depends on https://github.com/sailfishos/qtmozembed/pull/56