### PR TITLE
Fullscreen close button and captive portal fixes

### DIFF
--- a/apps/browser/main.cpp
+++ b/apps/browser/main.cpp
@@ -19,7 +19,6 @@
 #include <QDBusPendingCall>
 
 #include "browser.h"
-#include "browserappinfo.h"
 // Registered QML types
 #include "declarativebookmarkmodel.h"
 #include "bookmarkfiltermodel.h"
@@ -48,7 +47,6 @@
 
 #include <signal.h>
 
-namespace {
 static QObject *search_model_factory(QQmlEngine *, QJSEngine *)
 {
     return new SearchEngineModel;
@@ -62,7 +60,6 @@ static QObject *faviconmanager_factory(QQmlEngine *, QJSEngine *)
 static QObject *bookmarkmanager_factory(QQmlEngine *, QJSEngine *)
 {
     return BookmarkManager::instance();
-}
 }
 
 Q_DECL_EXPORT int main(int argc, char *argv[])
@@ -153,16 +150,15 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterUncreatableType<DeclarativeTabModel>(uri, 1, 0, "TabModel", "TabModel is abstract!");
     qmlRegisterUncreatableType<PrivateTabModel>(uri, 1, 0, "PrivateTabModel", "");
 
-    if (!BrowserAppInfo::captivePortal()) {
-        qmlRegisterType<DeclarativeBookmarkModel>(uri, 1, 0, "BookmarkModel");
-        qmlRegisterUncreatableType<PersistentTabModel>(uri, 1, 0, "PersistentTabModel", "");
-        qmlRegisterType<DeclarativeHistoryModel>(uri, 1, 0, "HistoryModel");
-        qmlRegisterType<BookmarkFilterModel>(uri, 1, 0, "BookmarkFilterModel");
-        qmlRegisterType<DeclarativeLoginModel>(uri, 1, 0, "LoginModel");
-        qmlRegisterType<LoginFilterModel>(uri, 1, 0, "LoginFilterModel");
-        qmlRegisterType<DeclarativeTabFilterModel>(uri, 1, 0, "TabFilterModel");
-        qmlRegisterSingletonType<BookmarkManager>(uri, 1, 0, "BookmarkManager", bookmarkmanager_factory);
-    }
+    // non-captive portal content
+    qmlRegisterType<DeclarativeBookmarkModel>(uri, 1, 0, "BookmarkModel");
+    qmlRegisterUncreatableType<PersistentTabModel>(uri, 1, 0, "PersistentTabModel", "");
+    qmlRegisterType<DeclarativeHistoryModel>(uri, 1, 0, "HistoryModel");
+    qmlRegisterType<BookmarkFilterModel>(uri, 1, 0, "BookmarkFilterModel");
+    qmlRegisterType<DeclarativeLoginModel>(uri, 1, 0, "LoginModel");
+    qmlRegisterType<LoginFilterModel>(uri, 1, 0, "LoginFilterModel");
+    qmlRegisterType<DeclarativeTabFilterModel>(uri, 1, 0, "TabFilterModel");
+    qmlRegisterSingletonType<BookmarkManager>(uri, 1, 0, "BookmarkManager", bookmarkmanager_factory);
 
     qmlRegisterSingletonType<FaviconManager>(uri, 1, 0, "FaviconManager", faviconmanager_factory);
     qmlRegisterUncreatableType<DownloadStatus>(uri, 1, 0, "DownloadStatus", "");

--- a/apps/browser/qml/pages/BrowserPage.qml
+++ b/apps/browser/qml/pages/BrowserPage.qml
@@ -164,6 +164,12 @@ Page {
             }
         }
 
+        onTouched: {
+            if (contentFullscreen) {
+                fullscreenCloseVisibleTimer.restart()
+            }
+        }
+
         onWebContentOrientationChanged: orientationFader.waitForWebContentOrientationChanged = false
 
         function applyContentOrientation(orientation) {
@@ -195,6 +201,27 @@ Page {
         }
     }
 
+    IconButton {
+        id: fullscreenClose
+
+        opacity: fullscreenCloseVisibleTimer.running || pressed ? 1.0 : 0.0
+        Behavior on opacity { FadeAnimation {} }
+        visible: opacity > 0
+        x: Theme.paddingLarge
+        y: Theme.paddingLarge
+        icon.source: "image://theme/icon-m-close"
+        onClicked: {
+            webView.sendAsyncMessage("embedui:exitFullscreen", {})
+        }
+
+        Timer {
+            id: fullscreenCloseVisibleTimer
+
+            interval: 2000
+            running: webView.contentFullscreen
+        }
+    }
+
     // Use Connections so that target updates when model changes.
     Connections {
         target: AccessPolicy.browserEnabled && webView && webView.tabModel || null
@@ -216,6 +243,9 @@ Page {
         overlayMask: (webView.enabled && browserPage.active && !webView.touchBlocked && !downloadPopup.visible)
                      ? Qt.rect(0, overlay.y, browserPage.width, browserPage.height - overlay.y)
                      : Qt.rect(0, 0, browserPage.width, browserPage.height)
+        closeButtonMask: fullscreenClose.visible ? Qt.rect(fullscreenClose.x, fullscreenClose.y,
+                                                           fullscreenClose.width, fullscreenClose.height)
+                                                 : Qt.rect(0, 0, 0, 0)
     }
 
     Browser.DimmerEffect {

--- a/apps/captiveportal/main.cpp
+++ b/apps/captiveportal/main.cpp
@@ -54,6 +54,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     QScopedPointer<QQuickView> view(new QQuickView);
 #endif
     app->setQuitOnLastWindowClosed(false);
+    app->setAttribute(Qt::AA_SynthesizeTouchForUnhandledMouseEvents, true);
 
     CaptivePortalService *service = new CaptivePortalService(app.data());
     // Handle command line launch

--- a/apps/captiveportal/qml/pages/CaptivePortalPage.qml
+++ b/apps/captiveportal/qml/pages/CaptivePortalPage.qml
@@ -110,6 +110,12 @@ Page {
             }
         }
 
+        onTouched: {
+            if (contentFullscreen) {
+                fullscreenCloseVisibleTimer.restart()
+            }
+        }
+
         onWebContentOrientationChanged: orientationFader.waitForWebContentOrientationChanged = false
 
         function applyContentOrientation(orientation) {
@@ -133,6 +139,27 @@ Page {
         }
     }
 
+    IconButton {
+        id: fullscreenClose
+
+        opacity: fullscreenCloseVisibleTimer.running || pressed ? 1.0 : 0.0
+        Behavior on opacity { FadeAnimation {} }
+        visible: opacity > 0
+        x: Theme.paddingLarge
+        y: Theme.paddingLarge
+        icon.source: "image://theme/icon-m-close"
+        onClicked: {
+            webView.sendAsyncMessage("embedui:exitFullscreen", {})
+        }
+
+        Timer {
+            id: fullscreenCloseVisibleTimer
+
+            interval: 2000
+            running: webView.contentFullscreen
+        }
+    }
+
     // Use Connections so that target updates when model changes.
     Connections {
         target: AccessPolicy.browserEnabled && webView && webView.tabModel || null
@@ -147,6 +174,9 @@ Page {
         overlayMask: (webView.enabled && browserPage.active && !webView.touchBlocked)
                      ? Qt.rect(0, overlay.y, browserPage.width, browserPage.height - overlay.y)
                      : Qt.rect(0, 0, browserPage.width, browserPage.height)
+        closeButtonMask: fullscreenClose.visible ? Qt.rect(fullscreenClose.x, fullscreenClose.y,
+                                                           fullscreenClose.width, fullscreenClose.height)
+                                                 : Qt.rect(0, 0, 0, 0)
     }
 
     Browser.CaptivePortalOverlay {

--- a/apps/captiveportal/qml/pages/CaptivePortalPage.qml
+++ b/apps/captiveportal/qml/pages/CaptivePortalPage.qml
@@ -27,6 +27,7 @@ Page {
     property alias url: webView.url
     property alias title: webView.title
     property alias webView: webView
+    property alias inputRegion: inputRegion
 
     // for time being make this fullscreen. TODO: avoid drawing over cutout and corner areas.
     cutoutMode: CutoutMode.FullScreen
@@ -93,6 +94,7 @@ Page {
     Shared.WebView {
         id: webView
 
+        activePortalMode: true
         enabled: overlay.animator.allowContentUse
         fullscreenHeight: portrait ? Screen.height : Screen.width
         portrait: browserPage.isPortrait
@@ -138,6 +140,8 @@ Page {
     }
 
     InputRegion {
+        id: inputRegion
+
         window: webView.chromeWindow
         orientation: browserPage.orientation // Qt and Silica orientations match
         overlayMask: (webView.enabled && browserPage.active && !webView.touchBlocked)

--- a/apps/core/declarativewebcontainer.cpp
+++ b/apps/core/declarativewebcontainer.cpp
@@ -801,7 +801,7 @@ void DeclarativeWebContainer::touchEvent(QTouchEvent *event)
         return;
     }
 
-    if (m_webPage && m_enabled && ((!m_touchBlocked || m_selectionActive) || event->type() != QEvent::TouchBegin)) {
+    if (m_webPage && m_enabled && (!m_touchBlocked || event->type() != QEvent::TouchBegin)) {
         QList<QTouchEvent::TouchPoint> touchPoints = event->touchPoints();
         QTouchEvent mappedTouchEvent = *event;
 
@@ -812,11 +812,8 @@ void DeclarativeWebContainer::touchEvent(QTouchEvent *event)
 
         mappedTouchEvent.setTouchPoints(touchPoints);
         m_webPage->touchEvent(&mappedTouchEvent);
-        if (m_selectionActive && event->type() == QEvent::TouchBegin) {
-            // If touch event is received here after selection is active it's pressed outside selection area
-            // Inform that selection should close
-            m_selectionActive = false;
-            emit selectionActiveChanged();
+        if (event->type() == QEvent::TouchBegin) {
+            emit touched();
         }
     } else {
         QWindow::touchEvent(event);

--- a/apps/core/declarativewebcontainer.h
+++ b/apps/core/declarativewebcontainer.h
@@ -47,7 +47,6 @@ class DeclarativeWebContainer : public QWindow, public QQmlParserStatus, protect
     Q_PROPERTY(int maxLiveTabCount READ maxLiveTabCount WRITE setMaxLiveTabCount NOTIFY maxLiveTabCountChanged FINAL)
     // This property should cover all possible popups
     Q_PROPERTY(bool touchBlocked MEMBER m_touchBlocked NOTIFY touchBlockedChanged FINAL)
-    Q_PROPERTY(bool selectionActive MEMBER m_selectionActive NOTIFY selectionActiveChanged FINAL)
 
     Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged FINAL)
     Q_PROPERTY(int loadProgress READ loadProgress NOTIFY loadProgressChanged FINAL)
@@ -165,7 +164,6 @@ signals:
     void foregroundChanged();
     void maxLiveTabCountChanged();
     void touchBlockedChanged();
-    void selectionActiveChanged();
 
     void loadingChanged();
     void loadProgressChanged();
@@ -197,6 +195,7 @@ signals:
     void keyPressed(int key);
     void backButtonPressed();
     void forwardButtonPressed();
+    void touched();
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
@@ -275,7 +274,6 @@ private:
     bool m_enabled = true;
     bool m_foreground = true;
     bool m_touchBlocked = false;
-    bool m_selectionActive = false;
 
     // See DeclarativeWebContainer::load (line 283) as load need to "work" even if engine, model,
     // or qml component is not yet completed (completed property is still false). So cache url/title for later use.

--- a/apps/core/inputregion.cpp
+++ b/apps/core/inputregion.cpp
@@ -34,6 +34,7 @@ public:
     QRect overlayMask;
     QRect selectionStartHandleMask;
     QRect selectionEndHandleMask;
+    QRect closeButtonMask;
     QWindow *window;
     InputRegion *q_ptr;
     int updateTimerId;
@@ -46,6 +47,7 @@ InputRegionPrivate::InputRegionPrivate(InputRegion *q)
     : overlayMask(0.0, 0.0, 0.0, 0.0)
     , selectionStartHandleMask(0.0, 0.0, 0.0, 0.0)
     , selectionEndHandleMask(0.0, 0.0, 0.0, 0.0)
+    , closeButtonMask(0.0, 0.0, 0.0, 0.0)
     , window(0)
     , q_ptr(q)
     , updateTimerId(0)
@@ -89,12 +91,13 @@ void InputRegionPrivate::update()
     updateTimerId = 0;
 
     if (window) {
-        QRect rects[3];
+        QRect rects[4];
         rects[0] = translateRect(selectionStartHandleMask);
         rects[1] = translateRect(selectionEndHandleMask);
         rects[2] = translateRect(overlayMask);
+        rects[3] = translateRect(closeButtonMask);
         QRegion mask;
-        mask.setRects(rects, 3);
+        mask.setRects(rects, 4);
         window->setMask(mask);
         if (window->handle()) {
             QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
@@ -166,6 +169,22 @@ void InputRegion::setSelectionEndHandleMask(const QRect& rect)
         d->selectionEndHandleMask = rect;
         d->scheduleUpdate();
         emit selectionEndHandleMaskChanged();
+    }
+}
+
+const QRect& InputRegion::closeButtonMask() const
+{
+    Q_D(const InputRegion);
+    return d->closeButtonMask;
+}
+
+void InputRegion::setCloseButtonMask(const QRect& rect)
+{
+    Q_D(InputRegion);
+    if (d->closeButtonMask != rect) {
+        d->closeButtonMask = rect;
+        d->scheduleUpdate();
+        emit closeButtonMaskChanged();
     }
 }
 

--- a/apps/core/inputregion.h
+++ b/apps/core/inputregion.h
@@ -25,6 +25,7 @@ class InputRegion : public QObject
     Q_PROPERTY(QRect overlayMask READ overlayMask WRITE setOverlayMask NOTIFY overlayMaskChanged)
     Q_PROPERTY(QRect selectionStartHandleMask READ selectionStartHandleMask WRITE setSelectionStartHandleMask NOTIFY selectionStartHandleMaskChanged FINAL)
     Q_PROPERTY(QRect selectionEndHandleMask READ selectionEndHandleMask WRITE setSelectionEndHandleMask NOTIFY selectionEndHandleMaskChanged FINAL)
+    Q_PROPERTY(QRect closeButtonMask READ closeButtonMask WRITE setCloseButtonMask NOTIFY closeButtonMaskChanged)
     Q_PROPERTY(QWindow *window READ window WRITE setWindow NOTIFY windowChanged FINAL)
     Q_PROPERTY(int orientation READ orientation WRITE setOrientation NOTIFY orientationChanged)
 
@@ -37,6 +38,8 @@ public:
     void setSelectionStartHandleMask(const QRect& rect);
     const QRect& selectionEndHandleMask() const;
     void setSelectionEndHandleMask(const QRect& rect);
+    const QRect& closeButtonMask() const;
+    void setCloseButtonMask(const QRect& rect);
 
     QWindow *window() const;
     void setWindow(QWindow *window);
@@ -48,6 +51,7 @@ signals:
     void overlayMaskChanged();
     void selectionStartHandleMaskChanged();
     void selectionEndHandleMaskChanged();
+    void closeButtonMaskChanged();
     void windowChanged();
     void orientationChanged();
 

--- a/apps/shared/OverlayAnimator.qml
+++ b/apps/shared/OverlayAnimator.qml
@@ -173,11 +173,11 @@ Item {
         target: webView
         ignoreUnknownSignals: true
 
-        onFullscreenModeChanged: {
-            if (webView.fullscreenMode) {
-                updateState(_fullscreenWebPage)
-            } else {
+        onNeedChromeChanged: {
+            if (webView.needChrome) {
                 updateState(_chromeVisible)
+            } else {
+                updateState(_fullscreenWebPage)
             }
         }
     }

--- a/apps/shared/WebView.qml
+++ b/apps/shared/WebView.qml
@@ -24,6 +24,7 @@ import "." as Browser
 WebContainer {
     id: webView
 
+    property bool activePortalMode
     readonly property bool moving: contentItem && contentItem.moving
     property bool portrait: true
     property bool fullscreenMode: contentItem && (!contentItem.chrome || contentItem.fullscreen)
@@ -91,6 +92,11 @@ WebContainer {
     }
 
     function thumbnailCaptureSize() {
+        if (webView.activePortalMode) {
+            console.log("Thumbnail size tried accessed in captive portal mode")
+            return Qt.size(0, 0)
+        }
+
         var ratio = Math.min(
                     browserPage.width / browserPage.thumbnailSize.width,
                     browserPage.height / browserPage.thumbnailSize.height)
@@ -101,6 +107,11 @@ WebContainer {
     }
 
     function grabActivePage() {
+        if (webView.activePortalMode) {
+            console.warn("Refusing page grab in active portal mode")
+            return
+        }
+
         if (webView.contentItem && webView.activeTabRendered) {
             if (webView.privateMode) {
                 webView.contentItem.grabThumbnail(thumbnailCaptureSize())
@@ -175,14 +186,18 @@ WebContainer {
 
                     // Possible path that leads to a new tab. Thus, capturing current
                     // view before opening context menu.
-                    webView.grabActivePage()
+                    if (!webView.activePortalMode) {
+                        webView.grabActivePage()
+                    }
                     contextMenuRequested(data)
                 }
 
                 onLoginSaved: {
-                    FaviconManager.grabIcon("logins", webPage,
-                                            Qt.size(Theme.iconSizeMedium,
-                                                    Theme.iconSizeMedium))
+                    if (!webView.activePortalMode) {
+                        FaviconManager.grabIcon("logins", webPage,
+                                                Qt.size(Theme.iconSizeMedium,
+                                                        Theme.iconSizeMedium))
+                    }
                 }
             }
 
@@ -277,13 +292,16 @@ WebContainer {
                                          })
                         resurrectedContentRect = null
                     }
-                    grabItem()
 
-                    if (!webView.privateMode) {
-                        // Update the favicon for history items.
-                        FaviconManager.grabIcon("history", webPage,
-                                                Qt.size(Theme.iconSizeMedium,
-                                                        Theme.iconSizeMedium))
+                    if (!webView.activePortalMode) {
+                        grabItem()
+
+                        if (!webView.privateMode) {
+                            // Update the favicon for history items.
+                            FaviconManager.grabIcon("history", webPage,
+                                                    Qt.size(Theme.iconSizeMedium,
+                                                            Theme.iconSizeMedium))
+                        }
                     }
                 }
 
@@ -309,7 +327,9 @@ WebContainer {
                     ++frameCounter
                 } else if (!rendered) {
                     rendered = true
-                    grabItem()
+                    if (!webView.activePortalMode) {
+                        grabItem()
+                    }
                 }
             }
 

--- a/apps/shared/WebView.qml
+++ b/apps/shared/WebView.qml
@@ -27,7 +27,8 @@ WebContainer {
     property bool activePortalMode
     readonly property bool moving: contentItem && contentItem.moving
     property bool portrait: true
-    property bool fullscreenMode: contentItem && (!contentItem.chrome || contentItem.fullscreen)
+    property bool contentFullscreen: contentItem && contentItem.fullscreen
+    property bool needChrome: !contentItem || (contentItem.chrome && !contentItem.fullscreen)
     property real fullscreenHeight
     property bool imOpened
     property real toolbarHeight
@@ -133,23 +134,20 @@ WebContainer {
                                                    && (webView.contentItem.domContentLoaded
                                                        || webView.contentItem.painted)
 
-    selectionActive: webView.contentItem && webView.contentItem.textSelectionActive
     touchBlocked: contentItem && contentItem.popupOpener && contentItem.popupOpener.active
                   || !AccessPolicy.browserEnabled || false
-
-    onSelectionActiveChanged: {
-        if (!selectionActive && webView.contentItem && webView.contentItem.textSelectionController) {
-            webView.contentItem.textSelectionController.clearSelection()
-            browserPage.inputRegion.selectionStartHandleMask = Qt.rect(0, 0, 0, 0)
-            browserPage.inputRegion.selectionEndHandleMask = Qt.rect(0, 0, 0, 0)
-        }
-    }
 
     onKeyPressed: handleKeyPress(key)
 
     onBackButtonPressed: webView.goBack()
 
     onForwardButtonPressed: webView.goForward()
+
+    onTouched: {
+        if (webView.contentItem && webView.contentItem.textSelectionActive) {
+            clearSelection()
+        }
+    }
 
     webPageComponent: Component {
         WebPage {


### PR DESCRIPTION
Depends on https://github.com/sailfishos/embedlite-components/pull/106

Some fixes on captive portal side and then separate commit for adding exit button for fullscreen mode. Captive portal can be perhaps easiest tested by running from commandline 'sailfish-captiveportal -captiveportal https://some_url'

Don't like the redundancy on main app pages but it's already there. For captive portal there's still some problem showing the text selection handles, but let's see if I have enough energy to dig into that.