### PR TITLE
Remove some unused methods

### DIFF
--- a/apps/browser/settings/declarativeloginmodel.h
+++ b/apps/browser/settings/declarativeloginmodel.h
@@ -23,9 +23,9 @@ class DeclarativeLoginModel : public QAbstractListModel, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
-
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
     Q_PROPERTY(bool populated READ populated NOTIFY populatedChanged)
+
 public:
     enum Roles {
         UidRole = Qt::UserRole,

--- a/apps/browser/settings/loginfiltermodel.h
+++ b/apps/browser/settings/loginfiltermodel.h
@@ -17,6 +17,7 @@ class LoginFilterModel : public QSortFilterProxyModel
 {
     Q_OBJECT
     Q_PROPERTY(QString search READ search WRITE setSearch NOTIFY searchChanged)
+
 public:
     LoginFilterModel(QObject *parent = nullptr);
 

--- a/apps/browser/settings/searchenginemodel.h
+++ b/apps/browser/settings/searchenginemodel.h
@@ -20,9 +20,7 @@ class SearchEngineModel : public QAbstractListModel, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
-
     Q_ENUMS(Status)
-
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
 
 public:

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -1154,19 +1154,6 @@ void DeclarativeWebContainer::updateWindowFlags()
     }
 }
 
-void DeclarativeWebContainer::updatePageFocus(bool focus)
-{
-    if (m_webPage) {
-        if (focus) {
-            QFocusEvent focusEvent(QEvent::FocusIn);
-            m_webPage->focusInEvent(&focusEvent);
-        } else {
-            QFocusEvent focusEvent(QEvent::FocusOut);
-            m_webPage->focusOutEvent(&focusEvent);
-        }
-    }
-}
-
 bool DeclarativeWebContainer::canInitialize() const
 {
     return SailfishOS::WebEngine::instance()->isInitialized() && m_model && m_model->loaded();

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -145,7 +145,6 @@ public:
     Q_INVOKABLE int activateTab(int tabId, const QString &url);
     Q_INVOKABLE void closeTab(int tabId);
 
-    Q_INVOKABLE void updatePageFocus(bool focus);
     Q_INVOKABLE void dumpPages() const;
 
     QObject *focusObject() const;

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -12,18 +12,16 @@
 
 #include <qmozcontext.h>
 #include <qmozsecurity.h>
+
 #include <QtGui/QWindow>
 #include <QtGui/QOpenGLFunctions>
 #include <QPointer>
-#include <QFutureWatcher>
 #include <QQmlComponent>
 #include <QQuickView>
 #include <QQuickItem>
 #include <QMutex>
-#include <QWaitCondition>
 #include <QTimer>
 
-class QInputMethodEvent;
 class QMozWindow;
 class QTimerEvent;
 class DeclarativeTabModel;
@@ -136,6 +134,7 @@ public:
     uint tabOwner(int tabId) const;
     int requestTabWithOwner(int tabId, const QString &url, uint ownerPid);
     void requestTabWithOwnerAsync(int tabId, const QString &url, uint ownerPid, void *context);
+
     Q_INVOKABLE void releaseActiveTabOwnership();
 
     Q_INVOKABLE void load(const QString &url, bool force = false, bool fromExternal = false);

--- a/apps/core/declarativewebutils.cpp
+++ b/apps/core/declarativewebutils.cpp
@@ -68,11 +68,6 @@ DeclarativeWebUtils::~DeclarativeWebUtils()
     gSingleton = 0;
 }
 
-int DeclarativeWebUtils::getLightness(const QColor &color) const
-{
-    return color.lightness();
-}
-
 void DeclarativeWebUtils::handleDumpMemoryInfoRequest(const QString &fileName)
 {
     if (qApp->arguments().contains("-debugMode")) {

--- a/apps/core/declarativewebutils.h
+++ b/apps/core/declarativewebutils.h
@@ -22,7 +22,6 @@ class MDConfItem;
 class DeclarativeWebUtils : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(QString homePage READ homePage NOTIFY homePageChanged FINAL)
     Q_PROPERTY(bool firstUseDone READ firstUseDone WRITE setFirstUseDone NOTIFY firstUseDoneChanged)
     Q_PROPERTY(qreal cssPixelRatio READ cssPixelRatio NOTIFY cssPixelRatioChanged)
@@ -34,7 +33,6 @@ public:
     void setFirstUseDone(bool firstUseDone);
     qreal cssPixelRatio() const;
 
-    Q_INVOKABLE int getLightness(const QColor &color) const;
     Q_INVOKABLE QString displayableUrl(const QString &fullUrl) const;
     Q_INVOKABLE QString pageName(const QString &fullUrl) const;
 

--- a/apps/core/downloadmanager.h
+++ b/apps/core/downloadmanager.h
@@ -24,10 +24,9 @@ class TransferEngineInterface;
 class DownloadManager : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(bool pdfPrinting READ pdfPrinting NOTIFY pdfPrintingChanged FINAL)
-
     Q_ENUMS(DownloadStatus::Status)
+
 public:
     static DownloadManager *instance();
 

--- a/apps/core/faviconmanager.h
+++ b/apps/core/faviconmanager.h
@@ -15,6 +15,7 @@
 #include <QMap>
 
 class DeclarativeWebPage;
+
 class FaviconManager : public QObject
 {
     Q_OBJECT

--- a/apps/core/secureaction.cpp
+++ b/apps/core/secureaction.cpp
@@ -199,7 +199,8 @@ void SecureAction::perform(const QJSValue &resolve)
             m_registered = systemBus.registerObject(m_replyPath, this);
 
             if (!m_registered) {
-                qmlInfo(this) << "DBus adaptor registration error " << systemBus.lastError().name() << " " << systemBus.lastError().message();
+                qmlInfo(this) << "DBus adaptor registration error " << systemBus.lastError().name()
+                              << " " << systemBus.lastError().message();
                 return;
             }
         }

--- a/tests/auto/mocks/declarativewebutils/declarativewebutils.cpp
+++ b/tests/auto/mocks/declarativewebutils/declarativewebutils.cpp
@@ -24,11 +24,6 @@ DeclarativeWebUtils::DeclarativeWebUtils(QObject *parent)
             this, &DeclarativeWebUtils::updateWebEngineSettings);
 }
 
-int DeclarativeWebUtils::getLightness(const QColor &color) const
-{
-    return color.lightness();
-}
-
 QString DeclarativeWebUtils::displayableUrl(const QString &fullUrl) const
 {
     return fullUrl;

--- a/tests/auto/mocks/declarativewebutils/declarativewebutils.h
+++ b/tests/auto/mocks/declarativewebutils/declarativewebutils.h
@@ -26,7 +26,6 @@ class DeclarativeWebUtils : public QObject
 public:
     explicit DeclarativeWebUtils(QObject *parent = 0);
 
-    Q_INVOKABLE int getLightness(const QColor &color) const;
     Q_INVOKABLE QString displayableUrl(const QString &fullUrl) const;
 
     static DeclarativeWebUtils *instance();


### PR DESCRIPTION
Beef:

    DeclarativeWebContainer::updatePageFocus() usage seemed like a short-lived
    thing in 2015, between commit 41e8992ce01 and commit ddfe22053db
    
    DeclarativeWebUtils::getLightness() usage dropped 2021, commit 4494bc1574
