### PR TITLE
[browser] Fix url field not always visible after creating new tab. JB#63325

### DIFF
--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -336,10 +336,13 @@ Shared.Background {
 
                 property bool edited
                 property bool enteringNewTabUrl
+                property bool _resetting
 
                 function resetUrl(url) {
+                    _resetting = true
                     // Reset first text and then mark as unedited.
                     text = url === "about:blank" ? "" : url || ""
+                    _resetting = false
                     edited = false
                 }
 
@@ -422,11 +425,7 @@ Shared.Background {
                 onFocusChanged: {
                     if (focus) {
                         cursorPosition = text.length
-                        // Mark SearchField as edited if focused before url is resolved.
-                        // Otherwise select all.
-                        if (!text) {
-                            edited = true
-                        } else {
+                        if (text.length > 0) {
                             searchField.selectAll()
                         }
                         dragArea.moved = false
@@ -434,7 +433,7 @@ Shared.Background {
                 }
 
                 onTextChanged: {
-                    if (!edited && text !== webView.url) {
+                    if (!_resetting && !edited && text !== webView.url) {
                         edited = true
                     }
                 }


### PR DESCRIPTION
When opening a new tab, the search field gets focused and its 'edited' property turned true. After loading a new page and reopening overlay the showHistoryButton property, depending on edited, was fluctuating, and as result the favoriteGrid header height changed, and opacityY changed. Finally resetUrl() turning edited false.

Avoiding here now unnecessary changes on 'edited' when nothing has really been manually edited.

The onFocusChanged part was added in commit 39bbe455638b4f / JB#29424 but I'm not able to reproduce the problem these days with the snippet removed.