### PR TITLE
Add menu button to quickly clear browsing data

### DIFF
--- a/apps/browser/qml/pages/components/PopUpMenuItem.qml
+++ b/apps/browser/qml/pages/components/PopUpMenuItem.qml
@@ -212,6 +212,21 @@ Item {
                 height: Theme.itemSizeSmall
                 iconWidth: root.iconWidth
                 horizontalOffset: root.horizontalOffset
+                //: The label for the button for accessing clear browsing data page
+                //% "Clear browsing data"
+                text: qsTrId("settings_browser-la-clear-browsing-data")
+                iconSource: "image://theme/icon-m-delete"
+
+                onClicked: {
+                    overlay.animator.showChrome()
+                    pageStack.push("../PrivacySettingsPage.qml", {previousPage: pageStack.currentPage})
+                }
+            }
+
+            OverlayListItem {
+                height: Theme.itemSizeSmall
+                iconWidth: root.iconWidth
+                horizontalOffset: root.horizontalOffset
                 //% "Downloads"
                 text: qsTrId("sailfish_browser-la-downloads")
                 iconSource: "image://theme/icon-m-downloads"


### PR DESCRIPTION
This adds a menu button to quickly clear browsing data without having to open the settings page first.

**Unexpanded menu:**

<img width="300" height="2100" alt="b1" src="https://github.com/user-attachments/assets/37f3ce73-6d1b-4a60-8d81-101f988401fd" />

**Before:**

<img width="300" height="2100" alt="b2" src="https://github.com/user-attachments/assets/60a7a345-4411-4af2-abbb-484f6f429350" />

**After:**

<img width="300" height="2100" alt="b3" src="https://github.com/user-attachments/assets/93980221-a046-4140-b8dd-7f2fd104ab67" />

