### PR TITLE
Allow PortraitInverted page orientation

### DIFF
--- a/apps/shared/BrowserWindow.qml
+++ b/apps/shared/BrowserWindow.qml
@@ -26,8 +26,8 @@ ApplicationWindow {
     property QtObject webView
     property alias activityDisabledByMdm: mdmView.activity
 
-    allowedOrientations: defaultAllowedOrientations
-    _defaultPageOrientations: Orientation.LandscapeMask | Orientation.Portrait
+    allowedOrientations: Orientation.All
+    _defaultPageOrientations: Orientation.LandscapeMask | Orientation.PortraitMask
     _defaultLabelFormat: Text.PlainText
     _clippingItem.opacity: 1.0
     _resizeContent: !window.rootPage.active


### PR DESCRIPTION
Allow the browser to be opened in inverted portrait orientation. Both landscape orientations are allowed anyway, so I don't see any reason to block inverted portrait.