### PR TITLE
Fix history button visibility

### DIFF
--- a/apps/browser/qml/pages/LoginsPage.qml
+++ b/apps/browser/qml/pages/LoginsPage.qml
@@ -80,8 +80,8 @@ Page {
             onClicked: openMenu()
 
             Row {
-                width: parent.width - 2 * Theme.horizontalPageMargin
                 x: Theme.horizontalPageMargin
+                width: parent.width - 2 * x
                 spacing: Theme.paddingMedium
                 anchors.verticalCenter: parent.verticalCenter
 

--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -463,8 +463,8 @@ Shared.Background {
 
                 text: qsTrId("sailfish_browser-la-history")
                 iconSource: "image://theme/icon-m-history"
-                visible: historyContainer.showHistoryButton
-                opacity: visible && toolBar.opacity < 0.9 ? 1.0 : 0.0
+                visible: opacity > 0
+                opacity: (historyContainer.showHistoryButton && toolBar.opacity < 0.9) ? 1.0 : 0.0
 
                 onClicked: {
                     var historyPage = pageStack.push("../HistoryPage.qml", { model: historyModel })

--- a/apps/browser/settings/declarativeloginmodel.cpp
+++ b/apps/browser/settings/declarativeloginmodel.cpp
@@ -220,4 +220,3 @@ bool DeclarativeLoginModel::canModify(int uid, const QString &username, const QS
     }
     return validModification;
 }
-

--- a/apps/browser/settings/loginfiltermodel.cpp
+++ b/apps/browser/settings/loginfiltermodel.cpp
@@ -14,7 +14,6 @@
 LoginFilterModel::LoginFilterModel(QObject *parent)
     : QSortFilterProxyModel(parent)
 {
-
 }
 
 int LoginFilterModel::getIndex(int currentIndex)
@@ -28,10 +27,8 @@ bool LoginFilterModel::filterAcceptsRow(int sourceRow, const QModelIndex &source
 {
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
 
-    if (sourceModel()->data(index, DeclarativeLoginModel::HostnameRole).toString().trimmed().contains(m_search, Qt::CaseInsensitive)) {
-        return true;
-    }
-    return false;
+    return sourceModel()->data(index, DeclarativeLoginModel::HostnameRole)
+            .toString().trimmed().contains(m_search, Qt::CaseInsensitive);
 }
 
 void LoginFilterModel::setSourceModel(QAbstractItemModel *sourceModel)

--- a/apps/browser/settings/settings.pri
+++ b/apps/browser/settings/settings.pri
@@ -3,14 +3,12 @@ INCLUDEPATH += $$PWD
 CONFIG += link_pkgconfig
 PKGCONFIG += mlite5 sailfishwebengine
 
-# C++ sources
 SOURCES += \
     $$PWD/searchenginemodel.cpp \
     $$PWD/logininfo.cpp \
     $$PWD/declarativeloginmodel.cpp \
     $$PWD/loginfiltermodel.cpp
 
-# C++ headers
 HEADERS += \
     $$PWD/searchenginemodel.h \
     $$PWD/logininfo.h \

--- a/apps/core/secureaction.cpp
+++ b/apps/core/secureaction.cpp
@@ -209,20 +209,23 @@ void SecureAction::perform(const QJSValue &resolve)
 
         m_response.reset(new QDBusPendingCallWatcher(systemBus.asyncCall(createAuthenticatorCall(
                     QStringLiteral("RequestPermission"),
-                    { QVariant::fromValue(QDBusObjectPath(m_replyPath)), m_message, QVariantMap(), uint(Method::AllAvailable) }))));
+                    { QVariant::fromValue(QDBusObjectPath(m_replyPath)), m_message,
+                      QVariantMap(), uint(Method::AllAvailable) }))));
 
         // The reply here just confirms that the device lock service received the request and is
         // handling it. The users response or further status changes will be delivered by
         // the device lock service invoking methods on the SecureActionAuthenticatorAdaptor
         // registered on m_replyPath.
-        connect(m_response.data(), &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher *watcher) {
+        connect(m_response.data(), &QDBusPendingCallWatcher::finished,
+                this, [this](QDBusPendingCallWatcher *watcher) {
             watcher->deleteLater();
             m_response.take();
 
             if (watcher->isError()) {
                 m_authenticating = false;
 
-                qmlInfo(this) << "Authentication D-Bus error " << watcher->error().name() << " " << watcher->error().message();
+                qmlInfo(this) << "Authentication D-Bus error " << watcher->error().name()
+                              << " " << watcher->error().message();
             }
         });
     }


### PR DESCRIPTION
    The enabled property was protecting this before 08d74ad5c4b345b,
    but looks like even then the history button was unnecessarily visible,
    but just having opacity 0.
    
    Was easiest reproduced by opening page security info and tapping
    below lock icon. Seems it's also possible to get the history button
    area covering the botton toolbar, but that appears a bit random.
