### PR TITLE
Remember Find-in-Page search terms

### DIFF
--- a/apps/browser/qml/pages/components/Overlay.qml
+++ b/apps/browser/qml/pages/components/Overlay.qml
@@ -338,6 +338,8 @@ Shared.Background {
                 property bool enteringNewTabUrl
                 property bool _resetting
 
+                property string lastFindText
+
                 function resetUrl(url) {
                     _resetting = true
                     // Reset first text and then mark as unedited.
@@ -392,6 +394,7 @@ Shared.Background {
                     }
 
                     if (toolBar.findInPageActive) {
+                        lastFindText = text
                         webView.sendAsyncMessage("embedui:find", { text: text, backwards: false, again: false })
                         overlayAnimator.showChrome()
                     } else {
@@ -554,7 +557,11 @@ Shared.Background {
                 onEnterNewTabUrl: overlay.enterNewTabUrl()
                 onFindInPage: {
                     _showFindInPage = true
-                    searchField.resetUrl("")
+                    if (searchField.lastFindText.length > 0) {
+                        searchField.resetUrl(searchField.lastFindText)
+                    } else {
+                        searchField.resetUrl("")
+                    }
                     _overlayGap = Qt.binding(function () { return overlayAnimator.fullscreenGap })
                     overlayAnimator.showOverlay()
                 }


### PR DESCRIPTION
Currently it's a bit annoying that the search field is cleared every time you do a on-page search (especially if nothing was found!).

I think the use cases are clear: I may want to do variations on my previous search term , I may have made a spelling mistake etc.