### PR TITLE
Use dialog instead of button to clear browser data

### DIFF
--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -28,7 +28,7 @@ Dialog {
                || clearBookmarks.checked
                || clearSitePermissions.checked
     acceptDestination: Qt.resolvedUrl("components/PrivacySettingsConfirmDialog.qml")
-    acceptDestinationAction: PageStackAction.Replace
+    acceptDestinationAction: PageStackAction.Push
 
     onAcceptPendingChanged: {
         acceptDestinationInstance.historyEnabled = clearHistory.checked

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -15,11 +15,31 @@ import Sailfish.Silica 1.0
 import Nemo.Configuration 1.0
 import Sailfish.Browser 1.0
 
-Page {
+Dialog {
     id: page
 
     property var remorse
     property var previousPage
+
+    canAccept: clearHistory.checked
+               || clearCookiesAndSiteData.checked
+               || clearSavedPasswords.checked
+               || clearCache.checked
+               || clearBookmarks.checked
+               || clearSitePermissions.checked
+    acceptDestination: Qt.resolvedUrl("components/PrivacySettingsConfirmDialog.qml")
+    acceptDestinationAction: PageStackAction.Replace
+
+    onAcceptPendingChanged: {
+        acceptDestinationInstance.historyEnabled = clearHistory.checked
+        acceptDestinationInstance.cookieAndSiteDataEnabled = clearCookiesAndSiteData.checked
+        acceptDestinationInstance.passwordsEnabled = clearSavedPasswords.checked
+        acceptDestinationInstance.cacheEnabled = clearCache.checked
+        acceptDestinationInstance.bookmarksEnabled = clearBookmarks.checked
+        acceptDestinationInstance.sitePermissionsEnabled = clearSitePermissions.checked
+        acceptDestinationInstance.historyPeriod = historyErasingComboBox.currentItem.period
+        acceptDestinationInstance.acceptDestination = previousPage
+    }
 
     SilicaFlickable {
         anchors.fill: parent
@@ -30,10 +50,13 @@ Page {
 
             width: parent.width
 
-            PageHeader {
+            DialogHeader {
                 //: Clear private data page header
                 //% "Clear private data"
                 title: qsTrId("settings_browser-ph-clear_private_data")
+
+                //% "Clear"
+                acceptText: qsTrId("sailfish_browser-he-clear")
             }
 
             Column {
@@ -125,38 +148,6 @@ Page {
                     //% "Site permissions"
                     text: qsTrId("settings_browser-la-clear_site_permissions")
                     checked: true
-                }
-
-                // Spacer between Button and switches
-                Item {
-                    width: parent.width
-                    height: Theme.paddingLarge
-                }
-
-                Button {
-                    //: Button for clearing selected private data items.
-                    //% "Clear"
-                    text: qsTrId("settings_browser-bt-clear")
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    enabled: clearHistory.checked
-                             || clearCookiesAndSiteData.checked
-                             || clearSavedPasswords.checked
-                             || clearCache.checked
-                             || clearBookmarks.checked
-                             || clearSitePermissions.checked
-
-                    onClicked: {
-                        var page = pageStack.push(Qt.resolvedUrl("components/PrivacySettingsConfirmDialog.qml"), {
-                                                      historyEnabled: clearHistory.checked,
-                                                      cookieAndSiteDataEnabled: clearCookiesAndSiteData.checked,
-                                                      passwordsEnabled: clearSavedPasswords.checked,
-                                                      cacheEnabled: clearCache.checked,
-                                                      bookmarksEnabled: clearBookmarks.checked,
-                                                      sitePermissionsEnabled: clearSitePermissions.checked,
-                                                      historyPeriod: historyErasingComboBox.currentItem.period,
-                                                      acceptDestination: previousPage
-                                                  })
-                    }
                 }
             }
         }

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -41,13 +41,25 @@ Dialog {
         acceptDestinationInstance.acceptDestination = previousPage
     }
 
+    ConfigurationGroup {
+        id: config
+        path: "/apps/sailfish-browser/actions"
+
+        property bool clear_history: true
+        property int clear_history_period: 0  // combo index
+        property bool clear_cookies_and_site_data: true
+        property bool clear_passwords: false
+        property bool clear_cache: true
+        property bool clear_bookmarks: false
+        property bool clear_site_permissions: false
+    }
+
     SilicaFlickable {
         anchors.fill: parent
         contentHeight: contentColumn.height
 
         Column {
             id: contentColumn
-
             width: parent.width
 
             DialogHeader {
@@ -68,16 +80,26 @@ Dialog {
 
                     //% "History"
                     text: qsTrId("settings_browser-la-clear_history")
-                    checked: true
 
                     //: Description for clearing history. This will clear history and tabs.
                     //% "Clears history and open tabs"
                     description: qsTrId("settings_browser-la-clear_history_description")
+
+                    checked: config.clear_history
+                    automaticCheck: false
+                    onClicked: config.clear_history = !config.clear_history
                 }
 
                 ComboBox {
                      id: historyErasingComboBox
                      enabled: clearHistory.checked
+                     currentIndex: config.clear_history_period
+
+                     onCurrentIndexChanged: {
+                         if (config.clear_history_period != currentIndex) {
+                             config.clear_history_period = currentIndex
+                         }
+                     }
 
                      width: parent.width
                      //% "Clear browser history for"
@@ -116,7 +138,10 @@ Dialog {
 
                     //% "Cookies and site data"
                     text: qsTrId("settings_browser-la-clear_cookies_and_site_data")
-                    checked: true
+
+                    checked: config.clear_cookies_and_site_data
+                    automaticCheck: false
+                    onClicked: config.clear_cookies_and_site_data = !config.clear_cookies_and_site_data
                 }
 
                 TextSwitch {
@@ -124,7 +149,10 @@ Dialog {
 
                     //% "Saved passwords"
                     text: qsTrId("settings_browser-la-clear_passwords")
-                    checked: false
+
+                    checked: config.clear_passwords
+                    automaticCheck: false
+                    onClicked: config.clear_passwords = !config.clear_passwords
                 }
 
                 TextSwitch {
@@ -132,7 +160,10 @@ Dialog {
 
                     //% "Cache"
                     text: qsTrId("settings_browser-la-clear_cache")
-                    checked: true
+
+                    checked: config.clear_cache
+                    automaticCheck: false
+                    onClicked: config.clear_cache = !config.clear_cache
                 }
 
                 TextSwitch {
@@ -140,7 +171,10 @@ Dialog {
 
                     //% "Bookmarks"
                     text: qsTrId("settings_browser-la-clear_bookmarks")
-                    checked: false
+
+                    checked: config.clear_bookmarks
+                    automaticCheck: false
+                    onClicked: config.clear_bookmarks = !config.clear_bookmarks
                 }
 
                 TextSwitch {
@@ -148,7 +182,10 @@ Dialog {
 
                     //% "Site permissions"
                     text: qsTrId("settings_browser-la-clear_site_permissions")
-                    checked: false
+
+                    checked: config.clear_site_permissions
+                    automaticCheck: false
+                    onClicked: config.clear_site_permissions = !config.clear_site_permissions
                 }
             }
         }

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -77,6 +77,7 @@ Dialog {
 
                 ComboBox {
                      id: historyErasingComboBox
+                     enabled: clearHistory.checked
 
                      width: parent.width
                      //% "Clear browser history for"

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -44,7 +44,7 @@ Dialog {
     ConfigurationGroup {
         id: config
 
-        path: "/apps/sailfish-browser/actions"
+        path: "/apps/sailfish-browser/privacy-cleanup"
 
         property bool clear_history: true
         property int clear_history_period: 0  // combo index

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -43,6 +43,7 @@ Dialog {
 
     ConfigurationGroup {
         id: config
+
         path: "/apps/sailfish-browser/actions"
 
         property bool clear_history: true
@@ -60,6 +61,7 @@ Dialog {
 
         Column {
             id: contentColumn
+
             width: parent.width
 
             DialogHeader {
@@ -92,6 +94,7 @@ Dialog {
 
                 ComboBox {
                      id: historyErasingComboBox
+
                      enabled: clearHistory.checked
                      currentIndex: config.clear_history_period
 

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -68,7 +68,7 @@ Dialog {
 
                     //% "History"
                     text: qsTrId("settings_browser-la-clear_history")
-                    checked: false
+                    checked: true
 
                     //: Description for clearing history. This will clear history and tabs.
                     //% "Clears history and open tabs"

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -31,6 +31,8 @@ Dialog {
     acceptDestinationAction: PageStackAction.Push
 
     onAcceptPendingChanged: {
+        if (!acceptPending) return
+
         acceptDestinationInstance.historyEnabled = clearHistory.checked
         acceptDestinationInstance.cookieAndSiteDataEnabled = clearCookiesAndSiteData.checked
         acceptDestinationInstance.passwordsEnabled = clearSavedPasswords.checked

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -28,7 +28,6 @@ Dialog {
                || clearBookmarks.checked
                || clearSitePermissions.checked
     acceptDestination: Qt.resolvedUrl("components/PrivacySettingsConfirmDialog.qml")
-    acceptDestinationAction: PageStackAction.Push
 
     onAcceptPendingChanged: {
         if (!acceptPending) return

--- a/apps/browser/qml/pages/PrivacySettingsPage.qml
+++ b/apps/browser/qml/pages/PrivacySettingsPage.qml
@@ -68,7 +68,7 @@ Dialog {
 
                     //% "History"
                     text: qsTrId("settings_browser-la-clear_history")
-                    checked: true
+                    checked: false
 
                     //: Description for clearing history. This will clear history and tabs.
                     //% "Clears history and open tabs"
@@ -124,7 +124,7 @@ Dialog {
 
                     //% "Saved passwords"
                     text: qsTrId("settings_browser-la-clear_passwords")
-                    checked: true
+                    checked: false
                 }
 
                 TextSwitch {
@@ -140,7 +140,7 @@ Dialog {
 
                     //% "Bookmarks"
                     text: qsTrId("settings_browser-la-clear_bookmarks")
-                    checked: true
+                    checked: false
                 }
 
                 TextSwitch {
@@ -148,7 +148,7 @@ Dialog {
 
                     //% "Site permissions"
                     text: qsTrId("settings_browser-la-clear_site_permissions")
-                    checked: true
+                    checked: false
                 }
             }
         }

--- a/apps/browser/qml/pages/components/PrivacySettingsConfirmDialog.qml
+++ b/apps/browser/qml/pages/components/PrivacySettingsConfirmDialog.qml
@@ -26,6 +26,7 @@ Dialog {
     property int _cacheUsage
 
     acceptDestinationAction: PageStackAction.Pop
+    // acceptDestination: set in PrivacySettingsPage
 
     SilicaFlickable {
         anchors.fill: parent


### PR DESCRIPTION
- Use dialog instead of button to clear browser data: This change makes the UI more Sailfish-y.
- Disable combo box when not deleting history: It's confusing to be able to change how much should be deleted when nothing should be deleted at all.
- ~~Only clear cookies and cache by default: Keep history, passwords, bookmarks, and site permissions by default. When deleting data for privacy, it's unexpected to delete passwords etc.~~
- When deleting data, the last used settings are remembered instead of always selecting defaults.

**Before:**

<img width="300" height="1400" alt="d1" src="https://github.com/user-attachments/assets/8dc51e85-8228-4468-b707-67244ca4233a" />
<img width="300" height="1400" alt="d2" src="https://github.com/user-attachments/assets/c15257b4-83d9-470a-90f6-923eda88aa8b" />

**After:**

<img width="300" height="1400" alt="d3" src="https://github.com/user-attachments/assets/ca1822b6-3818-4c9f-9c01-4583deafefb0" />
<img width="300" height="1400" alt="d4" src="https://github.com/user-attachments/assets/635faaee-b7f4-4250-a7c6-c7d4c0eafa6f" />
