### PR TITLE
[browser] Allow non-http bookmark URLs

### DIFF
--- a/apps/browser/qml/pages/components/BookmarkEditDialog.qml
+++ b/apps/browser/qml/pages/components/BookmarkEditDialog.qml
@@ -112,7 +112,7 @@ UserPromptDialog {
                 EnterKey.onClicked: accept()
 
                 validator: RegExpValidator {
-                    regExp: /^([^:]+):\/\/.+/
+                    regExp: /^([^:]+):.+/
                 }
             }
         }

--- a/apps/browser/qml/pages/components/BookmarkEditDialog.qml
+++ b/apps/browser/qml/pages/components/BookmarkEditDialog.qml
@@ -95,9 +95,9 @@ UserPromptDialog {
                     if (!errorHighlight) {
                         return ""
                     } else if (text.length > 0) {
-                        var scheme = root.url.match(/^([^:]+):\/\/.+/)
+                        var scheme = root.url.match(/^([^:]{3,}):/)
 
-                        //% "URL scheme (%1) missing"
+                        //% "URL scheme (%1) missing or not supported"
                         return qsTrId("sailfish_browser-la-missing_url_scheme").arg(scheme && scheme.length > 1
                                                                                     ? scheme[1] : "https")
                     } else {
@@ -112,7 +112,7 @@ UserPromptDialog {
                 EnterKey.onClicked: accept()
 
                 validator: RegExpValidator {
-                    regExp: /^([^:]+):.+/
+                    regExp: /^(file|https?):\/\/.+/
                 }
             }
         }

--- a/apps/browser/qml/pages/components/BookmarkEditDialog.qml
+++ b/apps/browser/qml/pages/components/BookmarkEditDialog.qml
@@ -95,7 +95,7 @@ UserPromptDialog {
                     if (!errorHighlight) {
                         return ""
                     } else if (text.length > 0) {
-                        var scheme = root.url.match(/^(https?):\/\/.+/)
+                        var scheme = root.url.match(/^([^:]+):\/\/.+/)
 
                         //% "URL scheme (%1) missing"
                         return qsTrId("sailfish_browser-la-missing_url_scheme").arg(scheme && scheme.length > 1
@@ -112,7 +112,7 @@ UserPromptDialog {
                 EnterKey.onClicked: accept()
 
                 validator: RegExpValidator {
-                    regExp: /^https?:\/\/.+/
+                    regExp: /^([^:]+):\/\/.+/
                 }
             }
         }

--- a/apps/browser/qml/pages/components/BookmarkItem.qml
+++ b/apps/browser/qml/pages/components/BookmarkItem.qml
@@ -97,6 +97,7 @@ ListItem {
             }
             MenuItem {
                 text: qsTrId("sailfish_browser-me-add_to_launcher")
+                enabled: /^(file|https?):\/\/.+/.test(url) // See also BookmarkEditDialog.qml
                 onClicked: pageStack.animatorPush("AddToAppGridDialog.qml",
                                                   {
                                                       "url": url,

--- a/apps/browser/qml/pages/components/BookmarkItem.qml
+++ b/apps/browser/qml/pages/components/BookmarkItem.qml
@@ -97,7 +97,9 @@ ListItem {
             }
             MenuItem {
                 text: qsTrId("sailfish_browser-me-add_to_launcher")
-                enabled: /^(file|https?):\/\/.+/.test(url) // See also BookmarkEditDialog.qml
+                // Should match up with .desktop mime-types. See also BookmarkEditDialog.qml
+                enabled: /^https?:\/\/.+/.test(url)
+                      || /^file:\/\/.+\.(xml|html?)$/.test(url)
                 onClicked: pageStack.animatorPush("AddToAppGridDialog.qml",
                                                   {
                                                       "url": url,


### PR DESCRIPTION
Allows saving from the bookmark edit dialog also when the URI does not start with https.

The most common case is probably file://, which currently can be bookmarked, but not edited.  
But folks may want to bookmark things like app:, geo:, or dav: as well
