### PR TITLE
[sailfish-browser] Fix some favorite item list glitches. JB#63270

### DIFF
--- a/apps/browser/qml/pages/components/FavoriteGrid.qml
+++ b/apps/browser/qml/pages/components/FavoriteGrid.qml
@@ -17,7 +17,8 @@ import Sailfish.Browser 1.0
 IconGridViewBase {
     id: favoriteGrid
 
-    property real menuHeight: 0
+    property real menuHeight
+    property int footerHeight: Theme.itemSizeLarge
 
     signal load(string url)
     signal newTab(string url)
@@ -48,7 +49,7 @@ IconGridViewBase {
 
     footer: Item {
         width: 1
-        height: Theme.itemSizeLarge
+        height: favoriteGrid.footerHeight
     }
 
     delegate: FavoriteItem {

--- a/apps/browser/qml/pages/components/HistoryList.qml
+++ b/apps/browser/qml/pages/components/HistoryList.qml
@@ -22,6 +22,7 @@ SilicaListView {
     property bool showDeleteButton
     property bool menuClosed
     property real horizontalMargin: Theme.horizontalPageMargin
+    property real footerHeight: Theme.itemSizeLarge
 
     signal load(string url, string title, bool newTab)
     signal saveBookmark(string url, string title, string favicon)
@@ -33,7 +34,7 @@ SilicaListView {
 
     footer: Item {
         width: 1
-        height: Theme.itemSizeLarge
+        height: view.footerHeight
     }
 
     delegate: HistoryItem {

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -465,7 +465,6 @@ Shared.Background {
                 iconSource: "image://theme/icon-m-history"
                 visible: historyContainer.showHistoryButton
                 opacity: visible && toolBar.opacity < 0.9 ? 1.0 : 0.0
-                enabled: overlayAnimator.atTop
 
                 onClicked: {
                     var historyPage = pageStack.push("../HistoryPage.qml", { model: historyModel })

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -184,6 +184,12 @@ Shared.Background {
         }
     }
 
+    BookmarkModel {
+        id: bookmarkModel
+
+        activeUrl: toolBar.url
+    }
+
     MouseArea {
         id: dragArea
 
@@ -577,11 +583,6 @@ Shared.Background {
                 }
             }
 
-            BookmarkModel {
-                id: bookmarkModel
-                activeUrl: toolBar.url
-            }
-
             Browser.HistoryList {
                 id: historyList
 
@@ -590,6 +591,7 @@ Shared.Background {
 
                 width: parent.width
                 height: browserPage.height - _overlayGap - panelSize
+                footerHeight: historyContainer.showHistoryList ? Theme.itemSizeLarge : 0
                 horizontalMargin: overlay.horizontalMargin
 
                 header: Browser.FavoriteGrid {
@@ -599,11 +601,12 @@ Shared.Background {
                     height: historyContainer.showHistoryList ? (count > 0
                                                                 ? cellHeight + headerItem.height + menuHeight
                                                                 : headerItem.height)
-                                                             : (historyList.height - historyList.footerItem.height)
+                                                             : historyList.height
                     opacity: visible && toolBar.opacity < 0.9 ? 1.0 : 0.0
                     enabled: overlayAnimator.atTop
                     visible: historyContainer.showFavorites
                     _quickScrollRightMargin: -(browserPage.width - width) / 2
+                    footerHeight: showHistoryList ? 0 : Theme.paddingLarge
 
                     header: Item {
                         width: parent.width


### PR DESCRIPTION
The FavoriteGrid (i.e. bookmarks) was having footer item applied too often:
- with keyboard open it was extracted from visible space, possibly hiding some bookmarks
- on landscape it was making the view needlessly scrollable, and not covering the bottom of the screen. Easily seen how scroll decorators moved only part of the view.
- With something written on search field it was making the filtered bookmark row scrollable over the search field while keeping history list in place.

Made footer to be used now only on either favorite grid or history list, not on both. For cosmetics, non-UI BookmarkModel model was moved out from the middle of UI parts.