### PR TITLE
Fix menu icon in toolbar moving when switching to an "about:" page

### DIFF
--- a/apps/browser/qml/pages/components/ToolBar.qml
+++ b/apps/browser/qml/pages/components/ToolBar.qml
@@ -259,12 +259,12 @@ Column {
             expandedWidth: toolBarRow.smallIconWidth
             icon.source: danger ? "image://theme/icon-s-filled-warning" : "image://theme/icon-s-outline-secure"
             active: webView.security && webView.security.validState && !findInPageActive
+                    && !(webView.url.indexOf("about:") === 0)
             icon.color: danger ? Qt.tint(Theme.primaryColor,
                                          Qt.rgba(Theme.errorColor.r, Theme.errorColor.g,
                                                  Theme.errorColor.b, glow))
                                : Theme.primaryColor
             enabled: webView.security
-            visible: !(webView.url.indexOf("about:") === 0)
             onTapped: {
                 if (certOverlayActive) {
                     showChrome()


### PR DESCRIPTION
As the title says: the right margin of the toolbar changed when viewing e.g. "about:blank#".

**Normal page:**

<img width="300" height="500" alt="m1" src="https://github.com/user-attachments/assets/756bb12d-7ca8-4940-9667-fc583709993b" />

**Before:**

<img width="300" height="500" alt="m2" src="https://github.com/user-attachments/assets/186a9db4-f61a-4e7c-8100-aeda994e5b1e" />

**After:**

<img width="300" height="500" alt="m3" src="https://github.com/user-attachments/assets/16ff0df0-4c08-4dd6-adb6-40437435636d" />
