### PR TITLE
[sailfish-browser] Fix reference error. JB#63270

### DIFF
--- a/apps/browser/qml/pages/HistoryPage.qml
+++ b/apps/browser/qml/pages/HistoryPage.qml
@@ -18,7 +18,7 @@ Page {
 
     property QtObject model
     property var remorse
-    readonly property bool pendingRemorse: remorse && remorse.pending
+    readonly property bool pendingRemorse: !!remorse && remorse.pending
 
     signal loadPage(string url, bool newTab)
     signal saveBookmark(string url, string title, string favicon)

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -605,7 +605,7 @@ Shared.Background {
                     enabled: overlayAnimator.atTop
                     visible: historyContainer.showFavorites
                     _quickScrollRightMargin: -(browserPage.width - width) / 2
-                    footerHeight: showHistoryList ? 0 : Theme.paddingLarge
+                    footerHeight: historyContainer.showHistoryList ? 0 : Theme.paddingLarge
 
                     header: Item {
                         width: parent.width


### PR DESCRIPTION
Could have expected working without id name, but it doesn't. And all the other places here to have the id so it's now consistent too.

Fixed also history page warning for assigning [undefined] to bool.