### PR TITLE
Popup button layouting adjustment

### DIFF
--- a/apps/browser/qml/pages/components/FavoriteGrid.qml
+++ b/apps/browser/qml/pages/components/FavoriteGrid.qml
@@ -94,20 +94,18 @@ IconGridViewBase {
         onClicked: favoriteGrid.load(model.url, model.title)
         onShowContextMenuChanged: {
             if (showContextMenu) {
-                openMenu(
-                            {
-                                "view": favoriteGrid,
-                                "delegate": favoriteItem,
-                                "title": model.title,
-                                "url": model.url,
-                                "index": model.index
-                            })
+                openMenu({
+                             "view": favoriteGrid,
+                             "delegate": favoriteItem,
+                             "title": model.title,
+                             "url": model.url,
+                             "index": model.index
+                         })
             }
         }
 
         GridView.onAdd: AddAnimation { target: favoriteItem }
     }
-
 
     FavoriteContextMenu {
         id: favoriteContextMenu

--- a/apps/browser/qml/pages/components/PopUpMenu.qml
+++ b/apps/browser/qml/pages/components/PopUpMenu.qml
@@ -199,10 +199,8 @@ SilicaControl {
                         id: footerLoader
 
                         y: menuFlickable.height - height
-
                         width: menuFlickable.width
                         height: item ? item.height: 0
-
                         source: popUpMenu.footer
 
                         onInitializeItem: {

--- a/apps/browser/qml/pages/components/PopUpMenuFooter.qml
+++ b/apps/browser/qml/pages/components/PopUpMenuFooter.qml
@@ -16,7 +16,7 @@ Rectangle {
     readonly property real overlayOpacity: 0.15
 
     height: Theme.itemSizeMedium - Theme.paddingMedium
-    implicitWidth: content.width
+    implicitWidth: 4 * Theme.itemSizeLarge // for each button
     implicitHeight: Theme.iconSizeMedium
     color: Qt.tint(Theme.colorScheme === Theme.LightOnDark ? "black" : "white",
                    Theme.rgba(Theme.primaryColor, root.overlayOpacity))
@@ -24,11 +24,13 @@ Rectangle {
     Row {
         id: content
 
+        property int buttonWidth: root.width / 4
+
         height: root.height
 
         Shared.IconButton {
             height: parent.height
-            width: Theme.itemSizeLarge
+            width: content.buttonWidth
             icon.source: "image://theme/icon-m-tab-close"
             icon.opacity: enabled ? 1.0 : Theme.opacityLow
             enabled: webView.tabModel.count > 0
@@ -42,7 +44,7 @@ Rectangle {
 
         Shared.IconButton {
             height: parent.height
-            width: Theme.itemSizeLarge
+            width: content.buttonWidth
             icon.source: "image://theme/icon-m-forward"
             icon.opacity: enabled ? 1.0 : Theme.opacityLow
             enabled: webView.canGoForward
@@ -54,7 +56,7 @@ Rectangle {
 
         Shared.IconButton {
             height: parent.height
-            width: Theme.itemSizeLarge
+            width: content.buttonWidth
             icon.source: overlay.toolBar.bookmarked ? "image://theme/icon-m-favorite-selected"
                                                     : "image://theme/icon-m-favorite"
             icon.opacity: enabled ? 1.0 : Theme.opacityLow
@@ -70,7 +72,7 @@ Rectangle {
 
         Shared.IconButton {
             height: parent.height
-            width: Theme.itemSizeLarge
+            width: content.buttonWidth
             icon.source: webView.loading ? "image://theme/icon-m-reset" : "image://theme/icon-m-refresh"
             icon.opacity: enabled ? 1.0 : Theme.opacityLow
             enabled: webView.contentItem

--- a/apps/browser/qml/pages/components/PopUpMenuFooter.qml
+++ b/apps/browser/qml/pages/components/PopUpMenuFooter.qml
@@ -18,9 +18,8 @@ Rectangle {
     height: Theme.itemSizeMedium - Theme.paddingMedium
     implicitWidth: content.width
     implicitHeight: Theme.iconSizeMedium
-    color: Qt.tint(
-               Theme.colorScheme === Theme.LightOnDark ? "black" : "white",
-               Theme.rgba(Theme.primaryColor, root.overlayOpacity))
+    color: Qt.tint(Theme.colorScheme === Theme.LightOnDark ? "black" : "white",
+                   Theme.rgba(Theme.primaryColor, root.overlayOpacity))
 
     Row {
         id: content


### PR DESCRIPTION
Alternative to https://github.com/sailfishos/sailfish-browser/pull/1131 -- compared to that this should be a bit simpler and uses the full width instead of needing to anchor the buttons to either side. (cc @nephros)

Looks like the PopupMenu.qml widthRatio doesn't end up always matching the width with the item size large.