### PR TITLE
Implement mouse back/forward button support

### DIFF
--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -823,6 +823,22 @@ void DeclarativeWebContainer::touchEvent(QTouchEvent *event)
     }
 }
 
+void DeclarativeWebContainer::mousePressEvent(QMouseEvent *event)
+{
+    switch (event->button()) {
+    case Qt::BackButton:
+        event->accept();
+        emit backButtonPressed();
+        break;
+    case Qt::ForwardButton:
+        event->accept();
+        emit forwardButtonPressed();
+        break;
+    default:
+        QWindow::mousePressEvent(event);
+    }
+}
+
 void DeclarativeWebContainer::wheelEvent(QWheelEvent *event)
 {
     if (m_webPage && m_enabled) {

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -193,12 +193,16 @@ signals:
 
     void hasInitialUrlChanged();
     void requestTabWithOwnerAsyncResult(int tabId, void *context);
+
     void keyPressed(int key);
+    void backButtonPressed();
+    void forwardButtonPressed();
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
     void exposeEvent(QExposeEvent *event) override;
     void touchEvent(QTouchEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     void keyReleaseEvent(QKeyEvent *event) override;

--- a/apps/shared/WebView.qml
+++ b/apps/shared/WebView.qml
@@ -136,6 +136,10 @@ WebContainer {
 
     onKeyPressed: handleKeyPress(key)
 
+    onBackButtonPressed: webView.goBack()
+
+    onForwardButtonPressed: webView.goForward()
+
     webPageComponent: Component {
         WebPage {
             id: webPage


### PR DESCRIPTION
Add a simple `mouseButtonPressed` handler to fire signals on `Qt::BackButton` and `Qt::ForwardButton` and wire them to `goBack()` and `goForward()` respectively.