### PR TITLE
[browser] Allow landscape content on cover. Fixes JB#35932

### DIFF
--- a/apps/captiveportal/qml/captiveportal.qml
+++ b/apps/captiveportal/qml/captiveportal.qml
@@ -18,7 +18,6 @@ BrowserWindow {
 
     //% "Captive portal"
     activityDisabledByMdm: qsTrId("sailfish_captiveportal-la-captive_portal");
-    coverMode: false
     initialPage: Component {
         CaptivePortalPage {
             id: browserPage

--- a/apps/shared/BrowserWindow.qml
+++ b/apps/shared/BrowserWindow.qml
@@ -21,19 +21,13 @@ ApplicationWindow {
     id: window
 
     readonly property bool largeScreen: Screen.sizeCategory > Screen.Medium
-    readonly property int browserVisibility: _mainWindow ? _mainWindow.visibility : QuickWindow.Window.Hidden
-    property bool coverMode: browserVisibility === QuickWindow.Window.Hidden
-                             || browserVisibility === QuickWindow.Window.Minimized
-                             || browserVisibility === QuickWindow.Window.Windowed
 
     property var rootPage
     property QtObject webView
     property alias activityDisabledByMdm: mdmView.activity
 
     allowedOrientations: defaultAllowedOrientations
-    // For non large screen fix cover to portrait.
-    _defaultPageOrientations: !largeScreen && coverMode ? Orientation.Portrait
-                                                        : Orientation.LandscapeMask | Orientation.Portrait
+    _defaultPageOrientations: Orientation.LandscapeMask | Orientation.Portrait
     _defaultLabelFormat: Text.PlainText
     _clippingItem.opacity: 1.0
     _resizeContent: !window.rootPage.active


### PR DESCRIPTION
Avoid relayouting browser content. Now that landscape home can be used also with smaller screen sizes previous conditions make very little sense. Thus, use Orientation.LandscapeMask and Orientation.Portrait as default orientations.