### PR TITLE
[browser] about:config: show modified values as bold

### DIFF
--- a/apps/browser/qml/pages/components/ConfigDialog.qml
+++ b/apps/browser/qml/pages/components/ConfigDialog.qml
@@ -277,6 +277,7 @@ Dialog {
                                 width: parent.width
                                 color: Theme.primaryColor
                                 font.pixelSize: preferenceNameFontSize
+                                font.bold: model.modified
                                 wrapMode: Text.Wrap
                                 text: model.name
                             }
@@ -350,6 +351,7 @@ Dialog {
                                 width: parent.width
                                 color: boolItem.highlighted ? Theme.highlightColor : Theme.primaryColor
                                 font.pixelSize: preferenceNameFontSize
+                                font.bold: model.modified
                                 wrapMode: Text.Wrap
                                 text: model.name
                             }


### PR DESCRIPTION
Trivial change to show user-modified preferences in bold.

This makes the dialog a bit similar to what most Desktop browsers do in the
`about:config` view, and these being bold is also noted in mozilla
documentation

