### PR TITLE
[browser] Indicate page permission exception 'always ask' as different from deny. JB#63322

### DIFF
--- a/apps/browser/qml/pages/PermissionExceptionsPage.qml
+++ b/apps/browser/qml/pages/PermissionExceptionsPage.qml
@@ -22,7 +22,7 @@ Page {
     property string iconSource
 
     property var remorse
-    readonly property bool pendingRemorse: remorse && remorse.pending
+    readonly property bool pendingRemorse: !!remorse && remorse.pending
 
     PermissionFilterProxyModel {
         id: proxyModel
@@ -54,7 +54,6 @@ Page {
             id: listItem
 
             width: parent.width
-
             contentHeight: Theme.itemSizeMedium
 
             function remove(uri, type, capability) {
@@ -81,6 +80,9 @@ Page {
                     case PermissionManager.Deny:
                         //% "Block"
                         return qsTrId("sailfish_browser-me-block")
+                    case PermissionManager.Prompt:
+                        //% "Always ask"
+                        return qsTrId("sailfish_browser-me-always_ask")
                     }
                 }
             }
@@ -94,6 +96,12 @@ Page {
                     //% "Block"
                     text: qsTrId("sailfish_browser-me-block")
                     onClicked: proxyModel.setCapability(model.index, PermissionManager.Deny)
+                }
+                MenuItem {
+                    //% "Always ask"
+                    text: qsTrId("sailfish_browser-me-always_ask")
+                    onClicked: proxyModel.setCapability(model.index, PermissionManager.Prompt)
+                    visible: model.type !== "popup" && model.type !== "cookie"
                 }
                 MenuItem {
                     //% "Delete"
@@ -126,8 +134,7 @@ Page {
         }
 
         ViewPlaceholder {
-            enabled: page.pendingRemorse || (view.count === 0)
-
+            enabled: page.pendingRemorse || view.count === 0
             //% "You have no exceptions"
             text: qsTrId("sailfish_browser-la-have-no-exceptions")
         }

--- a/apps/browser/qml/pages/SitePermissionPage.qml
+++ b/apps/browser/qml/pages/SitePermissionPage.qml
@@ -140,8 +140,8 @@ Page {
                     //: Shown for context menu always ask permission
                     //% "Always ask"
                     text: qsTrId("sailfish_browser-me-always_ask")
-                    onClicked: PermissionManager.add(url, model.type, PermissionManager.Prompt)
                     visible: model.type !== "popup" && model.type !== "cookie"
+                    onClicked: PermissionManager.add(url, model.type, PermissionManager.Prompt)
                 }
             }
         }

--- a/apps/browser/qml/pages/components/CertificateInfo.qml
+++ b/apps/browser/qml/pages/components/CertificateInfo.qml
@@ -28,7 +28,8 @@ SilicaFlickable {
     signal closeCertInfo
 
     function openSiteSettings() {
-        pageStack.push("../SitePermissionPage.qml", {
+        pageStack.push("../SitePermissionPage.qml",
+                       {
                            title: webView.title,
                            url: toolBarRow.url,
                            permissionModel: permissionIndicationModel
@@ -42,6 +43,7 @@ SilicaFlickable {
 
     PermissionModel {
         id: permissionIndicationModel
+
         host: toolBarRow.url
     }
 
@@ -171,36 +173,48 @@ SilicaFlickable {
                         columns: Math.min(permissionIndicationModel.count, 5)
                         anchors.horizontalCenter: parent.horizontalCenter
                         spacing: Theme.paddingLarge
+
                         Repeater {
                             id: permissionIndicationRepeater
+
                             model: permissionIndicationModel
                             delegate: Icon {
                                 source: {
-                                    var blocked = (model.capability === PermissionManager.Deny)
+                                    // template variants have small hole to avoid overlapping transparent
+                                    // icon content.
+                                    // TODO: designed for deny graphics, the prompt case should either
+                                    // have prompt icon adjusted to match the deny shape or there should be
+                                    // yet another set of clipped permission graphics.
+                                    var template = (model.capability === PermissionManager.Deny
+                                                    || model.capability === PermissionManager.Prompt)
                                     if (model.type === "geolocation") {
-                                        return "image://theme/icon-m-browser-location" + (blocked ? "-template" : "")
+                                        return "image://theme/icon-m-browser-location" + (template ? "-template" : "")
                                     } else if (model.type === "cookie") {
-                                        return "image://theme/icon-m-browser-cookies" + (blocked ? "-template" : "")
+                                        return "image://theme/icon-m-browser-cookies" + (template ? "-template" : "")
                                     } else if (model.type === "popup") {
-                                        return "image://theme/icon-m-browser-popup" + (blocked ? "-template" : "")
+                                        return "image://theme/icon-m-browser-popup" + (template ? "-template" : "")
                                     } else if (model.type === "camera") {
-                                        return "image://theme/icon-m-browser-camera" + (blocked ? "-template" : "")
+                                        return "image://theme/icon-m-browser-camera" + (template ? "-template" : "")
                                     } else if (model.type === "microphone") {
-                                        return "image://theme/icon-m-browser-microphone" + (blocked ? "-template" : "")
+                                        return "image://theme/icon-m-browser-microphone" + (template ? "-template" : "")
                                     } else {
                                         return ""
                                     }
                                 }
                                 highlighted: permissionArea.pressed
+
                                 Icon {
                                     anchors {
                                         bottom: parent.bottom
                                         right: parent.right
                                     }
-                                    source: "image://theme/icon-s-blocked"
-
-                                    color: Theme.errorColor
                                     visible: model.capability === PermissionManager.Deny
+                                             || model.capability === PermissionManager.Prompt
+                                    source: model.capability === PermissionManager.Deny
+                                            ? "image://theme/icon-s-blocked"
+                                            : "image://theme/icon-s-maybe"
+                                    color: model.capability === PermissionManager.Deny
+                                           ? Theme.errorColor : Theme.primaryColor
                                 }
                             }
                         }


### PR DESCRIPTION
It's confusing when these two permission states show the same icon. Just looking at the permission popup one might interpret that the page has permission to something without questions asked.

Adding now extra icon at the bottom corner similar to denied case. The 'icon-s-maybe' doesn't exactly match the 'icon-s-blocked' shape for the template variants but it should be good enough for now.